### PR TITLE
SDIT-3064 Ensure only one order is created per court appearance.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtOrderRepository.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
 
 @Repository
 interface CourtOrderRepository : JpaRepository<CourtOrder, Long> {
-  fun findByOffenderBookingAndCourtEventAndOrderType(
+  fun findFirstByOffenderBookingAndCourtEventAndOrderTypeOrderByIdAsc(
     offenderBooking: OffenderBooking,
     courtEvent: CourtEvent,
     orderType: String = "AUTO",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/CourtOrderIInsertRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/CourtOrderIInsertRepository.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.repository
+
+import org.springframework.context.annotation.Profile
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtOrder
+
+@Repository
+interface CourtOrderInsertRepository {
+  fun insertOnePerEvent(courtOrder: CourtOrder): Int
+}
+
+@Profile("oracle")
+@Repository
+class CourtOrderInsertRepositoryOracle(val template: JdbcTemplate) : CourtOrderInsertRepository {
+  override fun insertOnePerEvent(courtOrder: CourtOrder) = template.update(
+    //language=Oracle
+    """
+      insert into orders (ORDER_ID, OFFENDER_BOOK_ID, CASE_ID, COURT_DATE, ORDER_TYPE, ISSUING_AGY_LOC_ID, ORDER_STATUS,
+                          EVENT_ID)
+      select ORDER_ID.nextval,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?
+      from dual
+      where not exists (select * from orders where EVENT_ID = ?)
+    """.trimIndent(),
+    courtOrder.offenderBooking.bookingId,
+    courtOrder.courtCase.id,
+    courtOrder.courtDate,
+    courtOrder.orderType,
+    courtOrder.issuingCourt.id,
+    courtOrder.orderStatus,
+    courtOrder.courtEvent!!.id,
+    courtOrder.courtEvent!!.id,
+  )
+}
+
+@Profile("!oracle")
+@Repository
+class CourtOrderInsertRepositoryH2(val template: JdbcTemplate) : CourtOrderInsertRepository {
+  override fun insertOnePerEvent(courtOrder: CourtOrder) = template.update(
+    //language=H2
+    """
+      insert into orders (ORDER_ID, OFFENDER_BOOK_ID, CASE_ID, COURT_DATE, ORDER_TYPE, ISSUING_AGY_LOC_ID, ORDER_STATUS,
+                          EVENT_ID) 
+      values(
+             NEXT VALUE FOR ORDER_ID,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?,
+             ?
+      )
+    """.trimIndent(),
+    courtOrder.offenderBooking.bookingId,
+    courtOrder.courtCase.id,
+    courtOrder.courtDate,
+    courtOrder.orderType,
+    courtOrder.issuingCourt.id,
+    courtOrder.orderStatus,
+    courtOrder.courtEvent!!.id,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/sentencing/SentencingResourceIntTest.kt
@@ -5937,6 +5937,8 @@ class SentencingResourceIntTest : IntegrationTestBase() {
                     sentencePurpose(purposeCode = "REPAIR")
                     sentencePurpose(purposeCode = "PUNISH")
                   }
+                  // NOMIS allows multiple orders for an appearance - but it is rare
+                  courtOrder(courtDate = LocalDate.of(2023, 1, 10))
                 }
                 courtAppearanceNoCourtOrder = courtEvent {
                   courtEventCharge(


### PR DESCRIPTION
When multiple update charge events are received for a single appearance at the same time there is a race conditioning meaning multiple orders can be created for the same appearance. This is legal in NOMIS but not quite what we want.

Allow reading of the first order when there are multiples.

NOMIS allows multiple orders per event, but it is rare. We ensure we don't create multiples when several update events are received at the same time by using a SQL insert with a `where` clause on event_id