### PR TITLE
SDIT-1659 Previous alert of same type rules

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsResourceIntTest.kt
@@ -677,7 +677,7 @@ class AlertsResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `only one alert from previous booking of same type on same date is taken`() {
+      fun `both alerts from previous booking of same type on same date are taken`() {
         webTestClient.get().uri("/prisoners/${prisonerWithIdenticalAlerts.nomsId}/alerts/to-migrate")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
           .exchange()
@@ -685,10 +685,12 @@ class AlertsResourceIntTest : IntegrationTestBase() {
           .isOk
           .expectBody()
           .jsonPath("latestBookingAlerts.size()").isEqualTo(0)
-          .jsonPath("previousBookingsAlerts.size()").isEqualTo(1)
+          .jsonPath("previousBookingsAlerts.size()").isEqualTo(2)
           .jsonPath("previousBookingsAlerts[0].alertSequence").isEqualTo(1)
           .jsonPath("previousBookingsAlerts[0].alertCode.code").isEqualTo("RYP")
           .jsonPath("previousBookingsAlerts[0].date").isEqualTo("2019-07-19")
+          .jsonPath("previousBookingsAlerts[1].alertCode.code").isEqualTo("RYP")
+          .jsonPath("previousBookingsAlerts[1].date").isEqualTo("2019-07-19")
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsServiceTest.kt
@@ -1,0 +1,453 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.alerts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertCode
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertStatus.ACTIVE
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertStatus.INACTIVE
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Gender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAlert
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAlertId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class AlertsServiceTest {
+  private lateinit var alertsService: AlertsService
+
+  @Mock
+  lateinit var offenderBookingRepository: OffenderBookingRepository
+
+  @BeforeEach
+  fun setUp() {
+    alertsService = AlertsService(
+      offenderBookingRepository = offenderBookingRepository,
+      offenderAlertRepository = mock(),
+      alertCodeRepository = mock(),
+      alertTypeRepository = mock(),
+      workFlowActionRepository = mock(),
+    )
+  }
+
+  @Nested
+  inner class GetAlerts {
+    @Nested
+    @DisplayName("With no alerts on any booking")
+    inner class WithNoAlertsAtAll {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              listOf(),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be no alerts`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).isEmpty()
+        assertThat(alerts.previousBookingsAlerts).isEmpty()
+      }
+    }
+
+    @Nested
+    @DisplayName("With alerts only on the latest booking")
+    inner class WithAlertsOnlyOnLatestBooking {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be two alerts on latest and none on previous`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A", "B")
+        assertThat(alerts.previousBookingsAlerts).isEmpty()
+      }
+    }
+
+    @Nested
+    @DisplayName("With alerts only on the previous booking")
+    inner class WithAlertsOnlyOnPreviousBooking {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be two alerts on previous and none on latest`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("A", "B")
+        assertThat(alerts.latestBookingAlerts).isEmpty()
+      }
+    }
+
+    @Nested
+    @DisplayName("With the same alerts on latest and previous bookings")
+    inner class WithSameAlertsOnLatestAndPrevious {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be two alerts on latest and none on previous`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A", "B")
+        assertThat(alerts.previousBookingsAlerts).isEmpty()
+      }
+    }
+
+    @Nested
+    @DisplayName("With the extra alerts on previous booking")
+    inner class WithExtraAlertsOnPrevious {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+                alert(sequence = 3, alertCode = "C"),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be two alerts on latest and one on previous`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A", "B")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("C")
+      }
+    }
+
+    @Nested
+    @DisplayName("With the extra alerts on several previous booking")
+    inner class WithExtraAlertsOnSeveralPreviousBookings {
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+                alert(sequence = 2, alertCode = "B"),
+                alert(sequence = 3, alertCode = "C"),
+              ),
+            ),
+            booking(
+              bookingSequence = 3,
+              alerts = listOf(
+                alert(sequence = 4, alertCode = "D"),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `there will be two alerts on latest and two on previous`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A", "B")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("C", "D")
+      }
+    }
+
+    @Nested
+    @DisplayName("With the same extra alerts on previous booking that have the same alert dates but different status")
+    inner class WithPreviousBookingAlertDatesSame {
+      private val alertDate = LocalDate.parse("2021-01-01")
+
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 20, alertCode = "B", alertDate = alertDate, active = false),
+              ),
+            ),
+            booking(
+              bookingSequence = 3,
+              alerts = listOf(
+                alert(sequence = 30, alertCode = "B", alertDate = alertDate, active = true),
+              ),
+            ),
+            booking(
+              bookingSequence = 4,
+              alerts = listOf(
+                alert(sequence = 40, alertCode = "B", alertDate = alertDate, active = false),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `will choose the active alert over the inactive`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("B")
+        assertThat(alerts.previousBookingsAlerts).extracting<Long> { it.alertSequence }.containsOnly(30)
+      }
+    }
+
+    @Nested
+    @DisplayName("With the same extra alerts on previous booking that have the same alert dates, same status but different audit dates")
+    inner class WithPreviousBookingManyAlertDatesSameDifferentAuditDates {
+      private val alertDate = LocalDate.parse("2021-01-01")
+
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 20, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = LocalDateTime.now().minusDays(10)),
+              ),
+            ),
+            booking(
+              bookingSequence = 3,
+              alerts = listOf(
+                alert(sequence = 30, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = LocalDateTime.now().minusDays(1)),
+              ),
+            ),
+            booking(
+              bookingSequence = 4,
+              alerts = listOf(
+                alert(sequence = 40, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = LocalDateTime.now().minusDays(20)),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `will choose the active alerts on the same date with the latest audit timestamp`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("B")
+        assertThat(alerts.previousBookingsAlerts).extracting<Long> { it.alertSequence }.containsOnly(30)
+      }
+    }
+
+    @Nested
+    @DisplayName("With the same extra alerts on previous booking that have the same alert dates, same status and same audit dates")
+    inner class WithPreviousBookingManyAlertDatesSameAuditDatesSame {
+      private val alertDate = LocalDate.parse("2021-01-01")
+      private val auditTimestamp = LocalDateTime.parse("2021-01-02T10:00")
+
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 20, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = auditTimestamp),
+              ),
+            ),
+            booking(
+              bookingSequence = 3,
+              alerts = listOf(
+                alert(sequence = 30, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = auditTimestamp),
+              ),
+            ),
+            booking(
+              bookingSequence = 4,
+              alerts = listOf(
+                alert(sequence = 40, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = LocalDateTime.now().minusYears(99)),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `will choose all matching active alerts with the latest date and audit timestamp`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("B", "B")
+        assertThat(alerts.previousBookingsAlerts).extracting<Long> { it.alertSequence }.containsOnly(20, 30)
+      }
+    }
+
+    @Nested
+    @DisplayName("With the same extra alerts on previous booking that have the same alert dates, same status and same audit dates but some have null dates")
+    inner class WithPreviousBookingManyAlertDatesSameAuditDatesSameSomeNull {
+      private val alertDate = LocalDate.parse("2021-01-01")
+      private val auditTimestamp = LocalDateTime.parse("2021-01-02T10:00")
+
+      @BeforeEach
+      fun setUp() {
+        whenever(offenderBookingRepository.findAllByOffenderNomsId("A1234KT")).thenReturn(
+          listOf(
+            booking(
+              bookingSequence = 1,
+              alerts = listOf(
+                alert(sequence = 1, alertCode = "A"),
+              ),
+            ),
+            booking(
+              bookingSequence = 2,
+              alerts = listOf(
+                alert(sequence = 20, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = auditTimestamp),
+              ),
+            ),
+            booking(
+              bookingSequence = 3,
+              alerts = listOf(
+                alert(sequence = 30, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = auditTimestamp),
+              ),
+            ),
+            booking(
+              bookingSequence = 4,
+              alerts = listOf(
+                alert(sequence = 40, alertCode = "B", alertDate = alertDate, active = true, auditTimestamp = null),
+              ),
+            ),
+          ),
+        )
+      }
+
+      @Test
+      fun `will choose the active with the latest audit timestamp`() {
+        val alerts = alertsService.getAlerts("A1234KT")
+
+        assertThat(alerts.latestBookingAlerts).extracting<String> { it.alertCode.code }.containsOnly("A")
+        assertThat(alerts.previousBookingsAlerts).extracting<String> { it.alertCode.code }.containsOnly("B", "B")
+        assertThat(alerts.previousBookingsAlerts).extracting<Long> { it.alertSequence }.containsOnly(20, 30)
+      }
+    }
+  }
+}
+
+private fun booking(alerts: List<OffenderAlert> = emptyList(), bookingSequence: Int = 1): OffenderBooking =
+  OffenderBooking(
+    bookingSequence = bookingSequence,
+    alerts = alerts.toMutableList(),
+    bookingBeginDate = LocalDateTime.now(),
+    offender = Offender(nomsId = "A1234KT", gender = Gender("M", "MALE"), lastName = "SMITH"),
+  )
+
+private fun alert(
+  sequence: Long = 1,
+  alertCode: String = "A",
+  alertDate: LocalDate = LocalDate.now(),
+  auditTimestamp: LocalDateTime? = LocalDateTime.now(),
+  active: Boolean = true,
+): OffenderAlert = OffenderAlert(
+  id = OffenderAlertId(booking(), sequence),
+  alertCode = AlertCode(alertCode, "A Alert"),
+  alertType = AlertType("X", "X Type"),
+  alertDate = alertDate,
+  createUsername = "BOB",
+  alertStatus = if (active) ACTIVE else INACTIVE,
+
+).apply {
+  this.auditTimestamp = auditTimestamp
+  this.createDatetime = LocalDateTime.now()
+}


### PR DESCRIPTION
DPS Rules defined as:
Identical datetime logic (V1):
If more than one of the most recent alerts have the same datetime. 

We use the following rules: 

* If one active alert exists in this subset, we surface that active alert.
*  If more than one identical active alerts exist, we surface the active alert with the most recent audit datetime. 
* If no active alerts exist in the subset, we surface the alert with the most recent audit datetime. 
* If audit datetime is the same for more two or more alerts in either point 1 or 2 then we surface all alerts with the same audit datetime.