### PR TITLE
SDIT-1453 Remove prisonIds from adjudication summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationADAAwardSummaryResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationADAAwardSummaryResponse.kt
@@ -19,11 +19,6 @@ data class AdjudicationADAAwardSummaryResponse(
   )
   val offenderNo: String,
   @Schema(
-    description = "List of prisons this person attended during this booking",
-    required = true,
-  )
-  val prisonIds: List<String>,
-  @Schema(
     description = "List of ADAs awarded during this booking period",
     required = true,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -1193,7 +1193,6 @@ class AdjudicationService(
     val booking = offenderBookingRepository.findByIdOrNull(bookingId)
       ?: throw NotFoundException("Prisoner with bookingId $bookingId not found")
 
-    val prisonIds = offenderExternalMovementRepository.findPrisonsAdmittedIntoByBooking(booking)
     val awards =
       adjudicationHearingResultAwardRepository.findByIdOffenderBookIdAndSanctionCodeOrderByIdSanctionSequenceAsc(
         offenderBookId = bookingId,
@@ -1202,7 +1201,6 @@ class AdjudicationService(
     return AdjudicationADAAwardSummaryResponse(
       bookingId,
       offenderNo = booking.offender.nomsId,
-      prisonIds = prisonIds,
       adaSummaries = awards.map {
         ADASummary(
           adjudicationNumber = it.incidentParty.adjudicationNumber!!,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsADAAWardSummaryResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsADAAWardSummaryResourceIntTest.kt
@@ -94,9 +94,6 @@ class AdjudicationsADAAWardSummaryResourceIntTest : IntegrationTestBase() {
             }
           }
           bookingId = booking(agencyLocationId = "BXI", bookingBeginDate = LocalDateTime.parse("2022-01-01T10:00")) {
-            prisonTransfer(from = "BXI", to = "MDI", date = LocalDateTime.parse("2022-01-02T10:00"))
-            prisonTransfer(from = "MDI", to = "BXI", date = LocalDateTime.parse("2022-01-03T10:00"))
-            prisonTransfer(from = "BXI", to = "BMI", date = LocalDateTime.parse("2022-01-03T10:00"))
             adjudicationParty(incident = previousIncident, adjudicationNumber = previousAdjudicationNumber) {
               val charge = charge(offenceCode = "51:1A")
               hearing(
@@ -261,20 +258,6 @@ class AdjudicationsADAAWardSummaryResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `will list all prisons for this booking`() {
-        webTestClient.get()
-          .uri("/prisoners/booking-id/{bookingId}/awards/ada/summary", bookingId)
-          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
-          .exchange()
-          .expectStatus().isOk
-          .expectBody()
-          .jsonPath("prisonIds.size()").isEqualTo("3")
-          .jsonPath("prisonIds[0]").isEqualTo("BMI")
-          .jsonPath("prisonIds[1]").isEqualTo("BXI")
-          .jsonPath("prisonIds[2]").isEqualTo("MDI")
-      }
-
-      @Test
       fun `there will be a summary for each ADA award across all adjudications for this booking`() {
         webTestClient.get()
           .uri("/prisoners/booking-id/{bookingId}/awards/ada/summary", bookingId)
@@ -369,18 +352,6 @@ class AdjudicationsADAAWardSummaryResourceIntTest : IntegrationTestBase() {
           .expectStatus().isOk
           .expectBody()
           .jsonPath("offenderNo").isEqualTo(noAdjudicationsPrisoner.nomsId)
-      }
-
-      @Test
-      fun `will list all prisons for this booking`() {
-        webTestClient.get()
-          .uri("/prisoners/booking-id/{bookingId}/awards/ada/summary", noAdjudicationsBookingId)
-          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ADJUDICATIONS")))
-          .exchange()
-          .expectStatus().isOk
-          .expectBody()
-          .jsonPath("prisonIds.size()").isEqualTo("1")
-          .jsonPath("prisonIds[0]").isEqualTo("BXI")
       }
 
       @Test


### PR DESCRIPTION
Removed the usage of 'prisonIds' in the AdjudicationService, and its related test cases. This simplifies the adjudication summary response, as we no longer track and include the list of prisons attended during the booking in the response data.