### PR TITLE
SDIT-2982 Endpoint to clone court cases to the latest booking

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEventCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEventCharge.kt
@@ -95,7 +95,7 @@ class CourtEventCharge(
   var mostSeriousFlag: Boolean = false,
 
   @OneToOne(mappedBy = "courtEventCharge", fetch = FetchType.LAZY)
-  val linkedCaseTransaction: LinkCaseTxn? = null,
+  var linkedCaseTransaction: LinkCaseTxn? = null,
 ) {
   @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)
   @Generated

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/LinkCaseTxnRepositorySql.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/LinkCaseTxnRepositorySql.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.repository
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.LinkCaseTxn
+
+@Repository
+class LinkCaseTxnRepositorySql(
+  val jdbcTemplate: JdbcTemplate,
+) {
+  fun insert(linkCaseTxn: LinkCaseTxn) {
+    jdbcTemplate.update("insert into LINK_CASE_TXNS (CASE_ID, COMBINED_CASE_ID, OFFENDER_CHARGE_ID, EVENT_ID) values (?, ?, ?, ?) ", linkCaseTxn.id.caseId, linkCaseTxn.id.combinedCaseId, linkCaseTxn.id.offenderChargeId, linkCaseTxn.courtEvent.id)
+  }
+}


### PR DESCRIPTION
Linked cases links aka combined cases.

Complicated by the courtCase -> courtEvent -> courtEventCharge -> offenderCharge does not play well when the offenderCharge is pointed at by courtEventCharge in both the source and target linked cases. Then further complicated by the LinkCaseTxn entities point at all of the above making transient entity exceptions hard to avoid. Then further complicated that none of this can be persisted until we have persisted all the about objects for every case being cloned.

So fallen back to using SQL for inserting LinkCaseTxn

TODO - clone the other case children
* Case status
* Adjustments