### PR TITLE
SDIT-1591 Add option to fetch all sentencing adjustments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderKeyDateAdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderKeyDateAdjustmentRepository.kt
@@ -18,4 +18,5 @@ interface OffenderKeyDateAdjustmentRepository :
   @Query(nativeQuery = true)
   fun adjustmentIdsQueryNamed(fromDate: LocalDate? = null, toDate: LocalDate? = null, pageable: Pageable): Page<AdjustmentIdResponse>
   fun findByOffenderBookingAndActive(offenderBooking: OffenderBooking, isOffenderActive: Boolean): List<OffenderKeyDateAdjustment>
+  fun findByOffenderBooking(offenderBooking: OffenderBooking): List<OffenderKeyDateAdjustment>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceAdjustmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceAdjustmentRepository.kt
@@ -11,4 +11,5 @@ interface OffenderSentenceAdjustmentRepository :
   CrudRepository<OffenderSentenceAdjustment, Long>,
   JpaSpecificationExecutor<OffenderSentenceAdjustment> {
   fun findByOffenderBookingAndActiveAndOffenderKeyDateAdjustmentIdIsNull(offenderBooking: OffenderBooking, isOffenderActive: Boolean): List<OffenderSentenceAdjustment>
+  fun findByOffenderBookingAndOffenderKeyDateAdjustmentIdIsNull(offenderBooking: OffenderBooking): List<OffenderSentenceAdjustment>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentResource.kt
@@ -553,8 +553,15 @@ class SentencingAdjustmentResource(private val sentencingAdjustmentService: Sent
     @Schema(description = "NOMIS booking Id", example = "12345", required = true)
     @PathVariable
     bookingId: Long,
+    @Schema(description = "Indicate if should return just active adjustments", required = true)
+    @RequestParam(value = "active-only", required = false, defaultValue = "true")
+    activeOnly: Boolean,
   ): SentencingAdjustmentsResponse =
-    sentencingAdjustmentService.getActiveSentencingAdjustments(bookingId = bookingId)
+    if (activeOnly) {
+      sentencingAdjustmentService.getActiveSentencingAdjustments(bookingId = bookingId)
+    } else {
+      sentencingAdjustmentService.getAllSentencingAdjustments(bookingId = bookingId)
+    }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentService.kt
@@ -244,6 +244,18 @@ class SentencingAdjustmentService(
           .map { it.toAdjustmentResponse() },
       )
     } ?: throw NotFoundException("Booking $bookingId not found")
+
+  fun getAllSentencingAdjustments(bookingId: Long) =
+    offenderBookingRepository.findByIdOrNull(bookingId)?.let { offenderBooking ->
+      SentencingAdjustmentsResponse(
+        keyDateAdjustments = keyDateAdjustmentRepository.findByOffenderBooking(offenderBooking)
+          .map { it.toAdjustmentResponse() },
+        sentenceAdjustments = offenderSentenceAdjustmentRepository.findByOffenderBookingAndOffenderKeyDateAdjustmentIdIsNull(
+          offenderBooking,
+        )
+          .map { it.toAdjustmentResponse() },
+      )
+    } ?: throw NotFoundException("Booking $bookingId not found")
 }
 
 private fun OffenderKeyDateAdjustment.toAdjustmentResponse() =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
@@ -1982,7 +1982,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `get all active adjustments ignoring linked key date adjustments`() {
+    fun `get all active adjustments ignoring linked key date adjustments by default`() {
       webTestClient.get().uri("/prisoners/booking-id/{bookingId}/sentencing-adjustments", bookingId)
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
@@ -1994,6 +1994,29 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
         .jsonPath("$.sentenceAdjustments.size()").isEqualTo(2)
         .jsonPath("$.sentenceAdjustments[0].adjustmentType.code").isEqualTo("RSR")
         .jsonPath("$.sentenceAdjustments[1].adjustmentType.code").isEqualTo("S240A")
+    }
+
+    @Test
+    fun `can get all adjustments regardless of active status`() {
+      webTestClient.get().uri("/prisoners/booking-id/{bookingId}/sentencing-adjustments?active-only=false", bookingId)
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.keyDateAdjustments.size()").isEqualTo(3)
+        .jsonPath("$.keyDateAdjustments[0].adjustmentType.code").isEqualTo("LAL")
+        .jsonPath("$.keyDateAdjustments[0].active").isEqualTo(false)
+        .jsonPath("$.keyDateAdjustments[1].adjustmentType.code").isEqualTo("UAL")
+        .jsonPath("$.keyDateAdjustments[1].active").isEqualTo(true)
+        .jsonPath("$.keyDateAdjustments[2].adjustmentType.code").isEqualTo("ADA")
+        .jsonPath("$.keyDateAdjustments[2].active").isEqualTo(true)
+        .jsonPath("$.sentenceAdjustments.size()").isEqualTo(3)
+        .jsonPath("$.sentenceAdjustments[0].adjustmentType.code").isEqualTo("RSR")
+        .jsonPath("$.sentenceAdjustments[0].active").isEqualTo(true)
+        .jsonPath("$.sentenceAdjustments[1].adjustmentType.code").isEqualTo("S240A")
+        .jsonPath("$.sentenceAdjustments[1].active").isEqualTo(true)
+        .jsonPath("$.sentenceAdjustments[2].adjustmentType.code").isEqualTo("RX")
+        .jsonPath("$.sentenceAdjustments[2].active").isEqualTo(false)
     }
   }
 }


### PR DESCRIPTION
An option has been added to the sentencing adjustments API to return both active and all adjustments based on a new parameter, 'activeOnly'. This allows users to fetch all sentencing adjustments, regardless of their active status. The default behavior remains to return only active adjustments. Relevant testing has been adapted and expanded.