### PR TITLE
SDIT-1625 Rename merge properties

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
@@ -31,11 +31,11 @@ class PrisonerService(
       )
       .map {
         MergeDetail(
-          toOffenderNo = it.nomsId1,
-          toBookingId = it.offenderBookId1,
-          fromOffenderNo = it.nomsId2,
-          fromBookingId = it.offenderBookId2,
-          dateTime = it.requestDate,
+          retainedOffenderNo = it.nomsId1,
+          previousBookingId = it.offenderBookId1,
+          deletedOffenderNo = it.nomsId2,
+          activeBookingId = it.offenderBookId2,
+          requestDateTime = it.requestDate,
         )
       }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
@@ -178,7 +178,7 @@ data class PrisonerDetails(
 
 @Schema(description = "Details of a prisoner merge")
 data class MergeDetail(
-  @Schema(description = "The NOMIS reference of the that record was merged to and was then removed", example = "A1234AA")
+  @Schema(description = "The NOMIS reference of the record that was merged to and was then removed", example = "A1234AA")
   val deletedOffenderNo: String,
   @Schema(description = "The booking that was merged to and which then became active", example = "12345678")
   val activeBookingId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
@@ -182,7 +182,7 @@ data class MergeDetail(
   val deletedOffenderNo: String,
   @Schema(description = "The booking that was merged to and which then became active", example = "12345678")
   val activeBookingId: Long,
-  @Schema(description = "The NOMIS reference of record that was merged from and was retained", example = "A1234AA")
+  @Schema(description = "The NOMIS reference of the record that was merged from and was retained", example = "A1234AA")
   val retainedOffenderNo: String,
   @Schema(description = "The booking that was merged from and was retained as inactive", example = "12345678")
   val previousBookingId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResource.kt
@@ -178,14 +178,14 @@ data class PrisonerDetails(
 
 @Schema(description = "Details of a prisoner merge")
 data class MergeDetail(
-  @Schema(description = "The NOMIS reference of record was merged from", example = "A1234AA")
-  val fromOffenderNo: String,
-  @Schema(description = "The booking that was merged from", example = "12345678")
-  val fromBookingId: Long,
-  @Schema(description = "The NOMIS reference of record was merged to", example = "A1234AA")
-  val toOffenderNo: String,
-  @Schema(description = "The booking that was merged to", example = "12345678")
-  val toBookingId: Long,
+  @Schema(description = "The NOMIS reference of the that record was merged to and was then removed", example = "A1234AA")
+  val deletedOffenderNo: String,
+  @Schema(description = "The booking that was merged to and which then became active", example = "12345678")
+  val activeBookingId: Long,
+  @Schema(description = "The NOMIS reference of record that was merged from and was retained", example = "A1234AA")
+  val retainedOffenderNo: String,
+  @Schema(description = "The booking that was merged from and was retained as inactive", example = "12345678")
+  val previousBookingId: Long,
   @Schema(description = "When the merge happened", example = "2021-01-01T12:34:56")
-  val dateTime: LocalDateTime,
+  val requestDateTime: LocalDateTime,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonersResourceIntTest.kt
@@ -297,16 +297,16 @@ class PrisonersResourceIntTest : IntegrationTestBase() {
           .expectStatus().isOk
           .expectBody()
           .jsonPath("$.size()").isEqualTo(2)
-          .jsonPath("[0].fromOffenderNo").isEqualTo("A1234AL")
-          .jsonPath("[0].fromBookingId").isEqualTo(102)
-          .jsonPath("[0].toOffenderNo").isEqualTo("A1234AK")
-          .jsonPath("[0].toBookingId").isEqualTo(101)
-          .jsonPath("[0].dateTime").isEqualTo("2002-01-01T12:00:00")
-          .jsonPath("[1].fromOffenderNo").isEqualTo("A1234TL")
-          .jsonPath("[1].fromBookingId").isEqualTo(104)
-          .jsonPath("[1].toOffenderNo").isEqualTo("A1234AK")
-          .jsonPath("[1].toBookingId").isEqualTo(103)
-          .jsonPath("[1].dateTime").isEqualTo("2024-01-01T12:00:00")
+          .jsonPath("[0].deletedOffenderNo").isEqualTo("A1234AL")
+          .jsonPath("[0].activeBookingId").isEqualTo(102)
+          .jsonPath("[0].retainedOffenderNo").isEqualTo("A1234AK")
+          .jsonPath("[0].previousBookingId").isEqualTo(101)
+          .jsonPath("[0].requestDateTime").isEqualTo("2002-01-01T12:00:00")
+          .jsonPath("[1].deletedOffenderNo").isEqualTo("A1234TL")
+          .jsonPath("[1].activeBookingId").isEqualTo(104)
+          .jsonPath("[1].retainedOffenderNo").isEqualTo("A1234AK")
+          .jsonPath("[1].previousBookingId").isEqualTo(103)
+          .jsonPath("[1].requestDateTime").isEqualTo("2024-01-01T12:00:00")
       }
 
       @Test
@@ -317,11 +317,11 @@ class PrisonersResourceIntTest : IntegrationTestBase() {
           .expectStatus().isOk
           .expectBody()
           .jsonPath("$.size()").isEqualTo(1)
-          .jsonPath("[0].fromOffenderNo").isEqualTo("A1234TL")
-          .jsonPath("[0].fromBookingId").isEqualTo(104)
-          .jsonPath("[0].toOffenderNo").isEqualTo("A1234AK")
-          .jsonPath("[0].toBookingId").isEqualTo(103)
-          .jsonPath("[0].dateTime").isEqualTo("2024-01-01T12:00:00")
+          .jsonPath("[0].deletedOffenderNo").isEqualTo("A1234TL")
+          .jsonPath("[0].activeBookingId").isEqualTo(104)
+          .jsonPath("[0].retainedOffenderNo").isEqualTo("A1234AK")
+          .jsonPath("[0].previousBookingId").isEqualTo(103)
+          .jsonPath("[0].requestDateTime").isEqualTo("2024-01-01T12:00:00")
       }
 
       @Test


### PR DESCRIPTION
NOMIS Merge and DB use confusing names, these new names better represent the final state  of the various IDs