### PR TITLE
SDIT-1773 Punishment award lookup performance improvement

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingResultAwardRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingResultAwardRepository.kt
@@ -17,6 +17,18 @@ interface AdjudicationHearingResultAwardRepository : JpaRepository<AdjudicationH
     chargeSequence: Int,
   ): AdjudicationHearingResultAward?
 
+  @Query(
+    """
+    select award 
+        from AdjudicationHearingResultAward award 
+        join award.hearingResult hearingResult 
+        join hearingResult.incident incident 
+        join incident.parties adjudication 
+        where adjudication.adjudicationNumber = :adjudicationNumber 
+            and hearingResult.chargeSequence = :chargeSequence 
+        order by award.id.sanctionSequence asc
+  """,
+  )
   fun findByIncidentPartyAdjudicationNumberAndHearingResultChargeSequenceOrderByIdSanctionSequence(
     adjudicationNumber: Long,
     chargeSequence: Int,


### PR DESCRIPTION
 JPA be default wil generate a where clause on offender_oic_sanctions.oic_incident_id which is not indexed in NOMIS, ths rewrites the query so it navigates via AGENCY_INCIDENT_PARTIES where all joins are done on indexed columns.