### PR TITLE
SDIT-2845 Make schedule date/time non-nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderScheduledTemporaryAbsence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderScheduledTemporaryAbsence.kt
@@ -18,8 +18,8 @@ import java.time.LocalDateTime
 class OffenderScheduledTemporaryAbsence(
   eventId: Long = 0,
   offenderBooking: OffenderBooking,
-  eventDate: LocalDate? = null,
-  startTime: LocalDateTime? = null,
+  eventDate: LocalDate,
+  startTime: LocalDateTime,
   eventSubType: MovementReason,
   eventStatus: EventStatus,
   comment: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderScheduledTemporaryAbsenceReturn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderScheduledTemporaryAbsenceReturn.kt
@@ -13,8 +13,8 @@ import java.time.LocalDateTime
 class OffenderScheduledTemporaryAbsenceReturn(
   eventId: Long = 0,
   offenderBooking: OffenderBooking,
-  eventDate: LocalDate? = null,
-  startTime: LocalDateTime? = null,
+  eventDate: LocalDate,
+  startTime: LocalDateTime,
   eventSubType: MovementReason,
   eventStatus: EventStatus,
   comment: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/CreateScheduledTemporaryAbsence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/CreateScheduledTemporaryAbsence.kt
@@ -10,10 +10,10 @@ data class CreateScheduledTemporaryAbsenceRequest(
   val movementApplicationId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/CreateScheduledTemporaryAbsenceReturn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/CreateScheduledTemporaryAbsenceReturn.kt
@@ -13,10 +13,10 @@ data class CreateScheduledTemporaryAbsenceReturnRequest(
   val scheduledTemporaryAbsenceEventId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/MovementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/MovementsService.kt
@@ -510,8 +510,8 @@ class MovementsService(
 
   private fun OffenderScheduledTemporaryAbsence.toResponse() = ScheduledTemporaryAbsence(
     eventId = eventId,
-    eventDate = eventDate,
-    startTime = startTime,
+    eventDate = eventDate ?: temporaryAbsenceApplication.fromDate,
+    startTime = startTime ?: temporaryAbsenceApplication.releaseTime,
     eventSubType = eventSubType.code,
     eventStatus = eventStatus.code,
     comment = comment,
@@ -530,8 +530,8 @@ class MovementsService(
 
   private fun OffenderScheduledTemporaryAbsenceReturn.toResponse() = ScheduledTemporaryAbsenceReturn(
     eventId = eventId,
-    eventDate = eventDate,
-    startTime = startTime,
+    eventDate = eventDate ?: scheduledTemporaryAbsence.temporaryAbsenceApplication.fromDate,
+    startTime = startTime ?: scheduledTemporaryAbsence.temporaryAbsenceApplication.releaseTime,
     eventSubType = eventSubType.code,
     eventStatus = eventStatus.code,
     comment = comment,
@@ -631,8 +631,8 @@ class MovementsService(
     bookingId = offenderBooking.bookingId,
     movementApplicationId = temporaryAbsenceApplication.movementApplicationId,
     eventId = eventId,
-    eventDate = eventDate,
-    startTime = startTime,
+    eventDate = eventDate ?: temporaryAbsenceApplication.fromDate,
+    startTime = startTime ?: temporaryAbsenceApplication.releaseTime,
     eventSubType = eventSubType.code,
     eventStatus = eventStatus.code,
     comment = comment,
@@ -654,8 +654,8 @@ class MovementsService(
     bookingId = offenderBooking.bookingId,
     movementApplicationId = scheduledTemporaryAbsence.temporaryAbsenceApplication.movementApplicationId,
     eventId = eventId,
-    eventDate = eventDate,
-    startTime = startTime,
+    eventDate = eventDate ?: scheduledTemporaryAbsence.temporaryAbsenceApplication.fromDate,
+    startTime = startTime ?: scheduledTemporaryAbsence.temporaryAbsenceApplication.releaseTime,
     eventSubType = eventSubType.code,
     eventStatus = eventStatus.code,
     comment = comment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/OffenderTemporaryAbsencesResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/OffenderTemporaryAbsencesResponse.kt
@@ -162,10 +162,10 @@ data class ScheduledTemporaryAbsence(
   val eventId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,
@@ -216,10 +216,10 @@ data class ScheduledTemporaryAbsenceReturn(
   val eventId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/ScheduledTemporaryAbsenceResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/ScheduledTemporaryAbsenceResponse.kt
@@ -17,10 +17,10 @@ data class ScheduledTemporaryAbsenceResponse(
   val eventId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/ScheduledTemporaryAbsenceReturnResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/ScheduledTemporaryAbsenceReturnResponse.kt
@@ -17,10 +17,10 @@ data class ScheduledTemporaryAbsenceReturnResponse(
   val eventId: Long,
 
   @Schema(description = "Event date")
-  val eventDate: LocalDate?,
+  val eventDate: LocalDate,
 
   @Schema(description = "Start time")
-  val startTime: LocalDateTime?,
+  val startTime: LocalDateTime,
 
   @Schema(description = "Event sub type")
   val eventSubType: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderScheduledTemporaryAbsence.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderScheduledTemporaryAbsence.kt
@@ -84,8 +84,8 @@ class OffenderScheduledTemporaryAbsenceBuilder(
 
   fun build(
     temporaryAbsenceApplication: OffenderMovementApplication,
-    eventDate: LocalDate?,
-    startTime: LocalDateTime?,
+    eventDate: LocalDate,
+    startTime: LocalDateTime,
     eventSubType: String,
     eventStatus: String,
     comment: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderScheduledTemporaryAbsenceReturn.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderScheduledTemporaryAbsenceReturn.kt
@@ -66,8 +66,8 @@ class OffenderScheduledTemporaryAbsenceReturnBuilder(
 
   fun build(
     offenderBooking: OffenderBooking,
-    eventDate: LocalDate? = null,
-    startTime: LocalDateTime? = null,
+    eventDate: LocalDate,
+    startTime: LocalDateTime,
     eventSubType: String,
     eventStatus: String,
     comment: String? = null,


### PR DESCRIPTION
The from date/time is never null for scheduled TAPs, to date/time is null for a handful of old records. To be safe, we'll default from the application for both if they are null.