### PR TITLE
SDIT-871 Reorganise test repository

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ActivityResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ActivityResourceIntTest.kt
@@ -229,7 +229,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         val id = callCreateEndpoint()
 
         // Spot check that the database has been populated.
-        val courseActivity = repository.lookupActivity(id)
+        val courseActivity = repository.getActivity(id)
 
         assertThat(courseActivity.courseActivityId).isEqualTo(id)
         assertThat(courseActivity.capacity).isEqualTo(23)
@@ -260,7 +260,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
       @Test
       fun `should raise telemetry event`() {
         val id = callCreateEndpoint()
-        val courseActivity = repository.lookupActivity(id)
+        val courseActivity = repository.getActivity(id)
 
         verify(telemetryClient).trackEvent(
           eq("activity-created"),
@@ -490,7 +490,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.internalLocation?.locationId).isEqualTo(-27)
         assertThat(updated.payRates[0].endDate).isEqualTo(today)
         assertThat(updated.payRates[1].endDate).isNull()
@@ -669,7 +669,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.payRates[0].endDate).isEqualTo(today)
       }
 
@@ -759,7 +759,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.payRates[0].endDate).isEqualTo(today)
       }
     }
@@ -843,7 +843,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.courseScheduleRules.size).isEqualTo(1)
         with(updated.courseScheduleRules[0]) {
           assertThat(startTime.toLocalTime()).isEqualTo("09:00")
@@ -969,7 +969,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val saved = repository.lookupActivity(courseActivity.courseActivityId)
+        val saved = repository.getActivity(courseActivity.courseActivityId)
         assertThat(saved.courseSchedules.size).isEqualTo(2)
         with(saved.courseSchedules.first { it.scheduleDate == today }) {
           assertThat(startTime).isEqualTo("${today}T08:00:00")
@@ -1013,7 +1013,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val saved = repository.lookupActivity(courseActivity.courseActivityId)
+        val saved = repository.getActivity(courseActivity.courseActivityId)
         assertThat(saved.courseSchedules.size).isEqualTo(2)
         // The course from yesterday was omitted from the request but is not deleted
         with(saved.courseSchedules.first { it.scheduleDate == yesterday }) {
@@ -1060,7 +1060,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val saved = repository.lookupActivity(courseActivity.courseActivityId)
+        val saved = repository.getActivity(courseActivity.courseActivityId)
         assertThat(saved.courseSchedules.size).isEqualTo(2)
         with(saved.courseSchedules.first { it.scheduleDate == today }) {
           assertThat(startTime).isEqualTo("${today}T08:00:00")
@@ -1111,7 +1111,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.scheduleStartDate).isEqualTo(LocalDate.parse("2022-11-01"))
         assertThat(updated.scheduleEndDate).isEqualTo(LocalDate.parse("2022-11-30"))
         assertThat(updated.internalLocation?.locationId).isEqualTo(-27)
@@ -1134,7 +1134,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.scheduleEndDate).isNull()
         assertThat(updated.internalLocation).isNull()
       }
@@ -1169,7 +1169,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
           .expectStatus().isOk
 
         repository.runInTransaction {
-          val updated = repository.lookupActivity(courseActivity.courseActivityId)
+          val updated = repository.getActivity(courseActivity.courseActivityId)
           assertThat(updated.program.programCode).isEqualTo("NEW_SERVICE")
           assertThat(updated.getProgramCode(offenderBooking.bookingId)).isEqualTo("NEW_SERVICE")
           assertThat(updated.getProgramCode(deallocatedOffenderBooking.bookingId)).isEqualTo("INTTEST") // The deallocated booking is not moved to the new program
@@ -1366,7 +1366,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
 
       // Emulate the Nomis trigger COURSE_ACTIVITIES_T2.trg
       repository.runInTransaction {
-        val activity = repository.lookupActivity(activityId)
+        val activity = repository.getActivity(activityId)
         activity.area = CourseActivityArea(activityId, activity, "AREA")
         repository.activityRepository.save(activity)
       }
@@ -1381,8 +1381,8 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      val savedActivity = repository.lookupActivity(activityId)
-      val savedAllocation = repository.lookupOffenderProgramProfile(savedActivity, offenderAtMoorlands.latestBooking())
+      val savedActivity = repository.getActivity(activityId)
+      val savedAllocation = repository.getOffenderProgramProfiles(savedActivity, offenderAtMoorlands.latestBooking())
       assertThat(savedAllocation).isNotEmpty
 
       // delete activity and deallocate
@@ -1420,8 +1420,8 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      val savedActivity = repository.lookupActivity(activityId)
-      val savedSchedule = repository.lookupActivity(activityId).courseSchedules.first()
+      val savedActivity = repository.getActivity(activityId)
+      val savedSchedule = repository.getActivity(activityId).courseSchedules.first()
       assertThat(savedSchedule).isNotNull
       val savedAllocation = repository.offenderProgramProfileRepository.findByCourseActivityAndOffenderBooking(savedActivity, offenderAtMoorlands.latestBooking()).last()
       assertThat(savedAllocation).isNotNull
@@ -1461,7 +1461,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
 
       // Emulate the Nomis trigger COURSE_ACTIVITIES_T2.trg
       repository.runInTransaction {
-        val activity = repository.lookupActivity(activityId)
+        val activity = repository.getActivity(activityId)
         activity.area = CourseActivityArea(activityId, activity, "AREA")
         repository.activityRepository.save(activity)
       }
@@ -1474,7 +1474,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         .exchange()
 
       // check the activity still has an activity area
-      val savedActivity = repository.lookupActivity(activityId)
+      val savedActivity = repository.getActivity(activityId)
       assertThat(savedActivity.area!!.areaCode).isEqualTo("AREA")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationResourceIntTest.kt
@@ -321,7 +321,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       assertThat(response?.offenderProgramReferenceId).isGreaterThan(0)
       assertThat(response?.created).isTrue()
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(offenderBooking.bookingId).isEqualTo(bookingId)
         assertThat(startDate).isEqualTo("2022-11-14")
@@ -365,7 +365,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
 
       val response = upsertAllocationIsOk(request)!!
 
-      val saved = repository.lookupOffenderProgramProfile(courseActivity, offender.latestBooking())
+      val saved = repository.getOffenderProgramProfiles(courseActivity, offender.latestBooking())
       with(saved[0]) {
         assertThat(startDate).isEqualTo("2022-10-31")
         assertThat(endDate).isEqualTo("2022-11-01")
@@ -441,7 +441,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       assertThat(response?.offenderProgramReferenceId).isGreaterThan(0)
       assertThat(response?.created).isFalse()
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(offenderBooking.bookingId).isEqualTo(bookingId)
         assertThat(endDate).isEqualTo("$yesterday")
@@ -464,7 +464,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       assertThat(response?.offenderProgramReferenceId).isGreaterThan(0)
       assertThat(response?.created).isFalse()
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(offenderBooking.bookingId).isEqualTo(bookingId)
         assertThat(suspended).isTrue()
@@ -494,7 +494,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
         )
       val response = upsertAllocationIsOk(endRequest)
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(offenderBooking.bookingId).isEqualTo(bookingId)
         assertThat(endDate).isEqualTo("$yesterday")
@@ -512,7 +512,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       assertThat(response?.offenderProgramReferenceId).isGreaterThan(0)
       assertThat(response?.created).isFalse()
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(payBands[0].payBand.code).isEqualTo("5")
         assertThat(payBands[0].endDate).isEqualTo(today)
@@ -530,7 +530,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       val secondPayBandUpdateRequest = upsertRequest().withPayBandCode("7")
       val response = upsertAllocationIsOk(secondPayBandUpdateRequest)
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(payBands[0].payBand.code).isEqualTo("5")
         assertThat(payBands[0].endDate).isEqualTo(today)
@@ -548,7 +548,7 @@ class AllocationResourceIntTest : IntegrationTestBase() {
       val revertPayBandRequest = upsertRequest().withPayBandCode("5")
       val response = upsertAllocationIsOk(revertPayBandRequest)
 
-      val saved = repository.lookupOffenderProgramProfile(response!!.offenderProgramReferenceId)
+      val saved = repository.getOffenderProgramProfile(response!!.offenderProgramReferenceId)
       with(saved) {
         assertThat(offenderBooking.bookingId).isEqualTo(bookingId)
         assertThat(startDate).isEqualTo("2022-11-14")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AttendanceResourceIntTest.kt
@@ -384,7 +384,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
         assertThat(response.courseScheduleId).isEqualTo(courseSchedule.courseScheduleId)
         assertThat(response.created).isTrue()
 
-        val saved = repository.lookupAttendance(response.eventId)
+        val saved = repository.getAttendance(response.eventId)
         with(saved) {
           assertThat(offenderBooking.bookingId).isEqualTo(this@UpsertAttendance.offenderBooking.bookingId)
           assertThat(eventDate).isEqualTo("2022-11-01")
@@ -421,7 +421,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
         assertThat(response.courseScheduleId).isEqualTo(courseSchedule.courseScheduleId)
         assertThat(response.created).isTrue()
 
-        val saved = repository.lookupAttendance(response.eventId)
+        val saved = repository.getAttendance(response.eventId)
         with(saved) {
           assertThat(offenderBooking.bookingId).isEqualTo(this@UpsertAttendance.offenderBooking.bookingId)
           assertThat(eventDate).isEqualTo("2022-11-01")
@@ -480,7 +480,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
           .jsonPath("created").isEqualTo("false")
 
-        val saved = repository.lookupAttendance(attendance.eventId)
+        val saved = repository.getAttendance(attendance.eventId)
         assertThat(saved.eventStatus.code).isEqualTo("SCH")
       }
 
@@ -497,7 +497,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
           .jsonPath("created").isEqualTo("false")
 
-        val saved = repository.lookupAttendance(attendance.eventId)
+        val saved = repository.getAttendance(attendance.eventId)
         assertThat(saved.eventStatus.code).isEqualTo("SCH")
         assertThat(saved.eventDate).isEqualTo("2022-11-02")
         assertThat(saved.startTime).isEqualTo("2022-11-02T13:00")
@@ -524,7 +524,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
         webTestClient.upsertAttendance(courseSchedule.courseScheduleId, offenderBooking.bookingId, request)
           .expectStatus().isOk
 
-        val saved = repository.lookupAttendance(attendance.eventId)
+        val saved = repository.getAttendance(attendance.eventId)
         assertThat(saved.eventStatus.code).isEqualTo("CANC")
       }
 
@@ -548,7 +548,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
         webTestClient.upsertAttendance(courseSchedule.courseScheduleId, offenderBooking.bookingId, request)
           .expectStatus().isOk
 
-        val saved = repository.lookupAttendance(attendance.eventId)
+        val saved = repository.getAttendance(attendance.eventId)
         assertThat(saved.eventStatus.code).isEqualTo("EXP")
       }
 
@@ -594,7 +594,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
             .expectBody(UpsertAttendanceResponse::class.java)
             .returnResult().responseBody!!
 
-        val saved = repository.lookupAttendance(response.eventId)
+        val saved = repository.getAttendance(response.eventId)
         with(saved) {
           assertThat(eventStatus.code).isEqualTo("COMP")
           assertThat(attendanceOutcome?.code).isEqualTo("CANC")
@@ -630,7 +630,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
             .expectBody(UpsertAttendanceResponse::class.java)
             .returnResult().responseBody!!
 
-        val saved = repository.lookupAttendance(response.eventId)
+        val saved = repository.getAttendance(response.eventId)
         with(saved) {
           assertThat(eventStatus.code).isEqualTo("COMP")
           assertThat(attendanceOutcome?.code).isEqualTo("ATT")
@@ -668,7 +668,7 @@ class AttendanceResourceIntTest : IntegrationTestBase() {
         assertThat(response.courseScheduleId).isEqualTo(courseSchedule.courseScheduleId)
         assertThat(response.created).isFalse()
 
-        val saved = repository.lookupAttendance(response.eventId)
+        val saved = repository.getAttendance(response.eventId)
         with(saved) {
           assertThat(offenderBooking.bookingId).isEqualTo(this@UpsertAttendance.offenderBooking.bookingId)
           assertThat(eventStatus.code).isEqualTo("COMP")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ScheduleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ScheduleResourceIntTest.kt
@@ -208,7 +208,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleDate).isEqualTo("$today")
           assertThat(startTime).isEqualTo("${today}T08:00")
@@ -244,7 +244,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleStatus).isEqualTo("SCH")
         }
@@ -276,7 +276,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleStatus).isEqualTo("CANC")
         }
@@ -315,7 +315,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
             assertThat(it).contains("Cannot change schedule id=${courseSchedule.courseScheduleId} because it is immutable")
           }
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleDate).isEqualTo("$yesterday")
           assertThat(startTime).isEqualTo("${yesterday}T08:00")
