### PR TITLE
SDIT-927 Additional adjudication data required by DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
@@ -146,6 +146,8 @@ data class Staff(
   val firstName: String,
   @Schema(description = "Last name of staff member")
   val lastName: String,
+  @Schema(description = "Username of person who created the record in NOMIS where this staff is used", required = true)
+  val createdByUsername: String,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -156,6 +158,8 @@ data class Prisoner(
   val firstName: String?,
   @Schema(description = "Last name of prisoner")
   val lastName: String,
+  @Schema(description = "Username of person who created the record in NOMIS where this prisoner is used", required = true)
+  val createdByUsername: String,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -198,9 +202,13 @@ data class Evidence(
 data class Hearing(
   val hearingId: Long,
   val type: CodeDescription?,
+  @Schema(description = "Hearing scheduled date as set by DPS but not used by NOMIS or set in NOMIS")
   val scheduleDate: LocalDate?,
+  @Schema(description = "Hearing scheduled time as set by DPS but not used by NOMIS or set in NOMIS")
   val scheduleTime: LocalTime?,
+  @Schema(description = "Hearing date")
   val hearingDate: LocalDate?,
+  @Schema(description = "Hearing time")
   val hearingTime: LocalTime?,
   val comment: String?,
   val representativeText: String?,
@@ -209,6 +217,10 @@ data class Hearing(
   val eventStatus: CodeDescription?,
   val hearingResults: List<HearingResult>,
   val eventId: Long?,
+  @Schema(description = "Date time when the record was created the record in NOMIS", required = true)
+  val createdDateTime: LocalDateTime,
+  @Schema(description = "Username of person who created the record in NOMIS", required = true)
+  val createdByUsername: String,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -218,10 +230,16 @@ data class HearingResult(
   val charge: AdjudicationCharge,
   val offence: AdjudicationOffence,
   val resultAwards: List<HearingResultAward>,
+  @Schema(description = "Date time when the record was created the record in NOMIS", required = true)
+  val createdDateTime: LocalDateTime,
+  @Schema(description = "Username of person who created the record in NOMIS", required = true)
+  val createdByUsername: String,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class HearingResultAward(
+  @Schema(description = "Sequence of this sanction for this prisoner's booking", required = true)
+  val sequence: Int,
   val sanctionType: CodeDescription?, // may not have a matching description if dodgy data
   val sanctionStatus: CodeDescription?,
   val comment: String?,
@@ -233,9 +251,10 @@ data class HearingResultAward(
   val consecutiveAward: HearingResultAward?,
 )
 
-fun Offender.toPrisoner() =
+fun Offender.toPrisoner(createUsername: String) =
   Prisoner(
     offenderNo = nomsId,
     firstName = firstName,
     lastName = lastName,
+    createdByUsername = createUsername,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearing.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearing.kt
@@ -103,7 +103,12 @@ class AdjudicationHearing(
 
   @OneToMany(mappedBy = "hearing", cascade = [CascadeType.ALL], orphanRemoval = true)
   val hearingResults: MutableList<AdjudicationHearingResult> = mutableListOf(),
+
+  @Column(name = "CREATE_DATETIME", nullable = false)
+  var whenCreated: LocalDateTime = LocalDateTime.now(),
 ) {
+  @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
+  lateinit var createUsername: String
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResult.kt
@@ -18,6 +18,7 @@ import org.hibernate.annotations.JoinFormula
 import org.hibernate.annotations.NotFound
 import org.hibernate.annotations.NotFoundAction
 import java.io.Serializable
+import java.time.LocalDateTime
 
 @Embeddable
 class AdjudicationHearingResultId(
@@ -117,7 +118,12 @@ class AdjudicationHearingResult(
 
   @OneToMany(mappedBy = "hearingResult", cascade = [CascadeType.ALL], orphanRemoval = true)
   val resultAwards: MutableList<AdjudicationHearingResultAward> = mutableListOf(),
+
+  @Column(name = "CREATE_DATETIME", nullable = false)
+  var whenCreated: LocalDateTime = LocalDateTime.now(),
 ) {
+  @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
+  lateinit var createUsername: String
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncidentParty.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncidentParty.kt
@@ -89,6 +89,9 @@ class AdjudicationIncidentParty(
   var whenCreated: LocalDateTime = LocalDateTime.now(),
 
 ) {
+  @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
+  lateinit var createUsername: String
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationInvestigation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationInvestigation.kt
@@ -56,6 +56,8 @@ class AdjudicationInvestigation(
   @OneToMany(mappedBy = "investigation", cascade = [CascadeType.ALL], orphanRemoval = true)
   val evidence: MutableList<AdjudicationEvidence> = mutableListOf(),
 ) {
+  @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
+  lateinit var createUsername: String
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
@@ -684,8 +684,44 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
 
         @Test
         fun `returns details of the hearing outcome and punishments (aka awards)`() {
-          webTestClient.get().uri("/adjudications/adjudication-number/$adjudicationNumber")
-          getAdjudicationHearingOutcomeAndPunishmentTest("/adjudications/adjudication-number/$adjudicationNumber")
+          webTestClient.get()
+            .uri("/adjudications/adjudication-number/$adjudicationNumber")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("adjudicationNumber").isEqualTo(adjudicationNumber)
+            .jsonPath("hearings[0].hearingResults[0].pleaFindingType.description").isEqualTo("Not guilty")
+            .jsonPath("hearings[0].hearingResults[0].findingType.description").isEqualTo("Charge Proved")
+            .jsonPath("hearings[0].hearingResults[0].charge.offence.code").isEqualTo("51:1N")
+            .jsonPath("hearings[0].hearingResults[0].offence.code").isEqualTo("51:1N")
+            .jsonPath("hearings[0].hearingResults[0].createdByUsername").isNotEmpty
+            .jsonPath("hearings[0].hearingResults[0].createdDateTime").isNotEmpty
+            .jsonPath("hearings[0].hearingResults[1].pleaFindingType.description").isEqualTo("Unfit to Plea or Attend")
+            .jsonPath("hearings[0].hearingResults[1].findingType.description").isEqualTo("Charge Not Proceeded With")
+            .jsonPath("hearings[0].hearingResults[1].charge.offence.code").isEqualTo("51:3")
+            .jsonPath("hearings[0].hearingResults[1].offence.code").isEqualTo("51:3")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionType.description")
+            .isEqualTo("Removal from Activity")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionStatus.description").isEqualTo("Suspended")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].effectiveDate").isEqualTo("2023-01-03")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].statusDate").isEqualTo("2023-01-04")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].comment").isEqualTo("award comment")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].compensationAmount").isEqualTo(12.2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionMonths").isEqualTo(1)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionDays").isEqualTo(2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sequence").isEqualTo(1)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sanctionType.description")
+            .isEqualTo("Stoppage of Earnings (amount)")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].consecutiveAward.sanctionType.description")
+            .isEqualTo("Removal from Activity")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sequence").isEqualTo(2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].effectiveDate").isEqualTo("2023-01-08")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.sanctionType.description")
+            .isEqualTo("Stoppage of Earnings (amount)")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.consecutiveAward")
+            .doesNotExist()
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].sequence").isEqualTo(3)
         }
       }
     }
@@ -810,8 +846,55 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
         }
 
         @Test
-        fun `returns details of the hearing outcome and punishments (aka awards)`() {
-          getAdjudicationHearingOutcomeAndPunishmentTest("/adjudications/adjudication-number/$adjudicationNumber/charge-sequence/$hoochChargeSequence")
+        fun `returns details of the hearing outcome and punishments (aka awards) only for this charge`() {
+          webTestClient.get()
+            .uri("/adjudications/adjudication-number/$adjudicationNumber/charge-sequence/$hoochChargeSequence")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("adjudicationNumber").isEqualTo(adjudicationNumber)
+            .jsonPath("hearings[0].hearingResults[0].pleaFindingType.description").isEqualTo("Not guilty")
+            .jsonPath("hearings[0].hearingResults[0].findingType.description").isEqualTo("Charge Proved")
+            .jsonPath("hearings[0].hearingResults[0].charge.offence.code").isEqualTo("51:1N")
+            .jsonPath("hearings[0].hearingResults[0].offence.code").isEqualTo("51:1N")
+            .jsonPath("hearings[0].hearingResults[0].createdByUsername").isNotEmpty
+            .jsonPath("hearings[0].hearingResults[0].createdDateTime").isNotEmpty
+            .jsonPath("hearings[0].hearingResults[1]").doesNotExist()
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionType.description")
+            .isEqualTo("Removal from Activity")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionStatus.description").isEqualTo("Suspended")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].effectiveDate").isEqualTo("2023-01-03")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].statusDate").isEqualTo("2023-01-04")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].comment").isEqualTo("award comment")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].compensationAmount").isEqualTo(12.2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionMonths").isEqualTo(1)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionDays").isEqualTo(2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sequence").isEqualTo(1)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sanctionType.description")
+            .isEqualTo("Stoppage of Earnings (amount)")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].consecutiveAward.sanctionType.description")
+            .isEqualTo("Removal from Activity")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sequence").isEqualTo(2)
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].effectiveDate").isEqualTo("2023-01-08")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.sanctionType.description")
+            .isEqualTo("Stoppage of Earnings (amount)")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.consecutiveAward")
+            .doesNotExist()
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[2].sequence").isEqualTo(3)
+
+          webTestClient.get()
+            .uri("/adjudications/adjudication-number/$adjudicationNumber/charge-sequence/$deadSwanChargeSequence")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("adjudicationNumber").isEqualTo(adjudicationNumber)
+            .jsonPath("hearings[0].hearingResults[0].pleaFindingType.description").isEqualTo("Unfit to Plea or Attend")
+            .jsonPath("hearings[0].hearingResults[0].findingType.description").isEqualTo("Charge Not Proceeded With")
+            .jsonPath("hearings[0].hearingResults[0].charge.offence.code").isEqualTo("51:3")
+            .jsonPath("hearings[0].hearingResults[0].offence.code").isEqualTo("51:3")
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0]").doesNotExist()
         }
       }
     }
