### PR TITLE
SDIT-1161 Update awards with just the creates working for now

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResource.kt
@@ -981,8 +981,78 @@ class AdjudicationResource(
     @PathVariable
     chargeSequence: Int,
     @RequestBody @Valid
-    requests: CreateHearingResultAwardRequests,
+    requests: CreateHearingResultAwardRequest,
   ) = adjudicationService.createHearingResultAwards(adjudicationNumber, chargeSequence, requests)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_ADJUDICATIONS')")
+  @PutMapping("/adjudications/adjudication-number/{adjudicationNumber}/charge/{chargeSequence}/awards")
+  @Operation(
+    summary = "updates a batch of hearing result awards for a given adjudication",
+    description = "Creates a hearing result awards that have been added, updates those that have changed and deletes ones that are absent for the booking associated with the adjudication. Requires ROLE_NOMIS_ADJUDICATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Hearing result award IDs created and awards deleted",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = UpdateHearingResultAwardResponses::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_ADJUDICATIONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Adjudication does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Charge does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun updateCreateAndDeleteHearingResultAwards(
+    @Schema(description = "Adjudication number", example = "12345")
+    @PathVariable
+    adjudicationNumber: Long,
+    @Schema(description = "Nomis charge sequence", example = "1")
+    @PathVariable
+    chargeSequence: Int,
+    @RequestBody @Valid
+    requests: UpdateHearingResultAwardRequest,
+  ): UpdateHearingResultAwardResponses =
+    adjudicationService.updateCreateAndDeleteHearingResultAwards(adjudicationNumber, chargeSequence, requests)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_ADJUDICATIONS')")
   @GetMapping("/prisoners/booking-id/{bookingId}/awards/{sanctionSequence}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/HearingResultAwardRequests.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/HearingResultAwardRequests.kt
@@ -7,15 +7,32 @@ import java.time.LocalDate
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "A list of Hearing result awards (aka punishment) to be created")
-data class CreateHearingResultAwardRequests(
+data class CreateHearingResultAwardRequest(
 
   @Schema(description = "a list of award requests")
-  val awardRequests: List<CreateHearingResultAwardRequest>,
+  val awardRequests: List<HearingResultAwardRequest>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "A list of Hearing result awards (aka punishment) to be created and updated")
+data class UpdateHearingResultAwardRequest(
+  @Schema(description = "a list of award requests to create")
+  val awardRequestsToCreate: List<HearingResultAwardRequest>,
+  @Schema(description = "a list of award requests to update")
+  val awardRequestsToUpdate: List<ExistingHearingResultAwardRequest>,
+)
+
+@Schema(description = "Hearing result award (aka punishment) to be created")
+data class ExistingHearingResultAwardRequest(
+  @Schema(description = "award to update")
+  val awardRequests: HearingResultAwardRequest,
+  @Schema(description = "sanction sequence for the booking associated with the adjudication")
+  val sanctionSequence: Int,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Hearing result award (aka punishment) to be created")
-data class CreateHearingResultAwardRequest(
+data class HearingResultAwardRequest(
   @Schema(
     description = "The type of award",
     example = "CAUTION",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/UpdateHearingResultAwardResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/UpdateHearingResultAwardResponse.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.adjudications
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "A list of Hearing result awards created (aka punishment)")
+data class UpdateHearingResultAwardResponses(
+  @Schema(description = "an ordered list of award response, the order matching the request order for awardRequestsToCreate")
+  val awardResponsesCreated: List<HearingResultAwardResponse>,
+  @Schema(description = "a list of awards that were deleted due to this update")
+  val awardsDeleted: List<HearingResultAwardResponse>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Provides the generated Hearing Result Award composite ID after creation")
+data class HearingResultAwardResponse(
+  val bookingId: Long,
+  val sanctionSequence: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/audit/Audit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/audit/Audit.kt
@@ -1,4 +1,4 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.audit
 
-@Target(allowedTargets = [AnnotationTarget.FUNCTION])
+@Target(allowedTargets = arrayOf(AnnotationTarget.FUNCTION))
 annotation class Audit()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultAwardResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultAwardResourceIntTest.kt
@@ -410,4 +410,378 @@ class AdjudicationsHearingResultAwardResourceIntTest : IntegrationTestBase() {
       }
       """.trimIndent()
   }
+
+  @DisplayName("PUT /adjudications/adjudication-number/{adjudicationNumber}/awards")
+  @Nested
+  inner class UpdateHearingResultAward {
+    private val offenderNo = "A1965NM"
+    private lateinit var prisoner: Offender
+    private lateinit var reportingStaff: Staff
+    private lateinit var existingIncident: AdjudicationIncident
+    private lateinit var previousIncident: AdjudicationIncident
+    private val existingAdjudicationNumber = 123456L
+    private val previousAdjudicationNumber = 123455L
+    private lateinit var existingHearing: AdjudicationHearing
+    private lateinit var existingCharge: AdjudicationIncidentCharge
+    private lateinit var existingHearingResult: AdjudicationHearingResult
+
+    @BeforeEach
+    fun createPrisonerWithAdjudicationAndHearing() {
+      nomisDataBuilder.build {
+        reportingStaff = staff(firstName = "JANE", lastName = "STAFF") {
+          account(username = "JANESTAFF")
+        }
+        existingIncident = adjudicationIncident(reportingStaff = reportingStaff) {}
+        previousIncident = adjudicationIncident(reportingStaff = reportingStaff) {}
+        prisoner = offender(nomsId = offenderNo) {
+          booking {
+            adjudicationParty(incident = previousIncident, adjudicationNumber = previousAdjudicationNumber) {
+              val charge = charge(offenceCode = "51:1A")
+              hearing(
+                internalLocationId = aLocationInMoorland.locationId,
+                hearingDate = LocalDate.parse("2022-01-03"),
+                hearingTime = LocalDateTime.parse("2022-01-03T15:00:00"),
+                hearingStaff = reportingStaff,
+              ) {
+                result(
+                  charge = charge,
+                  pleaFindingCode = "NOT_GUILTY",
+                  findingCode = "PROVED",
+                ) {
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "CC",
+                    sanctionDays = 9,
+                    effectiveDate = LocalDate.parse("2022-01-01"),
+                  )
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "ADA",
+                    sanctionDays = 10,
+                    effectiveDate = LocalDate.parse("2022-01-02"),
+                  )
+                  award(
+                    statusCode = "IMMEDIATE",
+                    sanctionCode = "ASSO",
+                    sanctionDays = 11,
+                    effectiveDate = LocalDate.parse("2022-01-03"),
+                  )
+                }
+              }
+            }
+            adjudicationParty(incident = existingIncident, adjudicationNumber = existingAdjudicationNumber) {
+              existingCharge = charge(offenceCode = "51:1B")
+              existingHearing = hearing(
+                internalLocationId = aLocationInMoorland.locationId,
+                scheduleDate = LocalDate.parse("2023-01-02"),
+                scheduleTime = LocalDateTime.parse("2023-01-02T14:00:00"),
+                hearingDate = LocalDate.parse("2023-01-03"),
+                hearingTime = LocalDateTime.parse("2023-01-03T15:00:00"),
+                hearingTypeCode = AdjudicationHearingType.GOVERNORS_HEARING,
+                // no staff added to hearing as hearing result POST will add it
+              ) {
+                existingHearingResult = result(
+                  charge = existingCharge,
+                  pleaFindingCode = "NOT_GUILTY",
+                  findingCode = "PROVED",
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteHearingByAdjudicationNumber(existingAdjudicationNumber)
+      repository.deleteHearingByAdjudicationNumber(previousAdjudicationNumber)
+      repository.delete(previousIncident)
+      repository.delete(existingIncident)
+      repository.delete(prisoner)
+      repository.delete(reportingStaff)
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest()))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      private lateinit var prisonerWithNoBookings: Offender
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          prisonerWithNoBookings = offender(nomsId = "A9876AK")
+        }
+      }
+
+      @Test
+      fun `will return 404 if adjudication not found`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/88888/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest()))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody()
+          .jsonPath("developerMessage").isEqualTo("Adjudication party with adjudication number 88888 not found")
+      }
+
+      @Test
+      fun `will return 404 if charge not found`() {
+        webTestClient.put().uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/88/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest()))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody()
+          .jsonPath("developerMessage")
+          .isEqualTo("Charge not found for adjudication number $existingAdjudicationNumber and charge sequence 88")
+      }
+
+      @Test
+      fun `will return 400 if sanction type not valid`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest(sanctionType = "madeup")))
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody()
+          .jsonPath("developerMessage").isEqualTo("sanction type madeup not found")
+      }
+
+      @Test
+      fun `will return 400 if sanction status not valid`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(aUpdateHearingResultAwardRequest(sanctionStatus = "nope")))
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody()
+          .jsonPath("developerMessage").isEqualTo("sanction status nope not found")
+      }
+
+      @Test
+      fun `will return 400 if appropriate consecutive award not found`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              // language=JSON
+              """
+              {
+                "awardRequestsToCreate": [
+                  {
+                    "sanctionType": "EXTRA_WORK",
+                    "sanctionStatus": "SUSPENDED",
+                    "commentText": "a comment",
+                    "sanctionDays": 3,
+                    "effectiveDate": "2023-01-01",
+                    "consecutiveCharge" : {
+                      "adjudicationNumber": $previousAdjudicationNumber,
+                      "chargeSequence": 1
+                    }
+                  }
+                ],
+                "awardRequestsToUpdate": []
+              }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody()
+          .jsonPath("developerMessage")
+          .isEqualTo("Matching consecutive adjudication award not found. Adjudication number: 123455, charge sequence: 1, sanction code: EXTRA_WORK")
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `create any adjudication hearing result awards that need adding`() {
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              aUpdateHearingResultAwardRequest(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("awardResponsesCreated[0].sanctionSequence").isEqualTo(4)
+          .jsonPath("awardResponsesCreated[0].bookingId").isEqualTo(prisoner.latestBooking().bookingId)
+
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/4")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("sequence").isEqualTo(4)
+          .jsonPath("sanctionType.code").isEqualTo("ASSO")
+          .jsonPath("sanctionStatus.code").isEqualTo("IMMEDIATE")
+          .jsonPath("effectiveDate").isEqualTo("2023-01-01")
+          .jsonPath("sanctionDays").isEqualTo(2)
+          .jsonPath("compensationAmount").isEqualTo(10.5)
+          .jsonPath("comment").isEqualTo("a comment")
+
+        verify(telemetryClient).trackEvent(
+          eq("hearing-result-award-created"),
+          org.mockito.kotlin.check {
+            assertThat(it).containsEntry("bookingId", prisoner.latestBooking().bookingId.toString())
+            assertThat(it).containsEntry("hearingId", existingHearing.id.toString())
+            assertThat(it).containsEntry("adjudicationNumber", existingAdjudicationNumber.toString())
+            assertThat(it).containsEntry("resultSequence", "1")
+            assertThat(it).containsEntry("sanctionSequence", "4")
+          },
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `create a consecutive adjudication hearing result award`() {
+        // given there is an existing ADA
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/2")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("sequence").isEqualTo(2)
+          .jsonPath("sanctionType.code").isEqualTo("ADA")
+          .jsonPath("sanctionStatus.code").isEqualTo("IMMEDIATE")
+          .jsonPath("effectiveDate").isEqualTo("2022-01-02")
+          .jsonPath("sanctionDays").isEqualTo(10)
+          .jsonPath("chargeSequence").isEqualTo(1)
+          .jsonPath("adjudicationNumber").isEqualTo(previousAdjudicationNumber)
+
+        webTestClient.put()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingCharge.id.chargeSequence}/awards")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              // language=JSON
+              """
+              {
+                "awardRequestsToCreate": [
+                  {
+                    "sanctionType": "ADA",
+                    "sanctionStatus": "SUSPENDED",
+                    "commentText": "a comment",
+                    "sanctionDays": 3,
+                    "effectiveDate": "2023-01-01",
+                    "consecutiveCharge" : {
+                      "adjudicationNumber": $previousAdjudicationNumber,
+                      "chargeSequence": 1
+                    }
+                  }
+                ], 
+                "awardRequestsToUpdate": []
+              }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("awardResponsesCreated[0].sanctionSequence").isEqualTo(4)
+          .jsonPath("awardResponsesCreated[0].bookingId").isEqualTo(prisoner.latestBooking().bookingId)
+
+        webTestClient.get().uri("/prisoners/booking-id/${prisoner.bookings.first().bookingId}/awards/4")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("sequence").isEqualTo(4)
+          .jsonPath("sanctionType.code").isEqualTo("ADA")
+          .jsonPath("sanctionStatus.code").isEqualTo("SUSPENDED")
+          .jsonPath("effectiveDate").isEqualTo("2023-01-01")
+          .jsonPath("sanctionDays").isEqualTo(3)
+          .jsonPath("comment").isEqualTo("a comment")
+          .jsonPath("consecutiveAward.sequence").isEqualTo(2)
+          .jsonPath("consecutiveAward.sanctionType.code").isEqualTo("ADA")
+          .jsonPath("consecutiveAward.sanctionStatus.code").isEqualTo("IMMEDIATE")
+          .jsonPath("consecutiveAward.effectiveDate").isEqualTo("2022-01-02")
+          .jsonPath("consecutiveAward.sanctionDays").isEqualTo(10)
+          .jsonPath("consecutiveAward.chargeSequence").isEqualTo(1)
+          .jsonPath("consecutiveAward.adjudicationNumber").isEqualTo(previousAdjudicationNumber)
+
+        verify(telemetryClient).trackEvent(
+          eq("hearing-result-award-created"),
+          org.mockito.kotlin.check {
+            assertThat(it).containsEntry("bookingId", prisoner.latestBooking().bookingId.toString())
+            assertThat(it).containsEntry("hearingId", existingHearing.id.toString())
+            assertThat(it).containsEntry("adjudicationNumber", existingAdjudicationNumber.toString())
+            assertThat(it).containsEntry("resultSequence", "1")
+            assertThat(it).containsEntry("sanctionSequence", "4")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    private fun aUpdateHearingResultAwardRequest(
+      sanctionType: String = "ASSO",
+      sanctionStatus: String = "IMMEDIATE",
+      effectiveDate: String = "2023-01-01",
+    ): String =
+      """
+      {
+        "awardRequestsToCreate": [{
+         "sanctionType": "$sanctionType",
+         "sanctionStatus": "$sanctionStatus",
+         "commentText": "a comment",
+         "sanctionDays": 2,
+         "effectiveDate": "$effectiveDate",
+         "compensationAmount": 10.5
+        }],
+        "awardRequestsToUpdate": []
+      }
+      """.trimIndent()
+  }
 }


### PR DESCRIPTION
Added endpoint that updates awards as a batch, this might create new ones, update existing ones and delete ones removed by DPS

TODO:

- Refactor create to avoid duplicate code
- Implement update of awards
- Implement delete of awards

This is pushed so the sync service can regenerate DTOs due to rename of DTO