### PR TITLE
SDIT-2982 Clone cases case identifier fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
@@ -77,7 +77,7 @@ class CourtCase(
   var caseStatus: CaseStatus,
 
   @Column(name = "CASE_INFO_NUMBER")
-  val primaryCaseInfoNumber: String? = null,
+  var primaryCaseInfoNumber: String? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "COMBINED_CASE_ID")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
@@ -2357,6 +2357,7 @@ class SentencingResourceIntTest : IntegrationTestBase() {
                 caseSequence = 1,
                 caseStatus = "I",
               ) {
+                offenderCaseIdentifier(reference = "SOURCE", type = "CASE/INFO#")
                 lateinit var courtOrder: CourtOrder
                 val sentencedCharge = offenderCharge(offenceCode = "AN81016", resultCode1 = "1002")
                 val chargedThatWillBeLinked = offenderCharge(offenceCode = "HP09006", plea = "NG", resultCode1 = "4506")
@@ -2390,6 +2391,7 @@ class SentencingResourceIntTest : IntegrationTestBase() {
                 caseSequence = 2,
                 caseStatus = "I",
               ) {
+                offenderCaseIdentifier(reference = "TARGET", type = "CASE/INFO#")
                 val charge = offenderCharge(offenceCode = "LG72004", plea = "NG", resultCode1 = "4506")
                 targetCaseEvent = courtEvent(eventDateTime = LocalDateTime.parse("2025-01-01T10:00"), outcomeReasonCode = "2006") {
                   courtEventCharge(


### PR DESCRIPTION
NOMIS trigger was happening twice the case insert and update - causing 2 inserts into case identifiers table

This fix ensures we only update the identifiers after everything has been inserted and updated to the NOMIS trigger doesn't fire twice