@@ -344,7 +344,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
             assertThat(it).contains("Schedule for date $today has times out of order - 13:00 to 12:59")
           }
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleDate).isEqualTo("$today")
           assertThat(startTime).isEqualTo("${today}T08:00")
@@ -371,7 +371,7 @@ class ScheduleResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("courseScheduleId").isEqualTo(courseSchedule.courseScheduleId)
 
-        val saved = repository.lookupSchedule(courseSchedule.courseScheduleId)
+        val saved = repository.getSchedule(courseSchedule.courseScheduleId)
         with(saved) {
           assertThat(scheduleDate).isEqualTo("$today")
           assertThat(startTime).isEqualTo("${today}T13:00")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentsResourceIntTest.kt
@@ -246,7 +246,7 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
       val id = callCreateEndpoint()
 
       // Check the database
-      val offenderIndividualSchedule = repository.lookupAppointment(id)!!
+      val offenderIndividualSchedule = repository.getAppointment(id)!!
 
       assertThat(offenderIndividualSchedule.eventId).isEqualTo(id)
       assertThat(offenderIndividualSchedule.offenderBooking.bookingId).isEqualTo(offenderAtMoorlands.latestBooking().bookingId)
@@ -400,7 +400,7 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
       callUpdateEndpoint(eventId)
 
       // Check the database
-      val offenderIndividualSchedule = repository.lookupAppointment(eventId)!!
+      val offenderIndividualSchedule = repository.getAppointment(eventId)!!
 
       assertThat(offenderIndividualSchedule.eventId).isEqualTo(eventId)
       assertThat(offenderIndividualSchedule.offenderBooking.bookingId).isEqualTo(offenderAtMoorlands.latestBooking().bookingId)
@@ -475,7 +475,7 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
       callCancelEndpoint(eventId)
 
       // Check the database
-      val offenderIndividualSchedule = repository.lookupAppointment(eventId)!!
+      val offenderIndividualSchedule = repository.getAppointment(eventId)!!
 
       assertThat(offenderIndividualSchedule.eventId).isEqualTo(eventId)
       assertThat(offenderIndividualSchedule.eventStatus.code).isEqualTo("CANC")
@@ -523,7 +523,7 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
       callUncancelEndpoint(eventId)
 
       // Check the database
-      val offenderIndividualSchedule = repository.lookupAppointment(eventId)!!
+      val offenderIndividualSchedule = repository.getAppointment(eventId)!!
 
       assertThat(offenderIndividualSchedule.eventId).isEqualTo(eventId)
       assertThat(offenderIndividualSchedule.eventStatus.code).isEqualTo("SCH")
@@ -571,7 +571,7 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
 
       // Check the database
 
-      assertThat(repository.lookupAppointment(eventId)).isNull()
+      assertThat(repository.getAppointment(eventId)).isNull()
     }
 
     private fun callDeleteEndpoint(eventId: Long) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationIncidentBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationIncidentBuilder.kt
