### PR TITLE
SDIT-1699 Active alerts take precedence on inactive

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsService.kt
@@ -183,15 +183,15 @@ fun chooseLatestActiveAlert(first: OffenderAlert, second: OffenderAlert): Int {
   /*
   Order is as follows:
    * Latest booking (i.e. lowest booking sequence)
+   * Active takes precedence over inactive
    * Latest alert date
-   * Active if both have same date
    * Audit date if both same data and same status
 
    NB: many alerts might be equally the most relevant
    */
   return second.id.offenderBooking.bookingSequence!!.compareTo(first.id.offenderBooking.bookingSequence!!).takeIf { it != 0 }
-    ?: first.alertDate.compareTo(second.alertDate).takeIf { it != 0 }
     ?: second.alertStatus.name.compareTo(first.alertStatus.name).takeIf { it != 0 }
+    ?: first.alertDate.compareTo(second.alertDate).takeIf { it != 0 }
     ?: (first.auditTimestamp ?: LocalDateTime.MIN).compareTo(second.auditTimestamp ?: LocalDateTime.MIN).takeIf { it != 0 }
     ?: 0
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsServiceTest.kt
@@ -239,7 +239,7 @@ class AlertsServiceTest {
     }
 
     @Nested
-    @DisplayName("With the same extra alerts on previous booking that have the same alert dates but different status")
+    @DisplayName("With the same extra alerts on previous booking that have the different alert dates and different status")
     inner class WithPreviousBookingAlertDatesSame {
       private val alertDate = LocalDate.parse("2021-01-01")
 
@@ -258,9 +258,9 @@ class AlertsServiceTest {
               bookingSequence = 2,
             ).apply {
               this.alerts += listOf(
-                alert(booking = this, sequence = 20, alertCode = "B", alertDate = alertDate, active = false),
+                alert(booking = this, sequence = 20, alertCode = "B", alertDate = alertDate.plusDays(10), active = false),
                 alert(booking = this, sequence = 30, alertCode = "B", alertDate = alertDate, active = true),
-                alert(booking = this, sequence = 40, alertCode = "B", alertDate = alertDate, active = false),
+                alert(booking = this, sequence = 40, alertCode = "B", alertDate = alertDate.minusDays(10), active = false),
               )
             },
           ),


### PR DESCRIPTION
When selecting a precious bookings alerts (when that alert does not appear on latest booking) when two or more alerts of the same type exist choose the active one. This is an edge case since in normal circumstances the active would be the latest there are 2 scenarios where  this is not the case:
* A merge between two prisoners that have the same alert
* The NOMIS alert data was loaded outside the NOMIS screens (very old alerts)