### PR TITLE
SDIT-1590 Fix bug with pay rate sync for future ended rate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/PayRatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/PayRatesService.kt
@@ -99,7 +99,7 @@ class PayRatesService(
 
   private fun MutableList<CourseActivityPayRate>.findExistingPayRate(requested: PayRateRequest) =
     firstOrNull { existing ->
-      !existing.hasExpiryDate() &&
+      (existing.endDate == null || existing.endDate!! >= LocalDate.now()) &&
         requested.payBand == existing.id.payBandCode &&
         requested.incentiveLevel == existing.id.iepLevelCode
     }


### PR DESCRIPTION
Scenario:
* we have a pay rate that has a future end date
* we receive an update to change the value of the pay rate and remove the end date
* the existing rate's end date isn't updated, so in NOMIS it appears to be active when it's not

The fix is to end the existing pay rate today and start the new one from tomorrow.