### PR TITLE
SDIT-969 Set created user and fix issue with prisoners with aliases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocati
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.StaffUserAccountRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.findRootByNomisId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.specification.AdjudicationChargeSpecification
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.staffParty
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.suspectRole
@@ -176,6 +177,7 @@ class AdjudicationService(
       incidentDetails = request.incident.details,
       agencyInternalLocation = internalLocation,
       reportingStaff = reportingStaff,
+      createUser = reportingStaff,
     ).let { adjudicationIncidentRepository.save(it) }
       .apply {
         parties += createPrisonerAdjudicationParty(this, offenderBooking, request)
@@ -338,7 +340,7 @@ class AdjudicationService(
   }
 
   private fun findPrisoner(offenderNo: String): Offender {
-    return offenderRepository.findFirstByNomsId(offenderNo)
+    return offenderRepository.findRootByNomisId(offenderNo)
       ?: throw NotFoundException("Prisoner $offenderNo not found")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncident.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncident.kt
@@ -77,6 +77,9 @@ class AdjudicationIncident(
   @JoinColumn(name = "AGY_LOC_ID", nullable = false)
   val prison: AgencyLocation,
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "CREATE_USER_ID")
+  val createUser: Staff,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderRepository.kt
@@ -1,11 +1,16 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
 
 @Repository
 interface OffenderRepository : JpaRepository<Offender, Long> {
   fun findByNomsId(nomsId: String): List<Offender>
-  fun findFirstByNomsId(nomsId: String): Offender?
+
+  @Query("select o from Offender o left join fetch o.bookings b WHERE o.nomsId = :nomsId order by b.bookingSequence asc")
+  fun findByNomsIdOrderedWithBookings(nomsId: String): List<Offender>
 }
+
+fun OffenderRepository.findRootByNomisId(nomsId: String): Offender? = findByNomsIdOrderedWithBookings(nomsId).firstOrNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
@@ -1325,6 +1325,7 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
 
           assertThat(incident).isNotNull
           assertThat(incident!!.reportingStaff.accounts[0].username).isEqualTo("JANESTAFF")
+          assertThat(incident!!.createUser.accounts[0].username).isEqualTo("JANESTAFF")
           assertThat(incident!!.agencyInternalLocation.locationId).isEqualTo(aLocationInMoorland)
           assertThat(incident!!.prison.id).isEqualTo("MDI")
           assertThat(incident!!.incidentDate).isEqualTo(LocalDate.parse("2023-01-01"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationIncident.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationIncident.kt
@@ -104,6 +104,7 @@ class AdjudicationIncidentBuilder(
     incidentType = repository.lookupIncidentType(),
     prison = repository.lookupAgency(prisonId),
     incidentDetails = incidentDetails,
+    createUser = reportingStaff,
   )
     .let { repository.save(it) }
     .also { adjudicationIncident = it }


### PR DESCRIPTION
* Now sets created user on Incident since this is displayed in NOMIS
* Fix issues where root offender was not being retrieved so prisoners with aliases had "no bookings"