@@ -6,7 +6,6 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingResu
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingResultAward
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingResultAwardId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingResultId
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncident
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentCharge
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentChargeId
@@ -15,10 +14,8 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentPar
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentRepair
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentRepairId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationInvestigation
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.IncidentDecisionAction
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Staff
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.suspectRole
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -87,8 +84,8 @@ class AdjudicationPartyBuilder(
   private val comment: String,
   private val offenderBooking: OffenderBooking?,
   private val staff: Staff?,
-  private val incidentRole: String = suspectRole,
-  private val actionDecision: String = IncidentDecisionAction.NO_FURTHER_ACTION_CODE,
+  private val incidentRole: String,
+  private val actionDecision: String,
   private val partyAddedDate: LocalDate,
   var charges: List<AdjudicationChargeBuilder> = listOf(),
   var hearings: List<AdjudicationHearingBuilder> = listOf(),
@@ -159,6 +156,10 @@ class AdjudicationPartyBuilder(
     hearingDate: LocalDate?,
     hearingTime: LocalDateTime?,
     hearingStaff: Staff?,
+    hearingTypeCode: String,
+    eventStatusCode: String,
+    comment: String,
+    representativeText: String,
     dsl: AdjudicationHearingDsl.() -> Unit,
   ) {
     this.hearings += AdjudicationHearingBuilder(
@@ -168,6 +169,10 @@ class AdjudicationPartyBuilder(
       hearingDate = hearingDate,
       hearingDateTime = hearingTime,
       hearingStaff = hearingStaff,
+      comment = comment,
+      representativeText = representativeText,
+      eventStatusCode = eventStatusCode,
+      hearingTypeCode = hearingTypeCode,
     ).apply(dsl)
   }
 }
@@ -236,9 +241,9 @@ class AdjudicationInvestigationBuilder(
 }
 
 class AdjudicationEvidenceBuilder(
-  private val detail: String = "Knife found",
-  private val type: String = "WEAP",
-  private val date: LocalDate = LocalDate.now(),
+  private val detail: String,
+  private val type: String,
+  private val date: LocalDate,
 ) : AdjudicationEvidenceDsl {
   fun build(repository: Repository, investigation: AdjudicationInvestigation): AdjudicationEvidence =
     AdjudicationEvidence(
@@ -250,16 +255,16 @@ class AdjudicationEvidenceBuilder(
 }
 
 class AdjudicationHearingBuilder(
-  private val hearingDate: LocalDate? = LocalDate.now(),
-  private val hearingDateTime: LocalDateTime? = LocalDateTime.now(),
-  private val scheduledDate: LocalDate? = LocalDate.now(),
-  private val scheduledDateTime: LocalDateTime? = LocalDateTime.now(),
+  private val hearingDate: LocalDate?,
+  private val hearingDateTime: LocalDateTime?,
+  private val scheduledDate: LocalDate?,
+  private val scheduledDateTime: LocalDateTime?,
   private val hearingStaff: Staff? = null,
-  private val eventStatusCode: String = "SCH",
-  private val hearingTypeCode: String = AdjudicationHearingType.GOVERNORS_HEARING,
-  private val comment: String = "Hearing comment",
-  private val representativeText: String = "rep text",
+  private val comment: String,
+  private val representativeText: String,
   private val agencyInternalLocationId: Long?,
+  private val hearingTypeCode: String,
+  private val eventStatusCode: String,
   var results: List<AdjudicationHearingResultBuilder> = listOf(),
 ) : AdjudicationHearingDsl {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/DSL.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/DSL.kt
@@ -2,10 +2,12 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.PartyRole.WITNESS
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncident
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationIncidentCharge
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourseActivity
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.IncidentDecisionAction.Companion.NO_FURTHER_ACTION_CODE
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.IncidentDecisionAction.Companion.PLACED_ON_REPORT_ACTION_CODE
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.ProgramService
@@ -143,6 +145,8 @@ interface BookingDsl {
     adjudicationNumber: Long = 1224,
     comment: String = "party comment",
     partyAddedDate: LocalDate = LocalDate.of(2023, 5, 10),
+    incidentRole: String = suspectRole,
+    actionDecision: String = PLACED_ON_REPORT_ACTION_CODE,
     dsl: AdjudicationPartyDsl.() -> Unit = {},
   )
 
@@ -228,9 +232,13 @@ interface AdjudicationPartyDsl {
     internalLocationId: Long? = null,
     scheduleDate: LocalDate? = null,
     scheduleTime: LocalDateTime? = null,
-    hearingDate: LocalDate? = null,
-    hearingTime: LocalDateTime? = null,
+    hearingDate: LocalDate? = LocalDate.now(),
+    hearingTime: LocalDateTime? = LocalDateTime.now(),
     hearingStaff: Staff? = null,
+    hearingTypeCode: String = AdjudicationHearingType.GOVERNORS_HEARING,
+    eventStatusCode: String = "SCH",
+    comment: String = "Hearing comment",
+    representativeText: String = "rep text",
     dsl: AdjudicationHearingDsl.() -> Unit = {},
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderBookingBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderBookingBuilder.kt
@@ -70,6 +70,8 @@ class OffenderBookingBuilder(
     adjudicationNumber: Long,
     comment: String,
     partyAddedDate: LocalDate,
+    incidentRole: String,
+    actionDecision: String,
     dsl: AdjudicationPartyDsl.() -> Unit,
   ) {
     this.adjudications += Pair(
@@ -80,6 +82,8 @@ class OffenderBookingBuilder(
         partyAddedDate = partyAddedDate,
         offenderBooking = null,
         staff = null,
+        incidentRole = incidentRole,
+        actionDecision = actionDecision,
       ).apply(dsl),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/incentives/IncentivesResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/incentives/IncentivesResourceIntTest.kt
@@ -101,14 +101,14 @@ class IncentivesResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `will create incentive with correct details`() {
-      var offender = repository.lookupOffender("A1234TT")
+      var offender = repository.getOffender("A1234TT")
       var booking = offender?.latestBooking()
       var bookingId = booking?.bookingId
 
       callCreateEndpoint(bookingId)
 
       // Spot check that the database has been populated.
-      offender = repository.lookupOffender("A1234TT")
+      offender = repository.getOffender("A1234TT")
       booking = offender?.latestBooking()
       bookingId = booking?.bookingId
 
@@ -121,7 +121,7 @@ class IncentivesResourceIntTest : IntegrationTestBase() {
       // Add another to cover the case of existing incentive
       callCreateEndpoint(bookingId)
 
-      offender = repository.lookupOffender("A1234TT")
+      offender = repository.getOffender("A1234TT")
       booking = offender?.latestBooking()
       bookingId = booking?.bookingId
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitResourceIntTest.kt
@@ -201,7 +201,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .expectBody(CreateVisitResponse::class.java)
         .returnResult().responseBody
 
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.visitors).extracting("person.id", "eventStatus.code").containsExactly(
         tuple(null, "SCH"),
@@ -247,7 +247,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       assertThat(response?.visitId).isGreaterThan(0)
 
       // Spot check that the database has been populated.
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.endDateTime).isEqualTo(LocalDateTime.parse("2021-11-04T13:04"))
       assertThat(visit.offenderBooking.bookingId).isEqualTo(offenderBookingId)
@@ -283,7 +283,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       assertThat(response?.visitId).isGreaterThan(0)
 
       // Spot check that the database has been populated.
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.visitOrder).isNotNull
       assertThat(visit.visitOrder?.commentText).isEqualTo("VSIP Order Ref: asd-fff-ddd")
@@ -326,7 +326,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       assertThat(response?.visitId).isGreaterThan(0)
 
       // Spot check that the database has been populated.
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.agencyVisitSlot).isNotNull
       assertThat(visit.agencyVisitSlot!!.agencyInternalLocation.description).isEqualTo("$prisonId-VISIT-VSIP_SOC")
@@ -371,7 +371,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       assertThat(response?.visitId).isGreaterThan(0)
 
       // Spot check that the database has been populated.
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.agencyVisitSlot).isNotNull
       assertThat(visit.agencyVisitSlot!!.agencyInternalLocation.description).isEqualTo("MDI-VISITS-VSIP_SOC")
@@ -408,7 +408,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       assertThat(response?.visitId).isGreaterThan(0)
 
       // Spot check that the database has been populated.
-      val visit = repository.lookupVisit(response?.visitId)
+      val visit = repository.getVisit(response?.visitId)
 
       assertThat(visit.agencyVisitSlot).isNotNull
       assertThat(visit.agencyVisitSlot!!.agencyInternalLocation.description).isEqualTo("BXI-VISIT-VSIP_SOC")
@@ -421,9 +421,9 @@ class VisitResourceIntTest : IntegrationTestBase() {
     inner class RoomSlotSideEffects {
       @Test
       internal fun `will create a weekly slot when one does not already exist`() {
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).isEmpty()
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).isEmpty()
 
-        val visit = repository.lookupVisit(
+        val visit = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -432,10 +432,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
 
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(1)
           .anyMatch { it.id == visit.agencyVisitSlot!!.id }
 
-        val visitForFollowingWeek = repository.lookupVisit(
+        val visitForFollowingWeek = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-11T14:00",
             endTime = "16:00",
@@ -443,10 +443,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
             openClosedStatus = "OPEN",
           ),
         )
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(1)
           .anyMatch { it.id == visitForFollowingWeek.agencyVisitSlot!!.id }
 
-        val visitForNextDay = repository.lookupVisit(
+        val visitForNextDay = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-12T14:00",
             endTime = "16:00",
@@ -454,15 +454,15 @@ class VisitResourceIntTest : IntegrationTestBase() {
             openClosedStatus = "OPEN",
           ),
         )
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(2)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(2)
           .anyMatch { it.id == visitForNextDay.agencyVisitSlot!!.id }
       }
 
       @Test
       internal fun `visits in different rooms are in different slots only when closed v open`() {
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).isEmpty()
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).isEmpty()
 
-        val visit = repository.lookupVisit(
+        val visit = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -472,10 +472,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
         )
 
         assertThat(visit.agencyInternalLocation!!.description).isEqualTo("$prisonId-VISIT-VSIP_SOC")
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(1)
           .anyMatch { it.id == visit.agencyVisitSlot!!.id }
 
-        val visitInDifferentRestrictionRoom = repository.lookupVisit(
+        val visitInDifferentRestrictionRoom = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -484,10 +484,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
         assertThat(visitInDifferentRestrictionRoom.agencyInternalLocation!!.description).isEqualTo("$prisonId-VISIT-VSIP_CLO")
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(2)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(2)
           .anyMatch { it.id == visitInDifferentRestrictionRoom.agencyVisitSlot!!.id }
 
-        val visitInDifferentPhysicalRoom = repository.lookupVisit(
+        val visitInDifferentPhysicalRoom = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -496,15 +496,15 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
         assertThat(visitInDifferentPhysicalRoom.agencyInternalLocation!!.description).isEqualTo("$prisonId-VISIT-VSIP_CLO")
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(2)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(2)
           .anyMatch { it.id == visitInDifferentPhysicalRoom.agencyVisitSlot!!.id }
       }
 
       @Test
       internal fun `a different end time does not cause a new slot to be created`() {
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).isEmpty()
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).isEmpty()
 
-        val visit = repository.lookupVisit(
+        val visit = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -513,10 +513,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
 
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(1)
           .anyMatch { it.id == visit.agencyVisitSlot!!.id }
 
-        val visitThatEndAtDifferentTime = repository.lookupVisit(
+        val visitThatEndAtDifferentTime = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "14:30",
@@ -524,15 +524,15 @@ class VisitResourceIntTest : IntegrationTestBase() {
             openClosedStatus = "OPEN",
           ),
         )
-        assertThat(repository.findAllAgencyVisitSlots(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitSlots(prisonId)).hasSize(1)
           .anyMatch { it.id == visitThatEndAtDifferentTime.agencyVisitSlot!!.id }
       }
 
       @Test
       internal fun `a different end time does not cause a new time of day to be created`() {
-        assertThat(repository.findAllAgencyVisitTimes(prisonId)).isEmpty()
+        assertThat(repository.getAllAgencyVisitTimes(prisonId)).isEmpty()
 
-        val visit = repository.lookupVisit(
+        val visit = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "16:00",
@@ -541,10 +541,10 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
 
-        assertThat(repository.findAllAgencyVisitTimes(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitTimes(prisonId)).hasSize(1)
           .anyMatch { it.agencyVisitTimesId == visit.agencyVisitSlot!!.agencyVisitTime.agencyVisitTimesId }
 
-        val visitThatEndAtDifferentTime = repository.lookupVisit(
+        val visitThatEndAtDifferentTime = repository.getVisit(
           createVisit(
             startDateTime = "2021-11-04T14:00",
             endTime = "14:30",
@@ -552,15 +552,15 @@ class VisitResourceIntTest : IntegrationTestBase() {
             openClosedStatus = "OPEN",
           ),
         )
-        assertThat(repository.findAllAgencyVisitTimes(prisonId)).hasSize(1)
+        assertThat(repository.getAllAgencyVisitTimes(prisonId)).hasSize(1)
           .anyMatch { it.agencyVisitTimesId == visitThatEndAtDifferentTime.agencyVisitSlot!!.agencyVisitTime.agencyVisitTimesId }
       }
 
       @Test
       internal fun `a day of the week is created for prison when one does not already exist`() {
-        assertThat(repository.findAllAgencyVisitDays("MONDAY", prisonId)).isNull()
+        assertThat(repository.getAgencyVisitDays("MONDAY", prisonId)).isNull()
 
-        val visit = repository.lookupVisit(
+        val visit = repository.getVisit(
           createVisit(
             startDateTime = "2022-08-01T14:00",
             endTime = "16:00",
@@ -569,12 +569,12 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
 
-        assertThat(repository.findAllAgencyVisitDays("MON", prisonId))
+        assertThat(repository.getAgencyVisitDays("MON", prisonId))
           .isNotNull
           .matches { it!!.agencyVisitDayId.weekDay == visit.agencyVisitSlot!!.weekDay }
           .matches { it!!.agencyVisitDayId.weekDay == "MON" }
 
-        val visitForFollowingWeek = repository.lookupVisit(
+        val visitForFollowingWeek = repository.getVisit(
           createVisit(
             startDateTime = "2022-08-08T14:00",
             endTime = "16:00",
@@ -582,12 +582,12 @@ class VisitResourceIntTest : IntegrationTestBase() {
             openClosedStatus = "OPEN",
           ),
         )
-        assertThat(repository.findAllAgencyVisitDays("MON", prisonId))
+        assertThat(repository.getAgencyVisitDays("MON", prisonId))
           .isNotNull
           .matches { it!!.agencyVisitDayId.weekDay == visitForFollowingWeek.agencyVisitSlot!!.weekDay }
           .matches { it!!.agencyVisitDayId.weekDay == "MON" }
 
-        val visitForNextDay = repository.lookupVisit(
+        val visitForNextDay = repository.getVisit(
           createVisit(
             startDateTime = "2022-08-09T14:00",
             endTime = "16:00",
@@ -596,7 +596,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
           ),
         )
         assertThat(
-          repository.findAllAgencyVisitDays(
+          repository.getAgencyVisitDays(
             "TUE",
             prisonId,
           ),
@@ -666,7 +666,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
         .expectBody().isEmpty
 
       // Spot check that the database has been updated correctly.
-      val visit = repository.lookupVisit(visitId)
+      val visit = repository.getVisit(visitId)
 
       assertThat(visit.visitStatus.code).isEqualTo("CANC")
       assertThat(visit.offenderBooking.bookingId).isEqualTo(offenderBookingId)
@@ -744,7 +744,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
           .returnResult().responseBody?.userMessage,
       ).isEqualTo("Visit already cancelled, with outcome VISCANC")
 
-      repository.changeVisitStatus(visitId)
+      repository.updateVisitStatus(visitId)
 
       assertThat(
         webTestClient.put().uri("/prisoners/$offenderNo/visits/$visitId/cancel")


### PR DESCRIPTION
- Adjudication DSL interface now contains all defaults, with defaults moved from Builder constructor
- Repository reorganised into sections
- Helpers used in Tests (rather than in Builders) moved and renamed to use the convention of `get` rather than `lookup` to disiguish from Builder reference data lookups