### PR TITLE
SDIT-1753 Remove status from PrisonerIds and add active prisoner endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisoners/PrisonerService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBook
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.findLatestAliasByNomisId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.specification.ActiveBookingsSpecification
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.status
 import java.time.LocalDate
 
 @Service
@@ -25,7 +24,7 @@ class PrisonerService(
 ) {
   fun findAllActivePrisoners(pageRequest: Pageable): Page<PrisonerIds> {
     return bookingRepository.findAll(ActiveBookingsSpecification(), pageRequest)
-      .map { PrisonerIds(bookingId = it.bookingId, offenderNo = it.offender.nomsId, status = it.status()) }
+      .map { PrisonerIds(bookingId = it.bookingId, offenderNo = it.offender.nomsId) }
   }
 
   fun findAllPrisonersWithBookings(pageRequest: Pageable): Page<PrisonerIds> =
@@ -39,7 +38,6 @@ class PrisonerService(
       PrisonerIds(
         bookingId = it.getBookingId(),
         offenderNo = it.getNomsId(),
-        status = "${if (it.isActive()) "ACTIVE" else "INACTIVE"} ${it.getInOutStatus()}",
       )
     }
   fun findAllPrisoners(pageRequest: Pageable): Page<PrisonerId> =


### PR DESCRIPTION

The status property was removed from the PrisonerIds class as it was no longer used. A new endpoint, "/prisoners/ids/active", was added to allow fetching identifiers of all active prisoners this replaces the deprecated version which will be removed soon