### PR TITLE
SDIT-2029 Fix migration bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisonperson/PrisonPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/prisonperson/PrisonPersonService.kt
@@ -61,13 +61,14 @@ class PrisonPersonService(
 
   // NOMIS truncates the time from booking end date, so try and get the accurate time from the last release movement
   private fun OffenderBooking.getReleaseTime(): LocalDateTime? =
-    bookingEndDate?.let {
-      externalMovements
-        .filter { it.movementType?.code == "REL" }
-        .maxByOrNull { it.movementTime }
-        ?.movementTime
-        ?: bookingEndDate
-    }
+    takeIf { !active }
+      ?.let {
+        externalMovements
+          .filter { it.movementType?.code == "REL" }
+          .maxByOrNull { it.movementTime }
+          ?.movementTime
+          ?: bookingEndDate
+      }
 
   fun upsertPhysicalAttributes(offenderNo: String, request: UpsertPhysicalAttributesRequest): UpsertPhysicalAttributesResponse {
     val booking = bookingRepository.findLatestByOffenderNomsId(offenderNo)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderBooking.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderBooking.kt
@@ -237,6 +237,11 @@ interface BookingDsl {
   fun release(
     date: LocalDateTime = LocalDateTime.now(),
   ): OffenderExternalMovement
+
+  @OffenderExternalMovementDslMarker
+  fun receive(
+    date: LocalDateTime = LocalDateTime.now(),
+  ): OffenderExternalMovement
 }
 
 @Component
@@ -676,6 +681,18 @@ class BookingBuilder(
           date = date,
         )
           .also { offenderBooking.externalMovements.forEach { it.active = false } }
+          .also { offenderBooking.externalMovements += it }
+      }
+
+  override fun receive(
+    date: LocalDateTime,
+  ): OffenderExternalMovement =
+    offenderExternalMovementBuilderFactory.builder()
+      .let { builder ->
+        builder.buildReceive(
+          offenderBooking = offenderBooking,
+          date = date,
+        )
           .also { offenderBooking.externalMovements += it }
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderExternalMovement.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderExternalMovement.kt
@@ -118,6 +118,32 @@ class OffenderExternalMovementBuilder(
       }
     }
 
+  fun buildReceive(
+    date: LocalDateTime,
+    offenderBooking: OffenderBooking,
+  ): OffenderExternalMovement =
+    repository.save(
+      OffenderExternalMovement(
+        id = OffenderExternalMovementId(
+          offenderBooking,
+          offenderBooking.externalMovements.size + 1L,
+        ),
+        movementDate = date.toLocalDate(),
+        movementTime = date,
+        movementDirection = IN,
+        movementType = repository.lookupMovementType("ADM"),
+        movementReason = repository.lookupMovementReason("N"),
+        toAgency = offenderBooking.location,
+        fromAgency = null,
+        active = false,
+      ),
+    ).also {
+      offenderBooking.inOutStatus = "IN"
+      offenderBooking.location = offenderBooking.location
+      offenderBooking.active = true
+      offenderBooking.bookingEndDate = null
+    }
+
   fun build(
     fromPrisonId: String,
     toPrisonId: String,


### PR DESCRIPTION
In NOMIS we found some inactive bookings without an end date - we were sending these null booking end date, but we should have sent them the last release date.