### PR TITLE
SDIT-1582 Handle updates to expired allocations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationService.kt
@@ -206,7 +206,14 @@ class AllocationService(
     val expiredPayBand = payBands.filter { it.endDate != null }.filter { it.endDate!! < today }.maxByOrNull { it.id.startDate }
     val activePayBand = payBands.firstOrNull { it.id.startDate <= today && (it.endDate == null || it.endDate!! >= today) }
     val futurePayBand = payBands.firstOrNull { it.id.startDate > today }
+    val allocationExpired = request.endDate?.let { it < today } ?: false
     when {
+      // if the requested pay band is already expired then just make sure the end dates match
+      allocationExpired && activePayBand == null && futurePayBand == null -> {
+        expiredPayBand?.let {
+          it.endDate == request.endDate
+        }
+      }
       // if no active pay band then add a new pay band from today (or the date requested if in the future)
       activePayBand == null && futurePayBand == null -> {
         requestedPayBand?.also {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationResourceIntTest.kt
@@ -926,6 +926,16 @@ class AllocationResourceIntTest : IntegrationTestBase() {
             PayBandTestParameter("5", yesterday, yesterday),
             null,
           ),
+          Arguments.of(
+            "An expired pay band will be ignored if the allocation is expired",
+            listOf(
+              PayBandTestParameter("5", yesterday.minusDays(1), yesterday),
+              PayBandTestParameter("6", today, yesterday),
+            ),
+            PayBandTestParameter("6", today, yesterday),
+            PayBandTestParameter("5", yesterday.minusDays(1), yesterday),
+            PayBandTestParameter("6", today, yesterday),
+          ),
         )
       }
     }


### PR DESCRIPTION
Scenario is:
* prisoner allocated to a course in DPS
* later (at least next day), the pay band was changed in DPS
* the same day as the pay band change the prisoner was released
* the next day the deallocation reason was updated in DPS

This caused us to write a duplicate of the expired pay band, so the insert failed with a data integrity issue and the event was rejected.

We now just leave the pay bands alone if the allocation is expired.