### PR TITLE
SDIT-2301 Delete endpoints for all contact entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonResource.kt
@@ -432,6 +432,58 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
   ) = contactPersonService.updatePersonContact(personId, contactId, request)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping("/persons/{personId}/contact/{contactId}")
+  @Operation(
+    summary = "Deletes a person contact",
+    description = "Deletes a person contact; the relationship between a prisoner and a person. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Person Contact Updated, returned if in contact does not exist",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Contact does belong to person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonContact(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Contact Id", example = "75675")
+    @PathVariable
+    contactId: Long,
+  ) = contactPersonService.deletePersonContact(personId, contactId)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/contact/{contactId}/restriction")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
@@ -567,6 +619,60 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
   ) = contactPersonService.updatePersonContactRestriction(personId, contactId, contactRestrictionId, request)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @DeleteMapping("/persons/{personId}/contact/{contactId}/restriction/{contactRestrictionId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes a person contact restriction for a specific relationship",
+    description = "Deletes a person contact restriction; the restriction is for a specific relationship between a prisoner and a person. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The personId, ContactId or restrictionId exist but on other relationships",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonContactRestriction(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Contact Id", example = "67899")
+    @PathVariable
+    contactId: Long,
+    @Schema(description = "Restriction Id", example = "38383")
+    @PathVariable
+    contactRestrictionId: Long,
+  ) = contactPersonService.deletePersonContactRestriction(personId, contactId, contactRestrictionId)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/restriction")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
@@ -694,6 +800,57 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
     @RequestBody @Valid
     request: UpdateContactPersonRestrictionRequest,
   ) = contactPersonService.updatePersonRestriction(personId, personRestrictionId, request)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @DeleteMapping("/persons/{personId}/restriction/{personRestrictionId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes a global person restriction",
+    description = "Deletes a person restriction; the restriction is estate wide. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Restrictions exists but not for this person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonRestriction(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Person restrictions Id", example = "12345")
+    @PathVariable
+    personRestrictionId: Long,
+  ) = contactPersonService.deletePersonRestriction(personId, personRestrictionId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/address")
@@ -826,6 +983,58 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
   ) = contactPersonService.updatePersonAddress(personId = personId, addressId = addressId, request)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @DeleteMapping("/persons/{personId}/address/{addressId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes a person address",
+    description = "Deletes a person address in NOMIS. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "202",
+        description = "Person Address Deleted",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The address exist but not for this person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonAddress(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Address Id", example = "47474")
+    @PathVariable
+    addressId: Long,
+  ) = contactPersonService.deletePersonAddress(personId = personId, addressId = addressId)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/email")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
@@ -934,6 +1143,68 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
     @RequestBody @Valid
     request: UpdatePersonEmailRequest,
   ) = contactPersonService.updatePersonEmail(personId = personId, emailAddressId = emailAddressId, request = request)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping("/persons/{personId}/email/{emailAddressId}")
+  @Operation(
+    summary = "Deletes a person email",
+    description = "Deletes a person email in NOMIS. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Person Email ID aka InternetAddressId Delete",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "The email exist but not for this person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Person or email address does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonEmail(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Email address Id", example = "76554")
+    @PathVariable
+    emailAddressId: Long,
+  ) = contactPersonService.deletePersonEmail(personId = personId, emailAddressId = emailAddressId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/phone")
@@ -1064,6 +1335,58 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
     @RequestBody @Valid
     request: UpdatePersonPhoneRequest,
   ) = contactPersonService.updatePersonPhone(personId = personId, phoneId = phoneId, request)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping("/persons/{personId}/phone/{phoneId}")
+  @Operation(
+    summary = "Deleted a person global phone",
+    description = "Deletes a person global phone in NOMIS. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Person Phone ID Deleted",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Phone exists but not for this person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonPhone(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Phone Id", example = "35355")
+    @PathVariable
+    phoneId: Long,
+  ) = contactPersonService.deletePersonPhone(personId = personId, phoneId = phoneId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/address/{addressId}/phone")
@@ -1211,6 +1534,65 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
   )
 
   @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping("/persons/{personId}/address/{addressId}/phone/{phoneId}")
+  @Operation(
+    summary = "Deletes a person address phone",
+    description = "Deletes a person phone associated with an address in NOMIS. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Person Phone ID Deletes",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Phone exists but not for this address or address exists but not for this person",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletedPersonAddressPhone(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Address Id", example = "56789")
+    @PathVariable
+    addressId: Long,
+    @Schema(description = "Phone Id", example = "585850")
+    @PathVariable
+    phoneId: Long,
+  ) = contactPersonService.deletePersonAddressPhone(
+    personId = personId,
+    addressId = addressId,
+    phoneId = phoneId,
+  )
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
   @PostMapping("/persons/{personId}/identifier")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
