### PR TITLE
SDIT-1383 Add createdDateTime to adjudications and update tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationResponse.kt
@@ -275,6 +275,8 @@ data class HearingResultAward(
   val adjudicationNumber: Long,
   @Schema(description = "Username of person who created the record in NOMIS", required = true)
   val createdByUsername: String,
+  @Schema(description = "Date time when the record was created the record in NOMIS", required = true)
+  val createdDateTime: LocalDateTime,
 )
 
 fun Offender.toPrisoner(createUsername: String, dateAddedToIncident: LocalDate, comment: String? = null) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -1332,6 +1332,7 @@ fun AdjudicationHearingResultAward.toAward(isConsecutiveAward: Boolean = false):
     sanctionDays = this.sanctionDays,
     sanctionMonths = this.sanctionMonths,
     createdByUsername = this.createUsername,
+    createdDateTime = this.whenCreated,
     compensationAmount = this.compensationAmount,
     consecutiveAward = if (!isConsecutiveAward) {
       this.consecutiveHearingResultAward?.toAward(true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResultAward.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AdjudicationHearingResultAward.kt
@@ -19,6 +19,7 @@ import org.hibernate.annotations.NotFoundAction
 import java.io.Serializable
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Embeddable
 class AdjudicationHearingResultAwardId(
@@ -145,6 +146,10 @@ class AdjudicationHearingResultAward(
   @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
   @Generated
   lateinit var createUsername: String
+
+  @Column(name = "CREATE_DATETIME", insertable = false, updatable = false)
+  @Generated
+  lateinit var whenCreated: LocalDateTime
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsResourceIntTest.kt
@@ -762,6 +762,7 @@ class AdjudicationsResourceIntTest : IntegrationTestBase() {
             .jsonPath("hearings[0].hearingResults[0].resultAwards[0].sequence").isEqualTo(2)
             .jsonPath("hearings[0].hearingResults[0].resultAwards[0].chargeSequence").isEqualTo(1)
             .jsonPath("hearings[0].hearingResults[0].resultAwards[0].createdByUsername").isNotEmpty
+            .jsonPath("hearings[0].hearingResults[0].resultAwards[0].createdDateTime").isNotEmpty
             .jsonPath("hearings[0].hearingResults[0].resultAwards[1].sanctionType.description")
             .isEqualTo("Stoppage of Earnings (amount)")
             .jsonPath("hearings[0].hearingResults[0].resultAwards[1].consecutiveAward.sanctionType.description")


### PR DESCRIPTION
Extended adjudications to include a new field, 'createdDateTime', storing when the record was created. The AdjudicationService now returns this additional information in its response. Related unit tests have been updated accordingly to verify the state of this new field.