### PR TITLE
SDIT-1240 Generated offence ids when creating hearings and evidence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncidentCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationIncidentCharge.kt
@@ -72,7 +72,7 @@ class AdjudicationIncidentCharge(
 
   // adjudication number / charge index at incident level eg 4577667/1
   @Column(name = "OIC_CHARGE_ID")
-  val offenceId: String? = null,
+  var offenceId: String? = null,
 
   @Column(name = "CREATE_DATETIME", nullable = false)
   var whenCreated: LocalDateTime = LocalDateTime.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationCharge.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationCharge.kt
@@ -42,6 +42,7 @@ class AdjudicationChargeBuilder(
     reportDetail: String?,
     incidentParty: AdjudicationIncidentParty,
     chargeSequence: Int,
+    generateOfficeId: Boolean,
     whenCreated: LocalDateTime,
   ): AdjudicationIncidentCharge = AdjudicationIncidentCharge(
     id = AdjudicationIncidentChargeId(incidentParty.id.agencyIncidentId, chargeSequence),
@@ -51,7 +52,11 @@ class AdjudicationChargeBuilder(
     offence = repository.lookupAdjudicationOffence(offenceCode),
     guiltyEvidence = guiltyEvidence,
     reportDetails = reportDetail,
-    offenceId = "${incidentParty.adjudicationNumber}/$chargeSequence",
+    offenceId = if (generateOfficeId) {
+      "${incidentParty.adjudicationNumber}/$chargeSequence"
+    } else {
+      null
+    },
     whenCreated = whenCreated,
   )
     .also { adjudicationCharge = it }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationParty.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AdjudicationParty.kt
@@ -41,6 +41,7 @@ interface AdjudicationPartyDsl {
     reportDetail: String? = null,
     dsl: AdjudicationChargeDsl.() -> Unit = {},
     whenCreated: LocalDateTime = LocalDateTime.now(),
+    generateOfficeId: Boolean = true,
   ): AdjudicationIncidentCharge
 
   @AdjudicationHearingDslMarker
@@ -140,6 +141,7 @@ class AdjudicationPartyBuilder(
     reportDetail: String?,
     dsl: AdjudicationChargeDsl.() -> Unit,
     whenCreated: LocalDateTime,
+    generateOfficeId: Boolean,
   ) =
     adjudicationChargeBuilderFactory.builder().let { builder ->
       builder.build(
@@ -149,6 +151,7 @@ class AdjudicationPartyBuilder(
         incidentParty = adjudicationParty,
         chargeSequence = adjudicationParty.incident.parties.sumOf { it.charges.size } + 1,
         whenCreated = whenCreated,
+        generateOfficeId = generateOfficeId,
       )
         .also { adjudicationParty.charges += it }
         .also { builder.apply(dsl) }


### PR DESCRIPTION
This makes this consistent with NOMIS behaviour an fixes and issue where migrated adjudications that have no hearings may also not have an offenceId generated yet - which would affect NART reporting.