### PR TITLE
SDIT-1072 - fix for bad data where hearing award points at a deleted charge

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
@@ -60,7 +60,23 @@ data class AdjudicationCharge(
   val reportDetail: String?,
   val offenceId: String?,
   val chargeSequence: Int,
-)
+) {
+  constructor(offence: AdjudicationOffence) : this(
+    offence = offence,
+    evidence = null,
+    reportDetail = null,
+    offenceId = null,
+    chargeSequence = BAD_DATA_NOT_FOUND,
+  )
+
+  companion object {
+    // Not Found scenario for NOMIS bad data; these would always be filtered out since there would be no matching adjudication/charge combination
+    // but is required to prevent null charges leaking into model
+    // the scenario occurs for a Hearing with awards for a charge that no longer not exist in the adjudication
+    fun badDataNotFound(offence: AdjudicationOffence) = AdjudicationCharge(offence)
+    const val BAD_DATA_NOT_FOUND = -1
+  }
+}
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class AdjudicationOffence(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.adjudications.AdjudicationCharge.Companion.badDataNotFound
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.audit.Audit
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.CodeDescription
@@ -482,7 +483,7 @@ private fun AdjudicationHearingResult.toHearingResult(): HearingResult = Hearing
     "Unknown Plea Finding Code",
   ),
   findingType = this.findingType.toCodeDescription(),
-  charge = this.incidentCharge.toCharge(),
+  charge = this.incidentCharge?.toCharge() ?: badDataNotFound(this.offence.toOffence()),
   offence = this.offence.toOffence(),
   resultAwards = this.resultAwards.map { it.toAward() },
   createdDateTime = this.whenCreated,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResult.kt
@@ -45,6 +45,7 @@ class AdjudicationHearingResult(
   @JoinColumn(name = "OIC_OFFENCE_ID")
   val offence: AdjudicationIncidentOffence,
 
+  @NotFound(action = NotFoundAction.IGNORE)
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumns(
     value = [
@@ -62,7 +63,7 @@ class AdjudicationHearingResult(
       ),
     ],
   )
-  val incidentCharge: AdjudicationIncidentCharge,
+  val incidentCharge: AdjudicationIncidentCharge?,
 
   @Column(name = "CHARGE_SEQ", nullable = false)
   val chargeSequence: Int, // having to set this outside the incidentCharge mapping as that has to be insertable = false


### PR DESCRIPTION
It is possible in NOMIS for a adjudication award to point to a charge that has been deleted.

This causes an issue since hearings are related to all punishments awarded at that hearing including the "bad" ones.

This allows the bad data to not prevent other charges being loaded that are related to that hearing.