### PR TITLE
SDIT-2384 Use sub-select GET /bookings/ids/latest-from-id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
@@ -48,15 +48,16 @@ interface OffenderBookingRepository :
 
   @Query(
     """
-      select 
-       o.OFFENDER_ID_DISPLAY as prisonerid, 
-       b.OFFENDER_BOOK_ID    as bookingid
-      from OFFENDER_BOOKINGS b join OFFENDERS o on b.offender_id = o.offender_id
-      where OFFENDER_BOOK_ID > :bookingId
-        and b.BOOKING_SEQ = 1
-        and b.ACTIVE_FLAG = 'Y'
-        and rownum <= :pageSize
-      order by OFFENDER_BOOK_ID
+      select * from (
+        select 
+         o.OFFENDER_ID_DISPLAY as prisonerid, 
+         b.OFFENDER_BOOK_ID    as bookingid
+        from OFFENDER_BOOKINGS b join OFFENDERS o on b.offender_id = o.offender_id
+        where OFFENDER_BOOK_ID > :bookingId
+          and b.BOOKING_SEQ = 1
+          and b.ACTIVE_FLAG = 'Y'
+        order by OFFENDER_BOOK_ID) 
+      where rownum <= :pageSize
     """,
     nativeQuery = true,
   )


### PR DESCRIPTION
Needed since the booking filters seems to alter the order that Oracle returns the results by default; so order by in the sub-select so runnum() is guaranteed to work