### PR TITLE
SDIT-2053 Switch to mutating visit order list rather than recreating

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/VisitOrderVisitor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/VisitOrderVisitor.kt
@@ -33,7 +33,7 @@ data class VisitOrderVisitor(
 
   @Column(name = "GROUP_LEADER_FLAG", nullable = false)
   @Convert(converter = YesNoConverter::class)
-  val groupLeader: Boolean = false,
+  var groupLeader: Boolean = false,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -42,7 +42,5 @@ data class VisitOrderVisitor(
     return id == other.id
   }
 
-  override fun hashCode(): Int {
-    return Objects.hashCode(id)
-  }
+  override fun hashCode(): Int = Objects.hashCode(id)
 }


### PR DESCRIPTION
This might mitigate the locking on visit order visitor table

Not convinced this will fix the issue, but should reduce the occurrences since no DELETE will happen if no visitors removed.