### PR TITLE
SDIT-1645 Amended /prisoners/ids to return all prisoners not just active ones.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderBooking.kt
@@ -160,3 +160,4 @@ data class OffenderBooking(
 }
 
 fun OffenderBooking.hasBeenReleased() = !this.active && this.inOutStatus == "OUT"
+fun OffenderBooking.status() = "${if (this.active) "ACTIVE" else "INACTIVE"} $inOutStatus"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderRepository.kt
@@ -1,12 +1,13 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
 
 @Repository
-interface OffenderRepository : JpaRepository<Offender, Long> {
+interface OffenderRepository : JpaRepository<Offender, Long>, JpaSpecificationExecutor<Offender> {
   fun findByNomsId(nomsId: String): List<Offender>
 
   @Query("select o from Offender o left join fetch o.bookings b WHERE o.nomsId = :nomsId order by b.bookingSequence asc")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/specification/OffenderWithBookingsSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/specification/OffenderWithBookingsSpecification.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.specification
+
+import jakarta.persistence.criteria.CriteriaBuilder
+import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+
+class OffenderWithBookingsSpecification : Specification<Offender> {
+  override fun toPredicate(
+    root: Root<Offender>,
+    query: CriteriaQuery<*>,
+    criteriaBuilder: CriteriaBuilder,
+  ): Predicate? {
+    fun CriteriaBuilder.whereHasBookingWithSequenceOne() = equal(root.get<String>(Offender::bookings.name).get<String>(OffenderBooking::bookingSequence.name), 1)
+    return criteriaBuilder.and(criteriaBuilder.whereHasBookingWithSequenceOne())
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
@@ -1,16 +1,25 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.prisoners
 
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.ASC
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.MergeTransactionRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.findRootByNomisId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.specification.ActiveBookingsSpecification
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.specification.OffenderWithBookingsSpecification
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.status
 import java.time.LocalDate
 
 @Service
+@Transactional(readOnly = true)
 class PrisonerService(
   private val bookingRepository: OffenderBookingRepository,
   private val offenderRepository: OffenderRepository,
@@ -18,8 +27,24 @@ class PrisonerService(
 ) {
   fun findAllActivePrisoners(pageRequest: Pageable): Page<PrisonerId> {
     return bookingRepository.findAll(ActiveBookingsSpecification(), pageRequest)
-      .map { PrisonerId(it.bookingId, it.offender.nomsId) }
+      .map { PrisonerId(bookingId = it.bookingId, offenderNo = it.offender.nomsId, status = it.status()) }
   }
+
+  fun findAllPrisonersWithBookings(pageRequest: Pageable): Page<PrisonerId> =
+    offenderRepository.findAll(
+      OffenderWithBookingsSpecification(),
+      PageRequest.of(
+        pageRequest.pageNumber,
+        pageRequest.pageSize,
+        Sort.by(ASC, "rootOffenderId"),
+      ),
+    ).map {
+      PrisonerId(
+        bookingId = it.lastBooking().bookingId,
+        offenderNo = it.nomsId,
+        status = it.lastBooking().status(),
+      )
+    }
 
   fun findPrisonerDetails(bookingIds: List<Long>): List<PrisonerDetails> {
     return bookingRepository.findAllById(bookingIds)
@@ -39,4 +64,7 @@ class PrisonerService(
         )
       }
   }
+
+  fun Offender.lastBooking(): OffenderBooking =
+    this.bookings.firstOrNull { it.bookingSequence == 1 } ?: throw IllegalStateException("Offender has no latest bookings")
 }


### PR DESCRIPTION
…

The endpoint has an unfortunate parameter of `active` where setting this false means return active and inactive prisoners.

A prisoner is defined as someone at some-point that had a booking.

Also amened DSL to allow adding of Alias offender records.