### PR TITLE
SDIT-2090 Remove biometrics and corrected corporate nullability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResource.kt
@@ -171,10 +171,8 @@ data class ContactPerson(
   val deceasedDate: LocalDate?,
   @Schema(description = "True if a staff member")
   val isStaff: Boolean?,
-  @Schema(description = "No longer used in NOMIS since 2018")
+  @Schema(description = "Set to true when person created via finance remitter page")
   val isRemitter: Boolean?,
-  @Schema(description = "No longer used in NOMIS since 2019")
-  val keepBiometrics: Boolean,
   @Schema(description = "Audit data associated with the records")
   val audit: NomisAudit,
   @Schema(description = "List of phone numbers for the person")
@@ -268,7 +266,7 @@ data class PersonEmployment(
   @Schema(description = "Unique NOMIS sequence for this employment for this person")
   val sequence: Long,
   @Schema(description = "The entity the person is employed by")
-  val corporate: PersonEmploymentCorporate?,
+  val corporate: PersonEmploymentCorporate,
   @Schema(description = "True is employment is active")
   val active: Boolean,
   @Schema(description = "Audit data associated with the records")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
@@ -31,7 +31,6 @@ class ContactPersonService(private val personRepository: PersonRepository) {
       deceasedDate = it.deceasedDate,
       isStaff = it.isStaff,
       isRemitter = it.isRemitter,
-      keepBiometrics = it.keepBiometrics,
       audit = it.toAudit(),
       phoneNumbers = it.phones.map { number ->
         PersonPhoneNumber(
@@ -54,7 +53,7 @@ class ContactPersonService(private val personRepository: PersonRepository) {
           sequence = employment.id.sequence,
           active = employment.active,
           audit = employment.toAudit(),
-          corporate = employment.employerCorporate?.let { corporate ->
+          corporate = employment.employerCorporate.let { corporate ->
             PersonEmploymentCorporate(
               id = corporate.id,
               name = corporate.corporateName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/Person.kt
@@ -132,10 +132,6 @@ data class Person(
   @Convert(converter = YesNoConverter::class)
   val isRemitter: Boolean? = false,
 
-  @Column(name = "KEEP_BIOMETRICS")
-  @Convert(converter = YesNoConverter::class)
-  val keepBiometrics: Boolean = false,
-
   /* columns not mapped
   OCCUPATION_CODE - always null
   CRIMINAL_HISTORY_TEXT - always null
@@ -155,6 +151,7 @@ data class Person(
   CARE_OF - always null
   SUSPENDED_DATE - always null
   NAME_SEQUENCE - always null
+  KEEP_BIOMETRICS - not used in NOMIS
    */
 
 ) : NomisAuditableEntity() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonEmployment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/PersonEmployment.kt
@@ -36,7 +36,7 @@ class PersonEmployment(
 
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "EMPLOYER_CORP_ID", nullable = true)
-  val employerCorporate: Corporate?,
+  val employerCorporate: Corporate,
 
   /*
   Not mapped:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResourceIntTest.kt
@@ -57,7 +57,6 @@ class ContactPersonResourceIntTest : IntegrationTestBase() {
           deceasedDate = "2023-12-22",
           isStaff = true,
           isRemitter = true,
-          keepBiometrics = true,
           whoCreated = "KOFEADDY",
           whenCreated = LocalDateTime.parse("2020-01-01T10:00"),
         ) {
@@ -130,7 +129,6 @@ class ContactPersonResourceIntTest : IntegrationTestBase() {
           .jsonPath("deceasedDate").doesNotExist()
           .jsonPath("isStaff").doesNotExist()
           .jsonPath("isRemitter").doesNotExist()
-          .jsonPath("keepBiometrics").isEqualTo(false)
           .jsonPath("audit.createUsername").isNotEmpty
           .jsonPath("audit.createDatetime").isNotEmpty
       }
@@ -160,7 +158,6 @@ class ContactPersonResourceIntTest : IntegrationTestBase() {
           .jsonPath("deceasedDate").isEqualTo("2023-12-22")
           .jsonPath("isStaff").isEqualTo(true)
           .jsonPath("isRemitter").isEqualTo(true)
-          .jsonPath("keepBiometrics").isEqualTo(true)
           .jsonPath("audit.createUsername").isEqualTo("KOFEADDY")
           .jsonPath("audit.createDisplayName").isEqualTo("KOFE ADDY")
           .jsonPath("audit.createDatetime").isEqualTo("2020-01-01T10:00:00")
@@ -401,7 +398,7 @@ class ContactPersonResourceIntTest : IntegrationTestBase() {
               whoCreated = "KOFEADDY",
               whenCreated = LocalDateTime.parse("2020-01-01T10:00"),
             )
-            employment(active = false)
+            employment(employerCorporate = corporate, active = false)
           }
         }
       }
@@ -422,7 +419,7 @@ class ContactPersonResourceIntTest : IntegrationTestBase() {
           .jsonPath("employments[0].audit.createDisplayName").isEqualTo("KOFE ADDY")
           .jsonPath("employments[0].audit.createDatetime").isEqualTo("2020-01-01T10:00:00")
           .jsonPath("employments[1].sequence").isEqualTo(2)
-          .jsonPath("employments[1].corporate").doesNotExist()
+          .jsonPath("employments[1].corporate.name").isEqualTo("Police")
           .jsonPath("employments[1].active").isEqualTo(false)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
@@ -360,7 +360,6 @@ class NomisData(
     deceasedDate: String?,
     isStaff: Boolean?,
     isRemitter: Boolean?,
-    keepBiometrics: Boolean,
     whenCreated: LocalDateTime?,
     whoCreated: String?,
     dsl: PersonDsl.() -> Unit,
@@ -379,7 +378,6 @@ class NomisData(
         deceasedDate = deceasedDate?.let { LocalDate.parse(it) },
         isStaff = isStaff,
         isRemitter = isRemitter,
-        keepBiometrics = keepBiometrics,
         whenCreated = whenCreated,
         whoCreated = whoCreated,
       )
@@ -525,7 +523,6 @@ interface NomisDataDsl {
     deceasedDate: String? = null,
     isStaff: Boolean? = null,
     isRemitter: Boolean? = null,
-    keepBiometrics: Boolean = false,
     whenCreated: LocalDateTime? = null,
     whoCreated: String? = null,
     dsl: PersonDsl.() -> Unit = {},

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/Person.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/Person.kt
@@ -70,7 +70,7 @@ interface PersonDsl {
 
   @PersonEmploymentDslMarker
   fun employment(
-    employerCorporate: Corporate? = null,
+    employerCorporate: Corporate,
     active: Boolean = true,
     whenCreated: LocalDateTime? = null,
     whoCreated: String? = null,
@@ -168,7 +168,6 @@ class PersonBuilder(
     deceasedDate: LocalDate?,
     isStaff: Boolean?,
     isRemitter: Boolean?,
-    keepBiometrics: Boolean,
     whenCreated: LocalDateTime?,
     whoCreated: String?,
   ): Person = Person(
@@ -184,7 +183,6 @@ class PersonBuilder(
     deceasedDate = deceasedDate,
     isStaff = isStaff,
     isRemitter = isRemitter,
-    keepBiometrics = keepBiometrics,
   )
     .let { repository.save(it) }
     .also {
@@ -283,7 +281,7 @@ class PersonBuilder(
     }
 
   override fun employment(
-    employerCorporate: Corporate?,
+    employerCorporate: Corporate,
     active: Boolean,
     whenCreated: LocalDateTime?,
     whoCreated: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonEmployment.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/PersonEmployment.kt
@@ -40,7 +40,7 @@ class PersonEmploymentBuilder(val repository: PersonEmploymentBuilderRepository)
     person: Person,
     sequence: Long,
     active: Boolean,
-    employerCorporate: Corporate?,
+    employerCorporate: Corporate,
     whenCreated: LocalDateTime?,
     whoCreated: String?,
   ): PersonEmployment =


### PR DESCRIPTION
biometrics not used in NOMIS
Corporates and corporate names are nullable on database but not via NOMIS - so make non-nullable