### PR TITLE
SDIT-1612 Implement alert filtering by date range

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderAlertRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderAlertRepository.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAlert
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAlertId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import java.time.LocalDateTime
 
 @Repository
 interface OffenderAlertRepository : JpaRepository<OffenderAlert, OffenderAlertId> {
@@ -14,4 +17,42 @@ interface OffenderAlertRepository : JpaRepository<OffenderAlert, OffenderAlertId
 
   @Suppress("ktlint:standard:function-naming")
   fun findById_OffenderBookingAndId_Sequence(offenderBooking: OffenderBooking, alertSequence: Long): OffenderAlert?
+
+  @Query(
+    """
+      select 
+        alert.id.offenderBooking.bookingId as bookingId, 
+        alert.id.sequence as alertSequence, 
+        alert.id.offenderBooking.offender.nomsId as offenderNo
+      from OffenderAlert alert 
+        order by alert.id.offenderBooking.bookingId, alert.id.sequence asc
+    """,
+  )
+  fun findAllAlertIds(
+    pageable: Pageable,
+  ): Page<AlertId>
+
+  @Query(
+    """
+      select 
+        alert.id.offenderBooking.bookingId as bookingId, 
+        alert.id.sequence as alertSequence, 
+        alert.id.offenderBooking.offender.nomsId as offenderNo
+      from OffenderAlert alert 
+        where 
+          (:fromDate is null or alert.createDatetime > :fromDate) and 
+          (:toDate is null or alert.createDatetime < :toDate)    
+        order by alert.id.offenderBooking.bookingId, alert.id.sequence asc
+    """,
+  )
+  fun findAllAlertIds(
+    fromDate: LocalDateTime?,
+    toDate: LocalDateTime?,
+    pageable: Pageable,
+  ): Page<AlertId>
+}
+interface AlertId {
+  fun getBookingId(): Long
+  fun getAlertSequence(): Long
+  fun getOffenderNo(): String
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsResourceIntTest.kt
@@ -355,6 +355,260 @@ class AlertsResourceIntTest : IntegrationTestBase() {
     }
   }
 
