### PR TITLE
SDIT-916 Handle course start date moved back in time

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ActivityResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/ActivityResourceIntTest.kt
@@ -800,7 +800,7 @@ class ActivityResourceIntTest : IntegrationTestBase() {
         )
           .expectStatus().isOk
 
-        val updated = repository.lookupActivity(courseActivity.courseActivityId)
+        val updated = repository.getActivity(courseActivity.courseActivityId)
         assertThat(updated.payRates[0].id.startDate).isEqualTo(yesterday)
         assertThat(updated.payRates[0].endDate).isNull()
         assertThat(updated.payRates[1].id.startDate).isEqualTo(yesterday)


### PR DESCRIPTION
Handles an edge case where the course start date is movedbefore the existing pay rates become active by adjusting the start date of the pay rates.