### PR TITLE
SDIT-2764 Changed recall to accept a list of recall sentence types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResource.kt
@@ -738,6 +738,7 @@ class SentencingResource(private val sentencingService: SentencingService) {
       ),
     ],
   )
+  @Deprecated(message = "Use POST /prisoners/{offenderNo}/sentences/recall")
   fun recallSentences(
     @Schema(description = "Offender no", example = "AA668EC", required = true)
     @PathVariable
@@ -745,6 +746,87 @@ class SentencingResource(private val sentencingService: SentencingService) {
     @RequestBody @Valid
     request: CreateRecallRequest,
   ) = sentencingService.recallSentences(
+    offenderNo = offenderNo,
+    request = request,
+  )
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
+  @PostMapping("/prisoners/{offenderNo}/sentences/recall")
+  @Operation(
+    summary = "Recalls Sentences by convert the specified sentences to the requested recall sentence",
+    description = "Required role NOMIS_SENTENCING Recalls sentences for the offender",
+    requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+      content = [
+        Content(
+          mediaType = "application/json",
+          schema = Schema(implementation = ConvertToRecallRequest::class),
+        ),
+      ],
+    ),
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Sentences converted to recall",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Supplied data is invalid, for instance missing required fields or invalid values. See schema for details",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint when role NOMIS_SENTENCING not present",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Booking does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "One or more sentence does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun convertToRecallSentences(
+    @Schema(description = "Offender no", example = "AA668EC", required = true)
+    @PathVariable
+    offenderNo: String,
+    @RequestBody @Valid
+    request: ConvertToRecallRequest,
+  ) = sentencingService.convertToRecallSentences(
     offenderNo = offenderNo,
     request = request,
   )
@@ -2125,6 +2207,19 @@ data class CreateRecallRequest(
   val sentenceCalcType: String,
   val sentenceIds: List<SentenceId>,
   val returnToCustody: ReturnToCustodyRequest? = null,
+)
+
+@Schema(description = "Recall convert request")
+data class ConvertToRecallRequest(
+  val sentences: List<RecallSentenceDetails>,
+  val returnToCustody: ReturnToCustodyRequest? = null,
+)
+
+@Schema(description = "Recall sentences to set")
+data class RecallSentenceDetails(
+  val sentenceId: SentenceId,
+  val sentenceCategory: String,
+  val sentenceCalcType: String,
 )
 
 @Schema(description = "Sentence term request")


### PR DESCRIPTION
When recalling not all sentences get converted to the same type, so this is a breaking change.

Also changed to POST since event though the implementation is a update it is actually more like a created. Also we need to PUT for update the recall.

Kept deprecated version until I update the sync service. Converted to test to only test new endpoint