### PR TITLE
SDI-385 Fixed issue where visit date not set

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Visit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Visit.kt
@@ -40,7 +40,7 @@ data class Visit(
   val visitorConcernText: String? = null,
 
   @Column(nullable = false)
-  val visitDate: LocalDate,
+  var visitDate: LocalDate,
 
   @Column(name = "START_TIME", nullable = false)
   var startDateTime: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/service/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/service/VisitService.kt
@@ -206,6 +206,7 @@ class VisitService(
         roomDescription = updateVisitRequest.room,
         isClosedVisit = "CLOSED" == updateVisitRequest.openClosedStatus
       )
+    visit.visitDate = updateVisitRequest.startDateTime.toLocalDate()
     visit.startDateTime = updateVisitRequest.startDateTime
     visit.endDateTime = endDateTime
     visit.agencyInternalLocation = visit.agencyVisitSlot?.agencyInternalLocation


### PR DESCRIPTION
Interestingly the integration tests don't show these bugs since these fields are only used in NOMIS, I think I need another integration test that checks the state of the database rather as well as the data returned by endpoint.