### PR TITLE
SDIT-1405 Add getNextCaseSequence query in CourtCaseRepository

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtCaseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtCaseRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtCase
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
@@ -14,4 +15,7 @@ interface CourtCaseRepository : JpaRepository<CourtCase, Long> {
   fun findByOffenderBookingOrderByCreateDatetimeDesc(
     offenderBooking: OffenderBooking,
   ): List<CourtCase>
+
+  @Query("select coalesce(max(caseSequence), 0) + 1 from CourtCase where offenderBooking = :offenderBooking")
+  fun getNextCaseSequence(offenderBooking: OffenderBooking): Int
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
@@ -88,6 +88,7 @@ class SentencingService(
           beginDate = request.startDate,
           caseStatus = lookupCaseStatus(request.status),
           court = lookupEstablishment(request.courtId),
+          caseSequence = courtCaseRepository.getNextCaseSequence(booking),
         ),
       )
       courtCase.courtEvents.addAll(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
@@ -902,6 +902,49 @@ class SentencingResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
+      fun `can create multiple cases for the same prisoner`() {
+        val firstCourtCaseId = webTestClient.post().uri("/prisoners/$offenderNo/sentencing/court-cases")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createCourtCaseRequestHierarchy(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated.expectBody(CreateCourtCaseResponse::class.java)
+          .returnResult().responseBody!!.id
+
+        webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-cases/$firstCourtCaseId")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("offenderNo").isEqualTo(offenderNo)
+          .jsonPath("caseSequence").isEqualTo(1)
+
+        val secondCourtCaseId = webTestClient.post().uri("/prisoners/$offenderNo/sentencing/court-cases")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createCourtCaseRequestHierarchy(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated.expectBody(CreateCourtCaseResponse::class.java)
+          .returnResult().responseBody!!.id
+
+        webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-cases/$secondCourtCaseId")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("offenderNo").isEqualTo(offenderNo)
+          .jsonPath("caseSequence").isEqualTo(2)
+      }
+
+      @Test
       fun `can create a court case with court appearance`() {
         val courtCaseResponse = webTestClient.post().uri("/prisoners/$offenderNo/sentencing/court-cases")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))


### PR DESCRIPTION
Introduced a new query, getNextCaseSequence, in CourtCaseRepository for generating the next sequence number for a court case associated with an offender booking. This change enables handling multiple cases for the same prisoner. Added a corresponding test to check the functionality.