### PR TITLE
SDIT-1165 KEY_DATE now KEY-DATE so matches with mapping service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderKeyDateAdjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderKeyDateAdjustment.kt
@@ -21,7 +21,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 const val adjustmentIdsInner = "select adjustment_id, adjustment_category, create_datetime  from (" +
-  "    select offender_key_date_adjust_id adjustment_id, 'KEY_DATE' adjustment_category, create_datetime from offender_key_date_adjusts " +
+  "    select offender_key_date_adjust_id adjustment_id, 'KEY-DATE' adjustment_category, create_datetime from offender_key_date_adjusts " +
   "    union " +
   "    select  offender_sentence_adjust_id adjustment_id, 'SENTENCE' adjustment_category , create_datetime from offender_sentence_adjusts " +
   "    where offender_key_date_adjust_id is null" +

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjustmentRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjustmentRepositoryTest.kt
@@ -60,7 +60,7 @@ class AdjustmentRepositoryTest {
   fun findAdjustmentsNoDateFilter() {
     val persistedVisitList = repository.adjustmentIdsQuery_named(pageable = Pageable.ofSize(10))
 
-    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactlyInAnyOrder("KEY_DATE", "SENTENCE")
+    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactlyInAnyOrder("KEY-DATE", "SENTENCE")
   }
 
   @Test
@@ -76,7 +76,7 @@ class AdjustmentRepositoryTest {
     val persistedVisitList =
       repository.adjustmentIdsQuery_named(toDate = dateTimeJan5.toLocalDate(), pageable = Pageable.ofSize(10))
 
-    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactly("KEY_DATE")
+    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactly("KEY-DATE")
   }
 
   @Test
@@ -87,7 +87,7 @@ class AdjustmentRepositoryTest {
       pageable = Pageable.ofSize(10),
     )
 
-    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactly("KEY_DATE", "SENTENCE")
+    assertThat(persistedVisitList).extracting("adjustmentCategory").containsExactly("KEY-DATE", "SENTENCE")
   }
 
   @Test
@@ -104,7 +104,7 @@ class AdjustmentRepositoryTest {
     )
 
     assertThat(page1.totalPages).isEqualTo(2)
-    assertThat(page1.content).extracting("adjustmentCategory").containsExactly("KEY_DATE")
+    assertThat(page1.content).extracting("adjustmentCategory").containsExactly("KEY-DATE")
     assertThat(page2.content).extracting("adjustmentCategory").containsExactly("SENTENCE")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
@@ -1818,8 +1818,8 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
         .expectBody()
         .jsonPath("$.numberOfElements").isEqualTo(4)
         .jsonPath("$.content[0].adjustmentCategory").isEqualTo("SENTENCE")
-        .jsonPath("$.content[1].adjustmentCategory").isEqualTo("KEY_DATE")
-        .jsonPath("$.content[2].adjustmentCategory").isEqualTo("KEY_DATE")
+        .jsonPath("$.content[1].adjustmentCategory").isEqualTo("KEY-DATE")
+        .jsonPath("$.content[2].adjustmentCategory").isEqualTo("KEY-DATE")
         .jsonPath("$.content[3].adjustmentCategory").isEqualTo("SENTENCE")
     }
 


### PR DESCRIPTION
This value gets passed all the way through the migration service to the mapping service; but that is expecting KEY-DATE