### PR TITLE
Revert "SDIT-2423 Migrate activities with allocations in the last 6 months (#1070)"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/activities/AllocationService.kt
@@ -99,7 +99,7 @@ class AllocationService(
         courseActivityId = it.courseActivity.courseActivityId,
         nomisId = it.offenderBooking.offender.nomsId,
         bookingId = it.offenderBooking.bookingId,
-        startDate = it.startDate!!,
+        startDate = it.startDate,
         endDate = it.endDate,
         endComment = it.endComment,
         endReasonCode = it.endReason?.code,
@@ -146,7 +146,7 @@ class AllocationService(
       ?: newAllocation(request, offenderBooking, courseActivity, requestedPayBand)
 
     return allocation.apply {
-      startDate = if (allocation.startDate!! > LocalDate.now()) request.startDate else allocation.startDate
+      startDate = if (allocation.startDate > LocalDate.now()) request.startDate else allocation.startDate
       endDate = request.endDate
       endReason = requestedEndReason
       suspended = request.suspended ?: false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderProgramProfile.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderProgramProfile.kt
@@ -39,7 +39,7 @@ data class OffenderProgramProfile(
   var program: ProgramService,
 
   @Column(name = "OFFENDER_START_DATE")
-  var startDate: LocalDate?,
+  var startDate: LocalDate,
 
   @ManyToOne(optional = false)
   @NotFound(action = NotFoundAction.IGNORE)
@@ -113,4 +113,8 @@ data class OffenderProgramProfile(
       .filter { profilePayBands -> profilePayBands.endDate == null }
       .any { profilePayBands -> profilePayBands.payBand.code == payBandCode }
   }
+
+  fun isActive() = programStatus.code == "ALLOC" &&
+    startDate <= LocalDate.now() &&
+    (endDate == null || endDate!! >= LocalDate.now())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourseActivityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourseActivityRepository.kt
@@ -26,13 +26,16 @@ interface CourseActivityRepository : JpaRepository<CourseActivity, Long> {
       (
        select distinct(opp.courseActivity.courseActivityId) 
        from OffenderProgramProfile opp
+       join OffenderBooking ob on opp.offenderBooking = ob
        where opp.prison.id = :prisonId 
-       and opp.startDate is not null
-       and (opp.endDate is null or opp.endDate >= :oldestAllocation)
+       and opp.programStatus.code = 'ALLOC'
+       and (opp.endDate is null or opp.endDate > current_date)
+       and ob.active = true
+       and ob.location.id = :prisonId
       )   
   """,
   )
-  fun findActiveActivities(prisonId: String, courseActivityId: Long?, pageRequest: Pageable, oldestAllocation: LocalDate = LocalDate.now().minusMonths(6)): Page<Long>
+  fun findActiveActivities(prisonId: String, courseActivityId: Long?, pageRequest: Pageable): Page<Long>
 
   @Query(
     value = """
@@ -56,15 +59,18 @@ interface CourseActivityRepository : JpaRepository<CourseActivity, Long> {
       (
        select distinct(opp.courseActivity.courseActivityId) 
        from OffenderProgramProfile opp
+       join OffenderBooking ob on opp.offenderBooking = ob
        where opp.prison.id = :prisonId 
-       and opp.startDate is not null
-       and (opp.endDate is null or opp.endDate >= :oldestAllocation)
+       and opp.programStatus.code = 'ALLOC'
+       and (opp.endDate is null or opp.endDate > current_date)
+       and ob.active = true
+       and ob.location.id = :prisonId
       )   
     and (capr.endDate is null or capr.endDate > current_date)
     and pil.iepLevelCode is null
   """,
   )
-  fun findPayRatesWithUnknownIncentive(prisonId: String, courseActivityId: Long?, oldestAllocation: LocalDate = LocalDate.now().minusMonths(6)): List<PayRateWithUnknownIncentive>
+  fun findPayRatesWithUnknownIncentive(prisonId: String, courseActivityId: Long?): List<PayRateWithUnknownIncentive>
 
   @Query(
     value = """
@@ -83,13 +89,16 @@ interface CourseActivityRepository : JpaRepository<CourseActivity, Long> {
       (
        select distinct(opp.courseActivity.courseActivityId) 
        from OffenderProgramProfile opp
+       join OffenderBooking ob on opp.offenderBooking = ob
        where opp.prison.id = :prisonId 
-       and opp.startDate is not null
-       and (opp.endDate is null or opp.endDate >= :oldestAllocation)
+       and opp.programStatus.code = 'ALLOC'
+       and (opp.endDate is null or opp.endDate > current_date)
+       and ob.active = true
+       and ob.location.id = :prisonId
       )   
   """,
   )
-  fun findActivitiesWithoutScheduleRules(prisonId: String, courseActivityId: Long?, oldestAllocation: LocalDate = LocalDate.now().minusMonths(6)): List<ActivityWithoutScheduleRule>
+  fun findActivitiesWithoutScheduleRules(prisonId: String, courseActivityId: Long?): List<ActivityWithoutScheduleRule>
 
   @Modifying
   @Query(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourseAllocation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourseAllocation.kt
@@ -91,7 +91,7 @@ class CourseAllocationBuilder(
   ) = OffenderProgramProfile(
     offenderBooking = offenderBooking,
     program = courseActivity.program,
-    startDate = startDate?.let { LocalDate.parse(startDate) },
+    startDate = LocalDate.parse(startDate),
     programStatus = programStatus(programStatusCode),
     courseActivity = courseActivity,
     prison = courseActivity.prison,


### PR DESCRIPTION
Reverting because I did some before and after tests one of the endpoints in preprod for a handful of prisons, and in some cases there were a LOT of additional activities included in the migration. I need to investigate these first before going live.

Thinking about it I should have just run the endpoint against preprod locally... I'll do that before putting this change back in.

This reverts commit d8ea7713b29508536c756aac8a4dce52d4b0adc5.