### PR TITLE
SDIT-2369 Truncate Alert comment text to 4000

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.adjudications
 
-import com.google.common.base.Utf8
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
@@ -13,6 +12,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.CodeDescription
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.toCodeDescription
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.truncateToUtf8Length
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.usernamePreferringGeneralAccount
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationEvidence
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationEvidenceType
@@ -1360,9 +1360,3 @@ fun AdjudicationHearingResultAward.toAward(isConsecutiveAward: Boolean = false):
       null
     },
   )
-
-fun String.truncateToUtf8Length(maxLength: Int): String {
-  // ensure doesn't exceed number of bytes Oracle can take
-  val tooBigBy = Utf8.encodedLength(this) - maxLength
-  return this.take(this.length - tooBigBy)
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/alerts/AlertsService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.toCodeDescription
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.NomisAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.truncateToUtf8Length
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertCode
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AlertStatus.INACTIVE
@@ -61,7 +62,7 @@ class AlertsService(
       authorizePersonText = request.authorisedBy,
       alertStatus = if (request.isActive) ACTIVE else INACTIVE,
       verifiedFlag = false,
-      commentText = request.comment,
+      commentText = request.comment?.truncateToUtf8Length(4000),
       createUsername = request.createUsername,
     )
     alert.addWorkFlowLog(workActionCode = workActionCode)
@@ -102,7 +103,7 @@ class AlertsService(
           authorizePersonText = request.authorisedBy,
           alertStatus = if (request.isActive) ACTIVE else INACTIVE,
           verifiedFlag = false,
-          commentText = request.comment,
+          commentText = request.comment?.truncateToUtf8Length(4000),
           createUsername = request.createUsername,
         ).also {
           it.addWorkFlowLog(workActionCode = workActionCode)
@@ -130,7 +131,7 @@ class AlertsService(
 
     alert.expiryDate = request.expiryDate
     alert.alertStatus = if (request.isActive) ACTIVE else INACTIVE
-    alert.commentText = request.comment
+    alert.commentText = request.comment?.truncateToUtf8Length(4000)
     alert.modifyUserId = request.updateUsername
     alert.modifyDatetime = LocalDateTime.now()
     alert.alertDate = request.date

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helpers/StringUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helpers/StringUtils.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers
+
+import com.google.common.base.Utf8
+
+fun String.truncateToUtf8Length(maxLength: Int): String {
+  // ensure doesn't exceed number of bytes Oracle can take
+  return this.truncateByOneCharacterUntilFitToUtf8Length(maxLength)
+}
+
+private fun String.truncateByOneCharacterUntilFitToUtf8Length(maxLength: Int): String {
+  // so we don't cut into a double/triple byte character while truncating check
+  // we still have a valid string before returning, even if it fits the number of bytes
+  if (this.isStillValid() && Utf8.encodedLength(this) <= maxLength) return this
+  // Keep knocking of the last character until it fits the number of bytes and remains a valid string
+  return this.take(this.length - 1).truncateByOneCharacterUntilFitToUtf8Length(maxLength)
+}
+
+// Utf8.encodedLength will throw if the resulting String is cut at the incorrect boundary
+private fun String.isStillValid(): Boolean =
+  runCatching { Utf8.encodedLength(this) }.map { true }.getOrDefault(false)

--- a/src/main/resources/db/migration/V1_53__OFFENDER_ALERTS.sql
+++ b/src/main/resources/db/migration/V1_53__OFFENDER_ALERTS.sql
@@ -11,7 +11,7 @@ CREATE TABLE "OFFENDER_ALERTS"
   "ALERT_STATUS"                  VARCHAR2(12 CHAR)                 NOT NULL ,
   "VERIFIED_FLAG"                 VARCHAR2(1 CHAR) DEFAULT 'N'      NOT NULL ,
   "EXPIRY_DATE"                   DATE,
-  "COMMENT_TEXT"                  VARCHAR2(1000 CHAR),
+  "COMMENT_TEXT"                  VARCHAR2(4000 CHAR),
   "CASELOAD_ID"                   VARCHAR2(6 CHAR),
   "MODIFY_USER_ID"                VARCHAR2(32 CHAR),
   "MODIFY_DATETIME"               TIMESTAMP(9),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helpers/TruncateToUtf8LengthTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helpers/TruncateToUtf8LengthTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.nomisprisonerapi.adjudications
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers
 
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.jupiter.api.Test
@@ -25,7 +25,12 @@ class TruncateToUtf8LengthTest {
   }
 
   @Test
-  fun `will truncate when too big with huge byte characters`() {
+  fun `will truncate when too big with huge byte characters at beginning`() {
     assertThat("😀123456789".truncateToUtf8Length(10)).isEqualTo("😀123456")
+  }
+
+  @Test
+  fun `will truncate when too big with huge byte characters at end`() {
+    assertThat("123456789😀".truncateToUtf8Length(10)).isEqualTo("123456789")
   }
 }


### PR DESCRIPTION
Improve the truncate function to deal with multi-byte chars at the end of String.

Move to Util file as well so used for adjudications and alerts