### PR TITLE
SDIT-2817 Add court event for recall

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResource.kt
@@ -2336,6 +2336,12 @@ data class ConvertToRecallRequest(
   val recallRevocationDate: LocalDate = LocalDate.now(),
 )
 
+@Schema(description = "Recall convert response")
+data class ConvertToRecallResponse(
+  @Schema(description = "the breach court appearance ids created")
+  val courtEventIds: List<Long>,
+)
+
 @Schema(description = "Delete recall sentence request")
 data class DeleteRecallRequest(
   val sentences: List<RecallRelatedSentenceDetails>,


### PR DESCRIPTION
Return the newly created court event so they can be stored against recall in a mapping table