### PR TITLE
SDIT-1429 Add 'hasMultipleCharges' field to AdjudicationService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationChargeResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationChargeResponse.kt
@@ -47,4 +47,7 @@ data class AdjudicationChargeResponse(
 
   @Schema(description = "hearings associated with this adjudication")
   val hearings: List<Hearing>,
+
+  @Schema(description = "indicates if this charge was part of a larger multi-charge adjudication in NOMIS")
+  val hasMultipleCharges: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -130,6 +130,7 @@ class AdjudicationService(
           investigations = adjudication.investigations,
           // only use results for this charge
           hearings = adjudication.hearings.map { hearing -> hearing.copy(hearingResults = hearing.hearingResults.filter { results -> results.charge.chargeSequence == chargeSequence }) },
+          hasMultipleCharges = adjudication.charges.size > 1,
         )
       }
         ?: throw NotFoundException("Adjudication charge not found. Adjudication number: $adjudicationNumber, charge sequence: $chargeSequence")


### PR DESCRIPTION
The AdjudicationService now shows whether a single adjudication has multiple charges through a new field 'hasMultipleCharges'. This field returns true if the adjudication's charges size is greater than one. Additionally, changes were made to the AdjudicationsResourceIntTest to test this new feature.