### PR TITLE
SDIT-2553 revert appointment comment changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentService.kt
@@ -65,7 +65,7 @@ class AppointmentService(
         endTime = dto.endTime?.let { LocalDateTime.of(dto.eventDate, it) }
         eventDate = dto.eventDate
         eventSubType = subType
-        comment = formatComment(eventSubType, dto.comment)
+        comment = dto.comment
 
         telemetryClient.trackEvent(
           "appointment-updated",
@@ -155,6 +155,13 @@ class AppointmentService(
     val eventSubType = eventSubTypeRepository.findByIdOrNull(EventSubType.pk(dto.eventSubType))
       ?: throw BadDataException("EventSubType with code=${dto.eventSubType} does not exist")
 
+    val subTypeDescription = eventSubType.description.trim()
+    val comment = when {
+      dto.comment == null -> subTypeDescription
+      dto.comment.startsWith(subTypeDescription) -> dto.comment
+      else -> "$subTypeDescription - ${dto.comment}".take(4000)
+    }
+
     return OffenderIndividualSchedule(
       offenderBooking = offenderBooking,
       eventDate = dto.eventDate,
@@ -164,7 +171,7 @@ class AppointmentService(
       eventStatus = eventStatusRepository.findById(EventStatus.SCHEDULED_APPROVED).orElseThrow(),
       internalLocation = location,
       eventSubType = eventSubType,
-      comment = formatComment(eventSubType, dto.comment),
+      comment = comment,
     )
   }
 
@@ -217,15 +224,6 @@ class AppointmentService(
         count = it.getAppointmentCount(),
       )
     }
-}
-
-private fun formatComment(eventSubType: EventSubType, comment: String?): String {
-  val subTypeDescription = eventSubType.description.trim()
-  return when {
-    comment == null -> subTypeDescription
-    comment.startsWith(subTypeDescription) -> comment
-    else -> "$subTypeDescription - $comment".take(4000)
-  }
 }
 
 private fun mapModel(entity: OffenderIndividualSchedule): AppointmentResponse = AppointmentResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentService.kt
@@ -155,13 +155,6 @@ class AppointmentService(
     val eventSubType = eventSubTypeRepository.findByIdOrNull(EventSubType.pk(dto.eventSubType))
       ?: throw BadDataException("EventSubType with code=${dto.eventSubType} does not exist")
 
-    val subTypeDescription = eventSubType.description.trim()
-    val comment = when {
-      dto.comment == null -> subTypeDescription
-      dto.comment.startsWith(subTypeDescription) -> dto.comment
-      else -> "$subTypeDescription - ${dto.comment}".take(4000)
-    }
-
     return OffenderIndividualSchedule(
       offenderBooking = offenderBooking,
       eventDate = dto.eventDate,
@@ -171,7 +164,7 @@ class AppointmentService(
       eventStatus = eventStatusRepository.findById(EventStatus.SCHEDULED_APPROVED).orElseThrow(),
       internalLocation = location,
       eventSubType = eventSubType,
-      comment = comment,
+      comment = dto.comment,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/appointments/AppointmentsResourceIntTest.kt
@@ -33,11 +33,11 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
   lateinit var offenderAtMoorlands: Offender
   lateinit var offenderAtOtherPrison: Offender
 
-  private fun callCreateEndpoint(body: String = validCreateJsonRequest()): Long {
+  private fun callCreateEndpoint(hasEndTime: Boolean, inCell: Boolean = false): Long {
     val response = webTestClient.post().uri("/appointments")
       .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
       .contentType(MediaType.APPLICATION_JSON)
-      .body(BodyInserters.fromValue(body))
+      .body(BodyInserters.fromValue(validCreateJsonRequest(hasEndTime, inCell)))
       .exchange()
       .expectStatus().isCreated
       .expectBody(CreateAppointmentResponse::class.java)
@@ -46,13 +46,13 @@ class AppointmentsResourceIntTest : IntegrationTestBase() {
     return response!!.eventId
   }
 
-  private fun validCreateJsonRequest(hasEndTime: Boolean = false, inCell: Boolean = false, eventSubType: String = "ACTI") = """{
+  private fun validCreateJsonRequest(hasEndTime: Boolean, inCell: Boolean) = """{
             "bookingId"          : ${offenderAtMoorlands.latestBooking().bookingId},
             "eventDate"          : "2023-02-27",
             "startTime"          : "10:40",
 ${if (hasEndTime) """ "endTime"   : "12:10",""" else ""}
 ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
-            "eventSubType"       : "$eventSubType"
+            "eventSubType"       : "ACTI"
           }
   """.trimIndent()
 
@@ -250,7 +250,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will create appointment with correct details`() {
-      val id = callCreateEndpoint(validCreateJsonRequest(hasEndTime = true))
+      val id = callCreateEndpoint(true, false)
 
       // Check the database
       val offenderIndividualSchedule = repository.getAppointment(id)!!
@@ -270,7 +270,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will create appointment with correct details - no end time`() {
-      val id = callCreateEndpoint()
+      val id = callCreateEndpoint(false, false)
 
       val offenderIndividualSchedule = repository.getAppointment(id)!!
 
@@ -281,42 +281,12 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will create appointment with correct details - in cell`() {
-      val id = callCreateEndpoint(validCreateJsonRequest(inCell = true))
+      val id = callCreateEndpoint(false, true)
 
       val offenderIndividualSchedule = repository.getAppointment(id)!!
 
       assertThat(offenderIndividualSchedule.eventId).isEqualTo(id)
       assertThat(offenderIndividualSchedule.internalLocation?.locationId).isEqualTo(-3009) // cell
-    }
-
-    @Test
-    fun `will add event sub type to comments`() {
-      val request = validCreateJsonRequest(eventSubType = "CHAP").replace("}", """, "comment": "Prayers"}""")
-      val eventId = callCreateEndpoint(request)
-
-      with(repository.getAppointment(eventId)!!) {
-        assertThat(comment).isEqualTo("Chaplaincy - Prayers")
-      }
-    }
-
-    @Test
-    fun `will not duplicate event sub type`() {
-      val request = validCreateJsonRequest(eventSubType = "CHAP").replace("}", """, "comment": "Chaplaincy - Prayers"}""")
-      val eventId = callCreateEndpoint(request)
-
-      with(repository.getAppointment(eventId)!!) {
-        assertThat(comment).isEqualTo("Chaplaincy - Prayers")
-      }
-    }
-
-    @Test
-    fun `will handle max comment plus event sub type`() {
-      val request = validCreateJsonRequest(eventSubType = "CHAP").replace("}", """, "comment": "${"x".repeat(4000)}"}""")
-      val eventId = callCreateEndpoint(request)
-
-      with(repository.getAppointment(eventId)!!) {
-        assertThat(comment).startsWith("Chaplaincy - xxxxxxxxxxxx")
-      }
     }
   }
 
@@ -370,7 +340,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `access with room not found`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
         .body(BodyInserters.fromValue(updateAppointmentRequest().copy(internalLocationId = 999998)))
@@ -383,7 +353,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `EventSubType does not exist`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
         .body(BodyInserters.fromValue(updateAppointmentRequest().copy(eventSubType = "INVALID")))
@@ -396,7 +366,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `end time before start`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
         .body(BodyInserters.fromValue(updateAppointmentRequest().copy(endTime = LocalTime.of(7, 0))))
@@ -411,7 +381,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
     fun `invalid start time should return bad request`() {
       val invalidSchedule =
         validUpdateJsonRequest(false).replace(""""startTime"          : "10:50"""", """"startTime": "11:65",""")
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .contentType(MediaType.APPLICATION_JSON)
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
@@ -425,8 +395,8 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `invalid end time should return bad request`() {
-      val invalidSchedule = validUpdateJsonRequest(hasEndTime = true).replace(""""endTime"   : "12:20"""", """"endTime": "12:65"""")
-      val eventId = callCreateEndpoint()
+      val invalidSchedule = validUpdateJsonRequest(true).replace(""""endTime"   : "12:20"""", """"endTime": "12:65"""")
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .contentType(MediaType.APPLICATION_JSON)
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
@@ -444,7 +414,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
         """"eventDate"          : "2023-02-28"""",
         """"eventDate": "2022-13-31",""",
       )
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       webTestClient.put().uri("/appointments/$eventId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_APPOINTMENTS")))
         .contentType(MediaType.APPLICATION_JSON)
@@ -458,7 +428,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will update appointment with correct details`() {
-      val eventId = callCreateEndpoint(validCreateJsonRequest(hasEndTime = true))
+      val eventId = callCreateEndpoint(true)
       callUpdateEndpoint(eventId, true)
 
       // Check the database
@@ -479,7 +449,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will update appointment with correct details - no end time`() {
-      val eventId = callCreateEndpoint(validCreateJsonRequest(hasEndTime = true))
+      val eventId = callCreateEndpoint(true)
       callUpdateEndpoint(eventId, false)
 
       // Check the database
@@ -493,7 +463,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID,"""}
 
     @Test
     fun `will update appointment with correct details - in cell`() {
-      val eventId = callCreateEndpoint(validCreateJsonRequest(hasEndTime = true))
+      val eventId = callCreateEndpoint(true, false)
       callUpdateEndpoint(eventId, false, true)
 
       // Check the database
@@ -559,7 +529,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID_2,"""}
 
     @Test
     fun `will cancel appointment correctly`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       callCancelEndpoint(eventId)
 
       // Check the database
@@ -606,7 +576,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID_2,"""}
 
     @Test
     fun `will uncancel appointment correctly`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       callCancelEndpoint(eventId)
       callUncancelEndpoint(eventId)
 
@@ -654,7 +624,7 @@ ${if (inCell) "" else """ "internalLocationId" : $MDI_ROOM_ID_2,"""}
 
     @Test
     fun `will delete appointment correctly`() {
-      val eventId = callCreateEndpoint()
+      val eventId = callCreateEndpoint(false)
       callDeleteEndpoint(eventId)
 
       // Check the database


### PR DESCRIPTION
I thought DPS were going to stop sending the customName field to us in all cases - in which case we'd need to add the internal schedule reason to the comment on our side. Turns out they are only going to stop sending custom name if it's the same as the internal schedule reason - so we have nothing to do on our side