### PR TITLE
SDI-192 Add phones numbers to lead visitor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Address.kt
@@ -26,7 +26,18 @@ import javax.persistence.Table
 @Table(name = "ADDRESSES")
 @DiscriminatorColumn(name = "OWNER_CLASS")
 @Inheritance
-abstract class Address {
+abstract class Address(
+  val premise: String? = null,
+  val street: String? = null,
+  val locality: String? = null,
+  @Column(name = "START_DATE")
+  val startDate: LocalDate = LocalDate.now(),
+  @Column(name = "NO_FIXED_ADDRESS_FLAG")
+  val noFixedAddressFlag: String = "N",
+  @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
+  @Where(clause = "OWNER_CLASS = '" + AddressPhone.PHONE_TYPE + "'")
+  val phones: MutableList<AddressPhone> = ArrayList()
+) {
   @Id
   @SequenceGenerator(name = "ADDRESS_ID", sequenceName = "ADDRESS_ID", allocationSize = 1)
   @GeneratedValue(generator = "ADDRESS_ID")
@@ -47,15 +58,9 @@ abstract class Address {
   )
   open val addressType: AddressType? = null
   open val flat: String? = null
-  open val premise: String? = null
-  open val street: String? = null
-  open val locality: String? = null
 
   @Column(name = "POSTAL_CODE")
   open val postalCode: String? = null
-
-  @Column(name = "NO_FIXED_ADDRESS_FLAG")
-  open val noFixedAddressFlag: String? = null
 
   @Column(name = "PRIMARY_FLAG", nullable = false)
   open val primaryFlag = "N"
@@ -65,9 +70,6 @@ abstract class Address {
 
   @Column(name = "COMMENT_TEXT")
   open val commentText: String? = null
-
-  @Column(name = "START_DATE")
-  open val startDate: LocalDate? = null
 
   @Column(name = "END_DATE")
   open val endDate: LocalDate? = null
@@ -117,10 +119,6 @@ abstract class Address {
   @OneToMany
   @JoinColumn(name = "ADDRESS_ID")
   open val addressUsages: List<AddressUsage> = ArrayList()
-
-  @OneToMany(mappedBy = "address", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
-  @Where(clause = "OWNER_CLASS = '" + AddressPhone.PHONE_TYPE + "'")
-  open val phones: MutableList<AddressPhone> = ArrayList()
 
   fun removePhone(phone: AddressPhone) {
     phones.remove(phone)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AddressPhone.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AddressPhone.kt
@@ -8,19 +8,15 @@ import javax.persistence.ManyToOne
 
 @Entity
 @DiscriminatorValue(AddressPhone.PHONE_TYPE)
-data class AddressPhone(
+class AddressPhone(
 
   @JoinColumn(name = "OWNER_ID")
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  var address: Address
-) : Phone() {
-
-  constructor(address: Address, phoneId: Long, phoneType: String?, phoneNo: String?, extNo: String?) : this(address) {
-    this.phoneId = phoneId
-    this.phoneType = phoneType
-    this.phoneNo = phoneNo
-    this.extNo = extNo
-  }
+  var address: Address,
+  phoneType: String? = null,
+  phoneNo: String? = null,
+  extNo: String? = null,
+) : Phone(phoneType = phoneType, phoneNo = phoneNo, extNo = extNo) {
 
   companion object {
     const val PHONE_TYPE = "ADDR"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Person.kt
@@ -37,11 +37,11 @@ data class Person(
 
   @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @Where(clause = "OWNER_CLASS = '" + PersonAddress.ADDR_TYPE + "'")
-  val addresses: List<PersonAddress> = ArrayList(),
+  val addresses: MutableList<PersonAddress> = mutableListOf(),
 
   @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @Where(clause = "OWNER_CLASS = '" + PersonPhone.PHONE_TYPE + "'")
-  val phones: List<PersonPhone> = ArrayList(),
+  val phones: MutableList<PersonPhone> = mutableListOf(),
 
   @OneToMany(mappedBy = "person", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   @Where(clause = "OWNER_CLASS = '" + PersonInternetAddress.TYPE + "'")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonAddress.kt
@@ -1,18 +1,32 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa
 
+import java.time.LocalDate
 import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
-import javax.persistence.FetchType
+import javax.persistence.FetchType.LAZY
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 
 @Entity
 @DiscriminatorValue(PersonAddress.ADDR_TYPE)
-data class PersonAddress(
+class PersonAddress(
   @JoinColumn(name = "OWNER_ID")
-  @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  val person: Person
-) : Address() {
+  @ManyToOne(optional = false, fetch = LAZY)
+  val person: Person,
+  premise: String? = null,
+  street: String? = null,
+  locality: String? = null,
+  startDate: LocalDate = LocalDate.now(),
+  noFixedAddressFlag: String = "N",
+  phones: MutableList<AddressPhone> = ArrayList()
+) : Address(
+  premise = premise,
+  street = street,
+  locality = locality,
+  startDate = startDate,
+  noFixedAddressFlag = noFixedAddressFlag,
+  phones = phones
+) {
   companion object {
     const val ADDR_TYPE = "PER"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonPhone.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonPhone.kt
@@ -1,16 +1,21 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa
 
+import javax.persistence.DiscriminatorValue
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 
 @Entity
-class PersonPhone : Phone() {
+@DiscriminatorValue(PersonPhone.PHONE_TYPE)
+class PersonPhone(
   @JoinColumn(name = "OWNER_ID")
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
-  var person: Person? = null
-
+  var person: Person? = null,
+  phoneType: String? = null,
+  phoneNo: String? = null,
+  extNo: String? = null,
+) : Phone(phoneType = phoneType, phoneNo = phoneNo, extNo = extNo) {
   companion object {
     const val PHONE_TYPE = "PER"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Phone.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Phone.kt
@@ -14,21 +14,19 @@ import javax.persistence.Table
 @Table(name = "PHONES")
 @DiscriminatorColumn(name = "OWNER_CLASS")
 @Inheritance
-abstract class Phone {
+abstract class Phone(
+  @Column(name = "PHONE_TYPE")
+  val phoneType: String? = null,
+  @Column(name = "PHONE_NO")
+  val phoneNo: String? = null,
+  @Column(name = "EXT_NO")
+  val extNo: String? = null,
+) {
   @Id
   @SequenceGenerator(name = "PHONE_ID", sequenceName = "PHONE_ID", allocationSize = 1)
   @GeneratedValue(generator = "PHONE_ID")
   @Column(name = "PHONE_ID", nullable = false)
   open var phoneId: Long = 0
-
-  @Column(name = "PHONE_TYPE")
-  open var phoneType: String? = null
-
-  @Column(name = "PHONE_NO")
-  open var phoneNo: String? = null
-
-  @Column(name = "EXT_NO")
-  open var extNo: String? = null
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonAddressBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonAddressBuilder.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
+
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AddressPhone
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Person
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.PersonAddress
+
+class PersonAddressBuilder(
+  var premise: String = "41",
+  var street: String = "High Street",
+  var locality: String = "Sheffield",
+  private var phoneNumbers: List<Pair<String, String>> = listOf()
+) {
+  fun build(person: Person): PersonAddress =
+    PersonAddress(
+      person = person,
+      premise = premise,
+      street = street,
+      locality = locality
+    ).apply {
+      phoneNumbers.map { (type, number) ->
+        this.addPhone(
+          AddressPhone(
+            this,
+            phoneType = type,
+            phoneNo = number,
+            extNo = null
+          )
+        )
+      }
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonBuilder.kt
@@ -1,14 +1,31 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
 
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Person
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.PersonPhone
 
 class PersonBuilder(
   var firstName: String = "NEO",
-  var lastName: String = "AYOMIDE"
+  var lastName: String = "AYOMIDE",
+  var phoneNumbers: List<Pair<String, String>> = listOf(),
+  var addressBuilders: List<PersonAddressBuilder> = listOf(),
 ) {
   fun build(): Person =
     Person(
       firstName = firstName,
       lastName = lastName,
-    )
+    ).apply {
+      phoneNumbers.forEach { (type, number) ->
+        this.phones.add(
+          PersonPhone(
+            person = this,
+            phoneType = type,
+            phoneNo = number
+          )
+        )
+      }
+    }.apply {
+      addressBuilders.forEach {
+        this.addresses.add(it.build(this))
+      }
+    }
 }


### PR DESCRIPTION
* Had to some entity attributes up to constructor so we can create phone and addresses
* Builders can now create a person with addresses and phone numbers
* Visitor endpoint now returns the lead visitor (if exists) with name and phone numbers