### PR TITLE
SDIT-2982 Endpoint to clone court cases to the latest booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
@@ -1583,7 +1583,12 @@ class SentencingService(
           clonedSentence.consecSequence = clonedSentence.consecutiveSentence!!.id.sequence.toInt()
         }
       }
-      courtCaseRepository.saveAllAndFlush(clonedCases)
+      courtCaseRepository.saveAllAndFlush(clonedCases).also {
+        storedProcedureRepository.imprisonmentStatusUpdate(
+          bookingId = latestBooking.bookingId,
+          changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
+        )
+      }
     }.zip(sourceCourtCases)
 
     return BookingCourtCaseCloneResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
@@ -2348,6 +2348,19 @@ class SentencingResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
+      fun `will update the imprisonment status`() {
+        webTestClient.post().uri("/prisoners/booking-id/$previousBookingId/sentencing/court-cases/clone")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
+          .exchange()
+          .expectStatus().isOk
+
+        verify(spRepository).imprisonmentStatusUpdate(
+          bookingId = eq(latestBookingId),
+          changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
+        )
+      }
+
+      @Test
       internal fun `cases copied are returned along with source`() {
         val response: BookingCourtCaseCloneResponse = webTestClient.post().uri("/prisoners/booking-id/$previousBookingId/sentencing/court-cases/clone")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))


### PR DESCRIPTION
Recalculated imprisonment status given a new outcome or sentence would have been added to booking

* Clones Core case data held in DPS
* Clones case identifiers
* Clones Charges
* Clones Appearances
* Clones Appearance charges
* Clones orders
* Clones Sentences
* Clones Consecutive sentence links
* Clones Sentence charges
* Clones Terms

TODO - clone the other case children
* Linked cases links
* Adjustments