+  @DisplayName("GET /alerts/ids")
+  @Nested
+  inner class GetAlertIds {
+    var bookingId1 = 0L
+    var bookingId2 = 0L
+    private val alertSequenceFromJuly2020 = 1L
+    private val inactiveAlertSequenceFromJuly2020 = 2L
+    private val alertSequenceFromToday = 3L
+    private val alertSequenceFromJan2020 = 4L
+    private val alertSequenceFromFeb2020 = 4L
+    private lateinit var prisoner1: Offender
+    private lateinit var prisoner2: Offender
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        prisoner1 = offender(nomsId = "A1234AB") {
+          bookingId1 = booking {
+            alert(
+              sequence = alertSequenceFromJuly2020,
+              alertCode = "HPI",
+              typeCode = "X",
+              date = LocalDate.parse("2023-07-19"),
+              expiryDate = null,
+              authorizePersonText = null,
+              verifiedFlag = false,
+              status = ACTIVE,
+              commentText = null,
+            )
+            alert(
+              sequence = inactiveAlertSequenceFromJuly2020,
+              alertCode = "SC",
+              typeCode = "S",
+              date = LocalDate.parse("2020-07-19"),
+              expiryDate = LocalDate.parse("2025-07-19"),
+              authorizePersonText = "Security Team",
+              verifiedFlag = true,
+              status = INACTIVE,
+              commentText = "At risk",
+            )
+            alert(
+              sequence = alertSequenceFromToday,
+              alertCode = "HPI",
+              typeCode = "X",
+            ) {
+              audit()
+            }
+            alert(
+              sequence = alertSequenceFromJan2020,
+              alertCode = "HPI",
+              typeCode = "X",
+            ) {
+              audit(
+                createUsername = "JANE.NARK",
+                createDatetime = LocalDateTime.parse("2020-01-23T10:23"),
+                modifyUserId = "TREV.NACK",
+                modifyDatetime = LocalDateTime.parse("2022-02-23T10:23:12"),
+                auditTimestamp = LocalDateTime.parse("2022-02-23T10:23:13"),
+                auditUserId = "TREV.MACK",
+                auditModuleName = "OCDALERT",
+                auditClientUserId = "trev.nack",
+                auditClientIpAddress = "10.1.1.23",
+                auditClientWorkstationName = "MMD1234J",
+                auditAdditionalInfo = "POST /api/bookings/2904199/alert",
+              )
+            }
+          }.bookingId
+        }
+        prisoner2 = offender(nomsId = "A1234BC") {
+          bookingId2 = booking {
+            alert(
+              sequence = alertSequenceFromJuly2020,
+              alertCode = "HPI",
+              typeCode = "X",
+              date = LocalDate.parse("2023-07-19"),
+              expiryDate = null,
+              authorizePersonText = null,
+              verifiedFlag = false,
+              status = ACTIVE,
+              commentText = null,
+            )
+            alert(
+              sequence = inactiveAlertSequenceFromJuly2020,
+              alertCode = "SC",
+              typeCode = "S",
+              date = LocalDate.parse("2020-07-19"),
+              expiryDate = LocalDate.parse("2025-07-19"),
+              authorizePersonText = "Security Team",
+              verifiedFlag = true,
+              status = INACTIVE,
+              commentText = "At risk",
+            )
+            alert(
+              sequence = alertSequenceFromToday,
+              alertCode = "HPI",
+              typeCode = "X",
+            ) {
+              audit()
+            }
+            alert(
+              sequence = alertSequenceFromFeb2020,
+              alertCode = "HPI",
+              typeCode = "X",
+            ) {
+              audit(
+                createUsername = "JANE.NARK",
+                createDatetime = LocalDateTime.parse("2020-02-23T10:23"),
+                modifyUserId = "TREV.NACK",
+                modifyDatetime = LocalDateTime.parse("2022-03-23T10:23:12"),
+                auditTimestamp = LocalDateTime.parse("2022-03-23T10:23:13"),
+                auditUserId = "TREV.MACK",
+                auditModuleName = "OCDALERT",
+                auditClientUserId = "trev.nack",
+                auditClientIpAddress = "10.1.1.23",
+                auditClientWorkstationName = "MMD1234J",
+                auditAdditionalInfo = "POST /api/bookings/2904199/alert",
+              )
+            }
+          }.bookingId
+        }
+      }
+    }
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteOffenders()
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/alerts/ids")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/alerts/ids")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.get().uri("/alerts/ids")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `will return offender no, bookingId and alert sequence`() {
+        webTestClient.get().uri {
+          it.path("/alerts/ids")
+            .queryParam("fromDate", "2020-01-23")
+            .queryParam("toDate", "2020-01-23")
+            .build()
+        }
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(1)
+          .jsonPath("$.content[0].bookingId").isEqualTo(bookingId1)
+          .jsonPath("$.content[0].alertSequence").isEqualTo(alertSequenceFromJan2020)
+          .jsonPath("$.content[0].offenderNo").isEqualTo("A1234AB")
+      }
+
+      @Test
+      fun `can filter by just from date`() {
+        webTestClient.get().uri {
+          it.path("/alerts/ids")
+            .queryParam("fromDate", "2020-01-24")
+            .build()
+        }
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(7)
+      }
+
+      @Test
+      fun `can filter by just to date`() {
+        webTestClient.get().uri {
+          it.path("/alerts/ids")
+            .queryParam("toDate", "2020-01-24")
+            .build()
+        }
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(1)
+      }
+
+      @Test
+      fun `will get all alerts when there is no filter`() {
+        webTestClient.get().uri {
+          it.path("/alerts/ids")
+            .build()
+        }
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(8)
+      }
+
+      @Test
+      fun `will order by booking id, sequence ascending`() {
+        webTestClient.get().uri {
+          it.path("/alerts/ids")
+            .build()
+        }
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(8)
+          .jsonPath("$.content[0].bookingId").isEqualTo(bookingId1)
+          .jsonPath("$.content[0].alertSequence").isEqualTo(1)
+          .jsonPath("$.content[0].offenderNo").isEqualTo("A1234AB")
+          .jsonPath("$.content[1].bookingId").isEqualTo(bookingId1)
+          .jsonPath("$.content[1].alertSequence").isEqualTo(2)
+          .jsonPath("$.content[1].offenderNo").isEqualTo("A1234AB")
+          .jsonPath("$.content[2].bookingId").isEqualTo(bookingId1)
+          .jsonPath("$.content[2].alertSequence").isEqualTo(3)
+          .jsonPath("$.content[2].offenderNo").isEqualTo("A1234AB")
+          .jsonPath("$.content[3].bookingId").isEqualTo(bookingId1)
+          .jsonPath("$.content[3].alertSequence").isEqualTo(4)
+          .jsonPath("$.content[3].offenderNo").isEqualTo("A1234AB")
+          .jsonPath("$.content[4].bookingId").isEqualTo(bookingId2)
+          .jsonPath("$.content[4].alertSequence").isEqualTo(1)
+          .jsonPath("$.content[4].offenderNo").isEqualTo("A1234BC")
+          .jsonPath("$.content[5].bookingId").isEqualTo(bookingId2)
+          .jsonPath("$.content[5].alertSequence").isEqualTo(2)
+          .jsonPath("$.content[5].offenderNo").isEqualTo("A1234BC")
+          .jsonPath("$.content[6].bookingId").isEqualTo(bookingId2)
+          .jsonPath("$.content[6].alertSequence").isEqualTo(3)
+          .jsonPath("$.content[6].offenderNo").isEqualTo("A1234BC")
+          .jsonPath("$.content[7].bookingId").isEqualTo(bookingId2)
+          .jsonPath("$.content[7].alertSequence").isEqualTo(4)
+          .jsonPath("$.content[7].offenderNo").isEqualTo("A1234BC")
+      }
+    }
+  }
+
   @DisplayName("DELETE /prisoners/booking-id/{bookingId}/alerts/{alertSequence}")
   @Nested
   inner class DeleteAlert {


### PR DESCRIPTION
Introduced the ability to fetch alerts by filtering through a specific date range. The backend API now supports retrieving alerts from a 'fromDate' to a 'toDate'. Enhancements were made to the AlertsService and OffenderAlertRepository to facilitate this feature. Corresponding tests were also added. Changes also include an endpoint creation for retrieving alert Ids by applying a filter.