### PR TITLE
SDIT-2982 Endpoint to clone court cases to the latest booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
@@ -74,14 +74,14 @@ class CourtCase(
       JoinColumnOrFormula(column = JoinColumn(name = "CASE_STATUS", referencedColumnName = "code")),
     ],
   )
-  val caseStatus: CaseStatus,
+  var caseStatus: CaseStatus,
 
   @Column(name = "CASE_INFO_NUMBER")
   val primaryCaseInfoNumber: String? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "COMBINED_CASE_ID")
-  val targetCombinedCase: CourtCase? = null,
+  var targetCombinedCase: CourtCase? = null,
 
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "targetCombinedCase")
   val sourceCombinedCases: List<CourtCase> = mutableListOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCharge.kt
@@ -126,7 +126,7 @@ class OffenderCharge(
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "CASE_ID")
-  val courtCase: CourtCase,
+  var courtCase: CourtCase,
 
   // always populated in prod but presumably won't be by DPS
   val lidsOffenceNumber: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingService.kt
@@ -1447,6 +1447,7 @@ class SentencingService(
             clonedCourtEvent.courtEventCharges += courtEvent.courtEventCharges.map { courtEventCharge ->
               CourtEventCharge(
                 id = CourtEventChargeId(
+                  // TODO - if this is a linked case the charge might not be on this case, so grab from the courtEvent instead maybe
                   offenderCharge = clonedCase.offenderCharges[sourceCase.offenderCharges.indexOf(courtEventCharge.id.offenderCharge)],
                   courtEvent = clonedCourtEvent,
                 ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/LinkCaseTxn.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/LinkCaseTxn.kt
@@ -1,13 +1,18 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CaseStatus
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtCase
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEventCharge
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEventChargeId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.LinkCaseTxn
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.LinkCaseTxnId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCharge
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.LinkCaseTxnRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
 import java.time.LocalDateTime
 
 @DslMarker
@@ -29,17 +34,73 @@ class LinkCaseTxnBuilderFactory(
 class LinkCaseTxnBuilderRepository(
   val repository: LinkCaseTxnRepository,
   val jdbcTemplate: JdbcTemplate,
+  val caseStatusRepository: ReferenceCodeRepository<CaseStatus>,
 ) {
-  fun save(linkCaseTxn: LinkCaseTxn): LinkCaseTxn = repository.saveAndFlush(linkCaseTxn)
+  fun get(sourceCase: CourtCase, targetCourtCase: CourtCase, offenderCharge: OffenderCharge): LinkCaseTxn = repository.findByIdOrNull(
+    LinkCaseTxnId(
+      caseId = sourceCase.id,
+      combinedCaseId = targetCourtCase.id,
+      offenderChargeId = offenderCharge.id,
+    ),
+  )!!
+  fun insert(linkCaseTxn: LinkCaseTxn) {
+    jdbcTemplate.update("insert into LINK_CASE_TXNS (CASE_ID, COMBINED_CASE_ID, OFFENDER_CHARGE_ID, EVENT_ID) values (?, ?, ?, ?) ", linkCaseTxn.id.caseId, linkCaseTxn.id.combinedCaseId, linkCaseTxn.id.offenderChargeId, linkCaseTxn.courtEvent.id)
+  }
   fun updateCreateDatetime(linkCaseTxn: LinkCaseTxn, whenCreated: LocalDateTime) {
     jdbcTemplate.update("update LINK_CASE_TXNS set CREATE_DATETIME = ? where LINK_CASE_TXNS.CASE_ID = ? and LINK_CASE_TXNS.COMBINED_CASE_ID = ? and LINK_CASE_TXNS.OFFENDER_CHARGE_ID = ?", whenCreated, linkCaseTxn.id.caseId, linkCaseTxn.id.combinedCaseId, linkCaseTxn.id.offenderChargeId)
   }
+  fun lookupCaseStatus(code: String): CaseStatus = caseStatusRepository.findByIdOrNull(CaseStatus.pk(code))!!
 }
 
 class LinkCaseTxnBuilder(
   private val repository: LinkCaseTxnBuilderRepository,
 ) : LinkCaseTxnDsl {
   private lateinit var linkCaseTxn: LinkCaseTxn
+  fun linkCases(
+    sourceCase: CourtCase,
+    targetCase: CourtCase,
+    courtEvent: CourtEvent,
+    whenCreated: LocalDateTime,
+  ): List<LinkCaseTxn> {
+    val chargesToCopy = sourceCase.offenderCharges.filterNot { it.resultCode1?.dispositionCode == "F" }
+    chargesToCopy.forEach { it.courtCase = targetCase }
+    sourceCase.offenderCharges.removeAll(chargesToCopy)
+    sourceCase.targetCombinedCase = targetCase
+    sourceCase.caseStatus = repository.lookupCaseStatus("I")
+    targetCase.offenderCharges += chargesToCopy
+
+    courtEvent.courtEventCharges += chargesToCopy.map {
+      CourtEventCharge(
+        id = CourtEventChargeId(
+          offenderCharge = it,
+          courtEvent = courtEvent,
+        ),
+        offencesCount = it.offencesCount,
+        offenceDate = it.offenceDate,
+        offenceEndDate = it.offenceEndDate,
+        plea = it.plea,
+        propertyValue = it.propertyValue,
+        totalPropertyValue = it.totalPropertyValue,
+        cjitCode1 = it.cjitCode1,
+        cjitCode2 = it.cjitCode2,
+        cjitCode3 = it.cjitCode3,
+        resultCode1 = it.resultCode1,
+        resultCode2 = it.resultCode2,
+        resultCode1Indicator = it.resultCode1Indicator,
+        resultCode2Indicator = it.resultCode2Indicator,
+        mostSeriousFlag = it.mostSeriousFlag,
+      )
+    }
+    return chargesToCopy.map {
+      build(
+        sourceCase = sourceCase,
+        targetCase = targetCase,
+        courtEvent = courtEvent,
+        offenderCharge = it,
+        whenCreated = whenCreated,
+      )
+    }
+  }
 
   fun build(
     sourceCase: CourtCase,
@@ -59,7 +120,12 @@ class LinkCaseTxnBuilder(
     courtEventCharge = courtEvent.courtEventCharges.find { it.id.offenderCharge == offenderCharge }!!,
     courtEvent = courtEvent,
   )
-    .let { repository.save(it) }
+    .let {
+      // cannot get JPA to work without throwing detached entity exceptions
+      // so insert using SQL but then load using JPA
+      repository.insert(it)
+      repository.get(sourceCase, targetCase, offenderCharge)
+    }
     .also {
       if (whenCreated != null) {
         repository.updateCreateDatetime(it, whenCreated)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/Repository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/Repository.kt
@@ -56,6 +56,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtEventRe
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.GeneralLedgerTransactionRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.IWPTemplateRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.IncidentRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.LinkCaseTxnRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.MergeTransactionRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderAppointmentRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderCaseNoteRepository
@@ -120,6 +121,7 @@ class Repository(
   val offenderTransactionRepository: OffenderTransactionRepository,
   val generalLedgerTransactionRepository: GeneralLedgerTransactionRepository,
   val offenderTrustAccountRepository: OffenderTrustAccountRepository,
+  val linkCaseTxnRepository: LinkCaseTxnRepository,
 ) {
   @Autowired
   lateinit var jdbcTemplate: JdbcTemplate
@@ -174,6 +176,7 @@ class Repository(
   fun delete(courtEvent: CourtEvent) = courtEventRepository.deleteById(courtEvent.id)
 
   fun deleteOffenderChargeByBooking(bookingId: Long) = offenderChargeRepository.deleteByOffenderBookingBookingId(bookingId = bookingId)
+  fun deleteAllOffenderLinkedTransactions() = linkCaseTxnRepository.deleteAll()
 
   fun delete(sentence: OffenderSentence) = offenderSentenceRepository.deleteById(sentence.id)
 


### PR DESCRIPTION
Expose bug for linked cases where we cannot clone due to sourceCase no longer pointing at offender charge that is still on a court event

Will then fix bug - but setting up linked cases data is a large job in itself

TODO - clone the other case children
* Linked cases links
* Adjustments