### PR TITLE
SDIT-907 Allow creation of Nomis attendance from outside prison.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceService.kt
@@ -75,9 +75,6 @@ class AttendanceService(
         offenderProgramProfile,
         status,
       ).also {
-        if (offenderBooking.location?.id != courseSchedule.courseActivity.prison.id) {
-          throw BadDataException("Prisoner is at prison=${offenderBooking.location?.id}, not the Course activity prison=${courseSchedule.courseActivity.prison.id}")
-        }
         if (offenderProgramProfile.programStatus.code == "END") {
           throw BadDataException("Cannot create an attendance for allocation ${offenderProgramProfile.offenderProgramReferenceId} because it has ended")
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceResourceIntTest.kt
@@ -184,17 +184,14 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `should return bad request if creating attendance for offender in wrong prison`() {
+      fun `should return OK if creating attendance for offender in wrong prison`() {
         offender =
           repository.save(OffenderBuilder(nomsId = "A1234TU").withBooking(OffenderBookingBuilder(agencyLocationId = "MDI")))
         offenderBooking = offender.latestBooking()
         repository.save(allocationBuilderFactory.builder(), offenderBooking, courseActivity)
 
-        webTestClient.upsertAttendance(courseSchedule.courseScheduleId, offenderBooking.bookingId)
-          .expectStatus().isBadRequest
-          .expectBody().jsonPath("userMessage").value<String> {
-            assertThat(it).contains("Prisoner is at prison=${offenderBooking.location?.id}, not the Course activity prison=${courseActivity.prison.id}")
-          }
+        webTestClient.upsertAttendance(courseSchedule.courseScheduleId, offenderBooking.bookingId, validJsonRequest.withEventOutcomeCode("SUS"))
+          .expectStatus().isOk
       }
 
       @Test


### PR DESCRIPTION
E.g. when suspended after transfer, and possibly due to other Activities business rules.