### PR TITLE
SDIT-1534 Update sentence adjustment related sentence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceAdjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceAdjustment.kt
@@ -53,7 +53,7 @@ class OffenderSentenceAdjustment(
   val offenderBooking: OffenderBooking,
 
   @Column(name = "SENTENCE_SEQ", nullable = false)
-  val sentenceSequence: Long,
+  var sentenceSequence: Long,
 
   @Column(name = "OFFENDER_KEY_DATE_ADJUST_ID", nullable = true)
   val offenderKeyDateAdjustmentId: Long? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentResource.kt
@@ -639,6 +639,9 @@ data class UpdateSentenceAdjustmentRequest(
   val comment: String?,
   @Schema(description = "Flag to indicate if the adjustment is being applied", required = false, defaultValue = "true")
   val active: Boolean = true,
+  @Schema(description = "Sentence sequence", required = true)
+  @field:Min(0)
+  val sentenceSequence: Long = -1,
 )
 
 @Schema(description = "Key date adjustment create request")


### PR DESCRIPTION
DPS can change the sentence that an adjustment is associated with. This propagates this change to NOMIS (though this is not something you can do via the NOMIS UI)