### PR TITLE
SDIT-1138 Set consecutive award

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/CreateHearingResultAwardRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/CreateHearingResultAwardRequest.kt
@@ -65,5 +65,14 @@ data class CreateHearingResultAwardRequest(
   @Schema(description = "the duration  of the award, in days")
   val sanctionDays: Int?,
 
-  // TODO val consecutiveChargeNumber:
+  @Schema(description = "adjudication that contains the matching award that this award is consecutive to")
+  val consecutiveCharge: AdjudicationChargeId?,
+)
+
+data class AdjudicationChargeId(
+  @Schema(description = "adjudication number")
+  val adjudicationNumber: Long,
+
+  @Schema(description = "charge sequence within the adjudication")
+  val chargeSequence: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResultAward.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResultAward.kt
@@ -72,8 +72,6 @@ class AdjudicationHearingResultAward(
     name = "OIC_INCIDENT_ID",
     referencedColumnName = "OIC_INCIDENT_ID",
     nullable = false,
-    insertable = false,
-    updatable = false,
   )
   val incidentParty: AdjudicationIncidentParty,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingResultAwardRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingResultAwardRepository.kt
@@ -10,4 +10,10 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearingResu
 interface AdjudicationHearingResultAwardRepository : JpaRepository<AdjudicationHearingResultAward, AdjudicationHearingResultAwardId> {
   @Query(value = "SELECT NVL(MAX(SANCTION_SEQ)+1, 1) FROM OFFENDER_OIC_SANCTIONS oos WHERE OFFENDER_BOOK_ID = :offenderBookId", nativeQuery = true)
   fun getNextSanctionSequence(offenderBookId: Long): Int
+
+  fun findFirstOrNullByIncidentParty_adjudicationNumberAndSanctionCodeAndHearingResult_chargeSequence(
+    adjudicationNumber: Long,
+    sanctionCode: String,
+    chargeSequence: Int,
+  ): AdjudicationHearingResultAward?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultAwardResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultAwardResourceIntTest.kt
@@ -47,7 +47,9 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
     private lateinit var prisoner: Offender
     private lateinit var reportingStaff: Staff
     private lateinit var existingIncident: AdjudicationIncident
+    private lateinit var previousIncident: AdjudicationIncident
     private val existingAdjudicationNumber = 123456L
+    private val previousAdjudicationNumber = 123455L
     private lateinit var existingHearing: AdjudicationHearing
     private lateinit var existingCharge: AdjudicationIncidentCharge
     private lateinit var existingHearingResult: AdjudicationHearingResult
@@ -59,8 +61,43 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
           account(username = "JANESTAFF")
         }
         existingIncident = adjudicationIncident(reportingStaff = reportingStaff) {}
+        previousIncident = adjudicationIncident(reportingStaff = reportingStaff) {}
         prisoner = offender(nomsId = offenderNo) {
           booking {
+            adjudicationParty(incident = previousIncident, adjudicationNumber = previousAdjudicationNumber) {
+              val charge = charge(offenceCode = "51:1A")
+              hearing(
+                internalLocationId = aLocationInMoorland.locationId,
+                hearingDate = LocalDate.parse("2022-01-03"),
+                hearingTime = LocalDateTime.parse("2022-01-03T15:00:00"),
+                hearingStaff = reportingStaff,
+              ) {
+                result(
+                  charge = charge,
+                  pleaFindingCode = "NOT_GUILTY",
+                  findingCode = "PROVED",
+                ) {
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "CC",
+                    sanctionDays = 9,
+                    effectiveDate = LocalDate.parse("2022-01-01"),
+                  )
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "ADA",
+                    sanctionDays = 10,
+                    effectiveDate = LocalDate.parse("2022-01-02"),
+                  )
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "ASSO",
+                    sanctionDays = 11,
+                    effectiveDate = LocalDate.parse("2022-01-03"),
+                  )
+                }
+              }
+            }
             adjudicationParty(incident = existingIncident, adjudicationNumber = existingAdjudicationNumber) {
               existingCharge = charge(offenceCode = "51:1B")
               existingHearing = hearing(
@@ -87,6 +124,8 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
     @AfterEach
     fun tearDown() {
       repository.deleteHearingByAdjudicationNumber(existingAdjudicationNumber)
+      repository.deleteHearingByAdjudicationNumber(previousAdjudicationNumber)
+      repository.delete(previousIncident)
       repository.delete(existingIncident)
       repository.delete(prisoner)
       repository.delete(reportingStaff)
@@ -140,7 +179,8 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
 
       @Test
       fun `will return 404 if adjudication not found`() {
-        webTestClient.post().uri("/adjudications/adjudication-number/88888/charge/${existingCharge.id.chargeSequence}/awards")
+        webTestClient.post()
+          .uri("/adjudications/adjudication-number/88888/charge/${existingCharge.id.chargeSequence}/awards")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(BodyInserters.fromValue(aHearingResultAwardRequest()))
@@ -159,7 +199,8 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isNotFound
           .expectBody()
-          .jsonPath("developerMessage").isEqualTo("Charge not found for adjudication number $existingAdjudicationNumber and charge sequence 88")
+          .jsonPath("developerMessage")
+          .isEqualTo("Charge not found for adjudication number $existingAdjudicationNumber and charge sequence 88")
       }
 
       @Test
@@ -187,6 +228,41 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("developerMessage").isEqualTo("sanction status nope not found")
       }
+
+      @Test
+      fun `will return 400 if appropriate consecutive award not found`() {
+        webTestClient.post()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              // language=JSON
+              """
+              {
+                "awardRequests": [
+                  {
+                    "sanctionType": "EXTRA_WORK",
+                    "sanctionStatus": "SUSPENDED",
+                    "commentText": "a comment",
+                    "sanctionDays": 3,
+                    "effectiveDate": "2023-01-01",
+                    "consecutiveCharge" : {
+                      "adjudicationNumber": $previousAdjudicationNumber,
+                      "chargeSequence": 1
+                    }
+                  }
+                ]
+              }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody()
+          .jsonPath("developerMessage")
+          .isEqualTo("Matching consecutive adjudication award not found. Adjudication number: 123455, charge sequence: 1, sanction code: EXTRA_WORK")
+      }
     }
 
     @Nested
@@ -206,15 +282,15 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
           .expectBody()
-          .jsonPath("awardResponses[0].sanctionSequence").isEqualTo(1)
+          .jsonPath("awardResponses[0].sanctionSequence").isEqualTo(4)
           .jsonPath("awardResponses[0].bookingId").isEqualTo(prisoner.latestBooking().bookingId)
 
-        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/1")
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/4")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
           .exchange()
           .expectStatus().isOk
           .expectBody()
-          .jsonPath("sequence").isEqualTo(1)
+          .jsonPath("sequence").isEqualTo(4)
           .jsonPath("sanctionType.code").isEqualTo("ASSO")
           .jsonPath("sanctionStatus.code").isEqualTo("IMMEDIATE")
           .jsonPath("effectiveDate").isEqualTo("2023-01-01")
@@ -229,7 +305,87 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
             assertThat(it).containsEntry("hearingId", existingHearing.id.toString())
             assertThat(it).containsEntry("adjudicationNumber", existingAdjudicationNumber.toString())
             assertThat(it).containsEntry("resultSequence", "1")
-            assertThat(it).containsEntry("sanctionSequence", "1")
+            assertThat(it).containsEntry("sanctionSequence", "4")
+          },
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `create a consecutive adjudication hearing result award`() {
+        // given there is an existing ADA
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/2")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("sequence").isEqualTo(2)
+          .jsonPath("sanctionType.code").isEqualTo("ADA")
+          .jsonPath("sanctionStatus.code").isEqualTo("IMMEDIATE")
+          .jsonPath("effectiveDate").isEqualTo("2022-01-02")
+          .jsonPath("sanctionDays").isEqualTo(10)
+          .jsonPath("chargeSequence").isEqualTo(1)
+          .jsonPath("adjudicationNumber").isEqualTo(previousAdjudicationNumber)
+
+        webTestClient.post()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              // language=JSON
+              """
+              {
+                "awardRequests": [
+                  {
+                    "sanctionType": "ADA",
+                    "sanctionStatus": "SUSPENDED",
+                    "commentText": "a comment",
+                    "sanctionDays": 3,
+                    "effectiveDate": "2023-01-01",
+                    "consecutiveCharge" : {
+                      "adjudicationNumber": $previousAdjudicationNumber,
+                      "chargeSequence": 1
+                    }
+                  }
+                ]
+              }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("awardResponses[0].sanctionSequence").isEqualTo(4)
+          .jsonPath("awardResponses[0].bookingId").isEqualTo(prisoner.latestBooking().bookingId)
+
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/4")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("sequence").isEqualTo(4)
+          .jsonPath("sanctionType.code").isEqualTo("ADA")
+          .jsonPath("sanctionStatus.code").isEqualTo("SUSPENDED")
+          .jsonPath("effectiveDate").isEqualTo("2023-01-01")
+          .jsonPath("sanctionDays").isEqualTo(3)
+          .jsonPath("comment").isEqualTo("a comment")
+          .jsonPath("consecutiveAward.sequence").isEqualTo(2)
+          .jsonPath("consecutiveAward.sanctionType.code").isEqualTo("ADA")
+          .jsonPath("consecutiveAward.sanctionStatus.code").isEqualTo("IMMEDIATE")
+          .jsonPath("consecutiveAward.effectiveDate").isEqualTo("2022-01-02")
+          .jsonPath("consecutiveAward.sanctionDays").isEqualTo(10)
+          .jsonPath("consecutiveAward.chargeSequence").isEqualTo(1)
+          .jsonPath("consecutiveAward.adjudicationNumber").isEqualTo(previousAdjudicationNumber)
+
+        verify(telemetryClient).trackEvent(
+          eq("hearing-result-award-created"),
+          org.mockito.kotlin.check {
+            assertThat(it).containsEntry("bookingId", prisoner.latestBooking().bookingId.toString())
+            assertThat(it).containsEntry("hearingId", existingHearing.id.toString())
+            assertThat(it).containsEntry("adjudicationNumber", existingAdjudicationNumber.toString())
+            assertThat(it).containsEntry("resultSequence", "1")
+            assertThat(it).containsEntry("sanctionSequence", "4")
           },
           isNull(),
         )


### PR DESCRIPTION
Given an adjudication this will find the first award that is the same type of award that is being added. In practice this will always be an ADA (unless DPS rules change)