### PR TITLE
SDIT-2518 Zero days adjustments - keep status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentService.kt
@@ -51,7 +51,7 @@ class SentencingAdjustmentService(
           fromDate = request.adjustmentFromDate,
           toDate = request.adjustmentFromDate.asToDate(request.adjustmentDays),
           comment = request.comment,
-          active = request.active.takeUnlessZeroDays(request.adjustmentDays),
+          active = request.active,
         ),
       ).id
       telemetryClient.trackEvent(
@@ -79,13 +79,9 @@ class SentencingAdjustmentService(
       this.fromDate = request.adjustmentFromDate
       this.toDate = request.adjustmentFromDate.asToDate(request.adjustmentDays)
       this.comment = request.comment
-      if (request.adjustmentDays == 0L) {
-        this.active = false
-      } else {
-        request.active?.also {
-          // only set when supplied - currently DPS never overwrite this
-          this.active = it
-        }
+      request.active?.also {
+        // only set when supplied - currently DPS never overwrite this
+        this.active = it
       }
       this.sentenceSequence = sentence.id.sequence
       telemetryClient.trackEvent(
@@ -150,7 +146,7 @@ class SentencingAdjustmentService(
         fromDate = request.adjustmentFromDate,
         toDate = request.adjustmentFromDate.asToDate(request.adjustmentDays),
         comment = request.comment,
-        active = request.active.takeUnlessZeroDays(request.adjustmentDays),
+        active = request.active,
       ),
     ).id
     telemetryClient.trackEvent(
@@ -179,13 +175,9 @@ class SentencingAdjustmentService(
     this.fromDate = request.adjustmentFromDate
     this.toDate = request.adjustmentFromDate.asToDate(request.adjustmentDays)
     this.comment = request.comment
-    if (request.adjustmentDays == 0L) {
-      this.active = false
-    } else {
-      request.active?.also {
-        // only set when supplied - currently DPS never overwrite this
-        this.active = it
-      }
+    request.active?.also {
+      // only set when supplied - currently DPS never overwrite this
+      this.active = it
     }
     entityManager.flush()
     storedProcedureRepository.postKeyDateAdjustmentUpsert(
@@ -298,8 +290,3 @@ private fun OffenderSentenceAdjustment.toAdjustmentResponse() = SentenceAdjustme
 
 // dates are inclusive so a 1-day remand starts and end on dame day - unless zero days so have no toDate else it would be the day before
 private fun LocalDate?.asToDate(adjustmentDays: Long) = this?.takeIf { adjustmentDays > 0 }?.plusDays(adjustmentDays - 1)
-private fun Boolean.takeUnlessZeroDays(adjustmentDays: Long) = if (adjustmentDays == 0L) {
-  false
-} else {
-  this
-}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingAdjustmentsResourceIntTest.kt
@@ -370,7 +370,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `Adjustment with 0 days is made inactive and as no TO date`() {
+      fun `Adjustment with 0 days has no TO DATE`() {
         val adjustmentId = webTestClient.post().uri("/prisoners/booking-id/$bookingId/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
@@ -404,7 +404,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
           .jsonPath("adjustmentFromDate").isEqualTo("2023-01-01")
           .jsonPath("adjustmentToDate").doesNotExist()
           .jsonPath("adjustmentDays").isEqualTo("0")
-          .jsonPath("active").isEqualTo(false)
+          .jsonPath("active").isEqualTo(true)
 
         verify(spRepository).postKeyDateAdjustmentUpsert(
           eq(adjustmentId),
@@ -698,7 +698,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `updating an adjustment to zero days removed the to date and makes it inactive`() {
+      fun `updating an adjustment to zero days removes the TO DATE`() {
         webTestClient.put().uri("/key-date-adjustments/$adjustmentId")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
@@ -709,7 +709,8 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
               "adjustmentDays": 0,
               "adjustmentTypeCode": "ADA",
               "adjustmentDate": "2023-01-18",
-              "adjustmentFromDate": "2023-01-02"
+              "adjustmentFromDate": "2023-01-02",
+              "active": true
               }
               """,
             ),
@@ -730,7 +731,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
           .jsonPath("adjustmentFromDate").isEqualTo("2023-01-02")
           .jsonPath("adjustmentToDate").doesNotExist()
           .jsonPath("adjustmentDays").isEqualTo(0)
-          .jsonPath("active").isEqualTo(false)
+          .jsonPath("active").isEqualTo(true)
       }
 
       @Test
@@ -1348,7 +1349,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `Adjustment with 0 days is made inactive and as no TO date`() {
+      fun `Adjustment with 0 days has no TO DATE`() {
         val sentenceAdjustmentId = webTestClient.post().uri("/prisoners/booking-id/$bookingId/sentences/1/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
@@ -1382,7 +1383,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
           .jsonPath("adjustmentFromDate").isEqualTo("2023-01-01")
           .jsonPath("adjustmentToDate").doesNotExist()
           .jsonPath("adjustmentDays").isEqualTo(0)
-          .jsonPath("active").isEqualTo(false)
+          .jsonPath("active").isEqualTo(true)
       }
 
       @Test
@@ -1820,7 +1821,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `updating an adjustment to zero days removes the to date and makes it inactive`() {
+      fun `updating an adjustment to zero days removes the TO DATE`() {
         webTestClient.put().uri("/sentence-adjustments/$sentenceAdjustmentId")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
@@ -1855,7 +1856,7 @@ class SentencingAdjustmentsResourceIntTest : IntegrationTestBase() {
           .jsonPath("adjustmentFromDate").isEqualTo("2023-01-02")
           .jsonPath("adjustmentToDate").doesNotExist()
           .jsonPath("adjustmentDays").isEqualTo("0")
-          .jsonPath("active").isEqualTo(false)
+          .jsonPath("active").isEqualTo(true)
       }
 
       @Test


### PR DESCRIPTION
Original fix was to toggle the status of adjustments that are 0 days to inactive so the DPS CRDS ignores them. This caused a secondary issue for some adjustments; instead DPS CRDS will be changed to ignore the TO DATE for zero day adjustments. The TO DATE will continue not to be written for zero day adjustments since that makes more sense than have a TO DATE before the FROM DATE that was the previous functionality.