### PR TITLE
SDIT-2982 Endpoint to clone court cases to the latest booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
@@ -1363,7 +1363,8 @@ class SentencingService(
           caseSequence = courtCaseRepository.getNextCaseSequence(latestBooking),
           caseInfoNumbers = mutableListOf(),
         ).also { clonedCase ->
-          clonedCase.caseInfoNumbers += sourceCase.caseInfoNumbers.map { caseInfoNumber ->
+          // NOMIS trigger will insert primaryCaseInfoNumber - so exclude from our manually insert else we will have duplicate keys
+          clonedCase.caseInfoNumbers += sourceCase.caseInfoNumbers.filterNot { it.id.identifierType == "CASE/INFO#" && it.id.reference == sourceCase.primaryCaseInfoNumber }.map { caseInfoNumber ->
             OffenderCaseIdentifier(
               id = OffenderCaseIdentifierPK(
                 identifierType = caseInfoNumber.id.identifierType,


### PR DESCRIPTION
Fix bug where NOMIS copies the primary case info number to the case identifiers table vai a trigger causing duplicates.

* Clones Core case data held in DPS
* Clones case identifiers
* Clones Charges
* Clones Appearances
* Clones Appearance charges
* Clones orders
* Clones Sentences
* Clones Consecutive sentence links
* Clones Sentence charges
* Clones Terms

TODO - clone the other case children
* Linked cases links
* Adjustments