@@ -1329,7 +1711,7 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
       ),
     ],
   )
-  fun udpdatePersonIdentifier(
+  fun updatePersonIdentifier(
     @Schema(description = "Person Id", example = "12345")
     @PathVariable
     personId: Long,
@@ -1339,6 +1721,58 @@ class ContactPersonResource(private val contactPersonService: ContactPersonServi
     @RequestBody @Valid
     request: UpdatePersonIdentifierRequest,
   ) = contactPersonService.updatePersonIdentifier(personId, sequence, request)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_CONTACTPERSONS')")
+  @DeleteMapping("/persons/{personId}/identifier/{sequence}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes a person identifier",
+    description = "Deletes a person identifier in NOMIS. Requires ROLE_NOMIS_CONTACTPERSONS",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Person Identifier deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_CONTACTPERSONS",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Person does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deletePersonIdentifier(
+    @Schema(description = "Person Id", example = "12345")
+    @PathVariable
+    personId: Long,
+    @Schema(description = "Identifier sequence", example = "4")
+    @PathVariable
+    sequence: Long,
+  ) = contactPersonService.deletePersonIdentifier(personId, sequence)
 }
 
 @Schema(description = "The data held in NOMIS about a person who is a contact for a prisoner")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
@@ -310,6 +310,13 @@ class ContactPersonService(
     }
   }
 