@@ -917,42 +1000,8 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
         .jsonPath("hearings[0].internalLocation.description").isEqualTo("MDI-1-1-001")
         .jsonPath("hearings[0].eventStatus.code").isEqualTo("SCH")
         .jsonPath("hearings[0].eventId").isEqualTo(1)
-    }
-
-    private fun getAdjudicationHearingOutcomeAndPunishmentTest(url: String) {
-      webTestClient.get()
-        .uri(url)
-        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
-        .exchange()
-        .expectStatus().isOk
-        .expectBody()
-        .jsonPath("adjudicationNumber").isEqualTo(adjudicationNumber)
-        .jsonPath("hearings[0].hearingResults[0].pleaFindingType.description").isEqualTo("Not guilty")
-        .jsonPath("hearings[0].hearingResults[0].findingType.description").isEqualTo("Charge Proved")
-        .jsonPath("hearings[0].hearingResults[0].charge.offence.code").isEqualTo("51:1N")
-        .jsonPath("hearings[0].hearingResults[0].offence.code").isEqualTo("51:1N")
-        .jsonPath("hearings[0].hearingResults[1].pleaFindingType.description").isEqualTo("Unfit to Plea or Attend")
-        .jsonPath("hearings[0].hearingResults[1].findingType.description").isEqualTo("Charge Not Proceeded With")
-        .jsonPath("hearings[0].hearingResults[1].charge.offence.code").isEqualTo("51:3")
-        .jsonPath("hearings[0].hearingResults[1].offence.code").isEqualTo("51:3")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionType.description")
-        .isEqualTo("Removal from Activity")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionStatus.description").isEqualTo("Suspended")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].effectiveDate").isEqualTo("2023-01-03")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].statusDate").isEqualTo("2023-01-04")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].comment").isEqualTo("award comment")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].compensationAmount").isEqualTo(12.2)
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionMonths").isEqualTo(1)
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sanctionDays").isEqualTo(2)
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sanctionType.description")
-        .isEqualTo("Stoppage of Earnings (amount)")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[1].consecutiveAward.sanctionType.description")
-        .isEqualTo("Removal from Activity")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[2].effectiveDate").isEqualTo("2023-01-08")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.sanctionType.description")
-        .isEqualTo("Stoppage of Earnings (amount)")
-        .jsonPath("hearings[0].hearingResults[0].resultAwards[2].consecutiveAward.consecutiveAward")
-        .doesNotExist()
+        .jsonPath("hearings[0].createdByUsername").isNotEmpty
+        .jsonPath("hearings[0].createdDateTime").isNotEmpty
     }
 
     private fun getAdjudicationOtherPartiesTest(url: String) {


### PR DESCRIPTION
DPS requires additional data for migration

- User who created the witnesses and victims
- User who created a hearing result
- Date time the result was created
- The NOMIS sanction sequence

In addition only outcomes for the request charge are returned for multi-charge adjudications