+  fun deletePersonContact(personId: Long, contactId: Long) {
+    contactRepository.findByIdOrNull(contactId)?.also {
+      if (it.person?.id != personId) throw BadDataException("Contact of $contactId does not exist on person $personId but does on person ${it.person?.id}")
+    }
+    contactRepository.deleteById(contactId)
+  }
+
   fun createPersonAddress(personId: Long, request: CreatePersonAddressRequest): CreatePersonAddressResponse = personAddressRepository.saveAndFlush(
     request.let {
       uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.PersonAddress(
@@ -359,6 +366,13 @@ class ContactPersonService(
     }
   }
 
+  fun deletePersonAddress(personId: Long, addressId: Long) {
+    personAddressRepository.findByIdOrNull(addressId)?.also {
+      if (it.person.id != personId) throw BadDataException("Address of $addressId does not exist on person $personId but does on person ${it.person.id}")
+    }
+    personAddressRepository.deleteById(addressId)
+  }
+
   fun createPersonEmail(personId: Long, request: CreatePersonEmailRequest): CreatePersonEmailResponse = personInternetAddressRepository.saveAndFlush(
     PersonInternetAddress(
       person = personOf(personId),
@@ -372,6 +386,13 @@ class ContactPersonService(
         internetAddress = it.email
       }
     }
+  }
+
+  fun deletePersonEmail(personId: Long, emailAddressId: Long) {
+    personInternetAddressRepository.findByIdOrNull(emailAddressId)?.also {
+      if (it.person.id != personId) throw BadDataException("Internet Address of $emailAddressId does not exist on person $personId but does on person ${it.person.id}")
+    }
+    personInternetAddressRepository.deleteById(emailAddressId)
   }
 
   fun createPersonPhone(personId: Long, request: CreatePersonPhoneRequest): CreatePersonPhoneResponse = personPhoneRepository.saveAndFlush(
@@ -393,6 +414,13 @@ class ContactPersonService(
     }
   }
 
+  fun deletePersonPhone(personId: Long, phoneId: Long) {
+    personPhoneRepository.findByIdOrNull(phoneId)?.also {
+      if (it.person.id != personId) throw BadDataException("Phone of $phoneId does not exist on person $personId but does on person ${it.person.id}")
+    }
+    personPhoneRepository.deleteById(phoneId)
+  }
+
   fun updatePersonAddressPhone(personId: Long, addressId: Long, phoneId: Long, request: UpdatePersonPhoneRequest) {
     phoneOf(personId = personId, addressId = addressId, phoneId = phoneId).run {
       request.also {
@@ -411,6 +439,17 @@ class ContactPersonService(
       phoneType = phoneTypeOf(request.typeCode),
     ),
   ).let { CreatePersonPhoneResponse(phoneId = it.phoneId) }
+
+  fun deletePersonAddressPhone(personId: Long, addressId: Long, phoneId: Long) {
+    addressPhoneRepository.findByIdOrNull(phoneId)?.also {
+      if (it.address.addressId != addressId) throw BadDataException("Phone of $phoneId does not exist on address $addressId but does on person ${it.address.addressId}")
+    }
+    personAddressRepository.findByIdOrNull(addressId)?.also {
+      if (it.person.id != personId) throw BadDataException("Address of $addressId does not exist on person $personId but does on person ${it.person.id}")
+    }
+
+    addressPhoneRepository.deleteById(phoneId)
+  }
 
   fun createPersonIdentifier(personId: Long, request: CreatePersonIdentifierRequest): CreatePersonIdentifierResponse = personOf(personId).let { person ->
     personIdentifierRepository.saveAndFlush(
@@ -432,20 +471,10 @@ class ContactPersonService(
       }
     }
   }
-  fun createPersonContactRestriction(
-    personId: Long,
-    contactId: Long,
-    request: CreateContactPersonRestrictionRequest,
-  ): CreateContactPersonRestrictionResponse = personContactRestrictionRepository.saveAndFlush(
-    OffenderPersonRestrict(
-      restrictionType = restrictionTypeOf(request.typeCode),
-      contactPerson = contactOf(personId = personId, contactId = contactId),
-      comment = request.comment,
-      effectiveDate = request.effectiveDate,
-      expiryDate = request.expiryDate,
-      enteredStaff = staffOf(username = request.enteredStaffUsername),
-    ),
-  ).let { CreateContactPersonRestrictionResponse(id = it.id) }
+
+  fun deletePersonIdentifier(personId: Long, sequence: Long) {
+    personIdentifierRepository.deleteById(PersonIdentifierPK(person = personOf(personId), sequence = sequence))
+  }
 
   fun createPersonRestriction(
     personId: Long,
@@ -477,6 +506,28 @@ class ContactPersonService(
     }
   }
 
+  fun deletePersonRestriction(personId: Long, personRestrictionId: Long) {
+    personRestrictionRepository.findByIdOrNull(personRestrictionId)?.also {
+      if (it.person.id != personId) throw BadDataException("Restriction of $personRestrictionId does not exist on person $personId but does on person ${it.person.id}")
+    }
+    personRestrictionRepository.deleteById(personRestrictionId)
+  }
+
+  fun createPersonContactRestriction(
+    personId: Long,
+    contactId: Long,
+    request: CreateContactPersonRestrictionRequest,
+  ): CreateContactPersonRestrictionResponse = personContactRestrictionRepository.saveAndFlush(
+    OffenderPersonRestrict(
+      restrictionType = restrictionTypeOf(request.typeCode),
+      contactPerson = contactOf(personId = personId, contactId = contactId),
+      comment = request.comment,
+      effectiveDate = request.effectiveDate,
+      expiryDate = request.expiryDate,
+      enteredStaff = staffOf(username = request.enteredStaffUsername),
+    ),
+  ).let { CreateContactPersonRestrictionResponse(id = it.id) }
+
   fun updatePersonContactRestriction(
     personId: Long,
     contactId: Long,
@@ -492,6 +543,17 @@ class ContactPersonService(
       restriction.expiryDate = expiryDate
       restriction.enteredStaff = staffOf(username = enteredStaffUsername)
     }
+  }
+
+  fun deletePersonContactRestriction(personId: Long, contactId: Long, contactRestrictionId: Long) {
+    personContactRestrictionRepository.findByIdOrNull(contactRestrictionId)?.also {
+      if (it.contactPerson.id != contactId) throw BadDataException("Contact Restriction of $contactRestrictionId does not exist on contact $contactId but does on contact ${it.contactPerson.id}")
+    }
+    contactRepository.findByIdOrNull(contactId)?.also {
+      if (it.person?.id != personId) throw BadDataException("Contact of $contactId does not exist on person $personId but does on person ${it.person?.id}")
+    }
+
+    personContactRestrictionRepository.deleteById(contactRestrictionId)
   }
 
   fun assertDoesNotExist(request: CreatePersonRequest) {


### PR DESCRIPTION
Will return 204 for delete or if the entity does not exist. The exception is identifier that is a composite key so 404 for not found makes more sense if person is not found.

400 when the combination of child / parents entities do not match since this indicates a client coding issue.