### PR TITLE
SDIT-3666 clone use additional audit

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.courtsentencing
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -108,7 +107,6 @@ class CourtSentencingService(
   private val offenderFixedTermRecallRepository: OffenderFixedTermRecallRepository,
   private val sentencingAdjustmentService: SentencingAdjustmentService,
   private val linkCaseTxnRepository: LinkCaseTxnRepository,
-  @Value("\${spring.datasource.username}") val datasourceUsername: String,
 ) {
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -658,7 +656,7 @@ class CourtSentencingService(
     eventId: Long,
   ) {
     findCourtCase(caseId, offenderNo).let { case ->
-      var telemetry = mutableMapOf(
+      val telemetry = mutableMapOf(
         "bookingId" to case.offenderBooking.bookingId.toString(),
         "offenderNo" to offenderNo,
         "eventId" to eventId.toString(),
@@ -2165,7 +2163,7 @@ private fun CourtEvent.toCourtEvent(): CourtEventResponse = CourtEventResponse(
   modifiedByUsername = this.modifyUserId,
   courtEventCharges = this.courtEventCharges.map { it.toCourtEventCharge() },
   courtOrders = this.courtOrders.map { it.toCourtOrder() },
-  isClone = this.auditAdditionalInfo?.startsWith("DPS Cloned from") == true,
+  isClone = this.auditAdditionalInfo?.startsWith("DPS Cloned") == true,
 )
 
 private fun CourtOrder.toCourtOrder(): CourtOrderResponse = CourtOrderResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.courtsentencing
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -107,6 +108,7 @@ class CourtSentencingService(
   private val offenderFixedTermRecallRepository: OffenderFixedTermRecallRepository,
   private val sentencingAdjustmentService: SentencingAdjustmentService,
   private val linkCaseTxnRepository: LinkCaseTxnRepository,
+  @Value("\${spring.datasource.username}") val datasourceUsername: String,
 ) {
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -656,7 +658,7 @@ class CourtSentencingService(
     eventId: Long,
   ) {
     findCourtCase(caseId, offenderNo).let { case ->
-      val telemetry = mutableMapOf(
+      var telemetry = mutableMapOf(
         "bookingId" to case.offenderBooking.bookingId.toString(),
         "offenderNo" to offenderNo,
         "eventId" to eventId.toString(),
@@ -1717,7 +1719,7 @@ class CourtSentencingService(
           caseSequence = courtCaseRepository.getNextCaseSequence(latestBooking),
           caseInfoNumbers = mutableListOf(),
           statusUpdateReason = sourceCase.statusUpdateReason,
-          auditAdditionalInfo = "DPS Cloned from ${sourceCase.id}",
+
         ).also { clonedCase ->
           clonedCase.offenderCharges += sourceCase.offenderCharges.map { offenderCharge ->
             OffenderCharge(
@@ -1739,7 +1741,6 @@ class CourtSentencingService(
               resultCode1Indicator = offenderCharge.resultCode1Indicator,
               resultCode2Indicator = offenderCharge.resultCode2Indicator,
               mostSeriousFlag = offenderCharge.mostSeriousFlag,
-              auditAdditionalInfo = "DPS Cloned from ${offenderCharge.id}",
             )
           }
         },
@@ -1762,7 +1763,6 @@ class CourtSentencingService(
             nextEventStartTime = courtEvent.nextEventStartTime,
             directionCode = courtEvent.directionCode,
             holdFlag = courtEvent.holdFlag,
-            auditAdditionalInfo = "DPS Cloned from ${courtEvent.id}",
           ).also { clonedCourtEvent ->
             clonedCourtEvent.courtOrders += courtEvent.courtOrders.map { courtOrder ->
               CourtOrder(
@@ -1779,7 +1779,6 @@ class CourtSentencingService(
                 requestDate = courtOrder.requestDate,
                 nonReportFlag = courtOrder.nonReportFlag,
                 commentText = courtOrder.commentText,
-                auditAdditionalInfo = "DPS Cloned from ${courtOrder.id}",
               ).also { clonedCourtOrder ->
                 clonedCourtOrder.sentencePurposes += courtOrder.sentencePurposes.map { sentencePurpose ->
                   SentencePurpose(
@@ -1848,7 +1847,6 @@ class CourtSentencingService(
               sled2Calc = offenderSentence.sled2Calc,
               startDate2Calc = offenderSentence.startDate2Calc,
               adjustments = mutableListOf(),
-              auditAdditionalInfo = "DPS Cloned from ${offenderSentence.id.offenderBooking.bookingId}/${offenderSentence.id.sequence}",
             ).also { clonedSentence ->
               clonedSentence.offenderSentenceCharges += offenderSentence.offenderSentenceCharges.map { sourceOffenderSentenceCharge ->
                 val clonedOffenderSentenceCharge = clonedCase.offenderCharges[sourceCase.offenderCharges.indexOf(sourceOffenderSentenceCharge.offenderCharge)]
@@ -1860,7 +1858,6 @@ class CourtSentencingService(
                   ),
                   offenderSentence = clonedSentence,
                   offenderCharge = clonedOffenderSentenceCharge,
-                  auditAdditionalInfo = "DPS Cloned from ${sourceOffenderSentenceCharge.id.offenderBooking.bookingId}/${sourceOffenderSentenceCharge.id.sequence}/${sourceOffenderSentenceCharge.id.offenderChargeId}",
                 )
               }
             },
@@ -1887,7 +1884,6 @@ class CourtSentencingService(
                   startDate = sourceOffenderSentenceTerm.startDate,
                   endDate = sourceOffenderSentenceTerm.endDate,
                   sentenceTermType = sourceOffenderSentenceTerm.sentenceTermType,
-                  auditAdditionalInfo = "DPS Cloned from ${sourceOffenderSentenceTerm.id.offenderBooking.bookingId}/${sourceOffenderSentenceTerm.id.sentenceSequence}/${sourceOffenderSentenceTerm.id.termSequence}",
                 ),
               )
             }
@@ -1933,7 +1929,6 @@ class CourtSentencingService(
                 resultCode1Indicator = sourceCourtEventCharge.resultCode1Indicator,
                 resultCode2Indicator = sourceCourtEventCharge.resultCode2Indicator,
                 mostSeriousFlag = sourceCourtEventCharge.mostSeriousFlag,
-                auditAdditionalInfo = "DPS Cloned from ${sourceCourtEventCharge.id}",
               ),
             ).also { clonedCourtEventCharge ->
               if (sourceCourtEventCharge.linkedCaseTransaction != null) {
@@ -1953,7 +1948,6 @@ class CourtSentencingService(
                       targetCase = clonedCase,
                       offenderCharge = clonedCourtEventCharge.id.offenderCharge,
                       courtEvent = clonedCourtEvent,
-                      auditAdditionalInfo = "DPS Cloned from ${sourceCourtEventCharge.linkedCaseTransaction?.id?.caseId} / ${sourceCourtEventCharge.linkedCaseTransaction?.id?.combinedCaseId} / ${sourceCourtEventCharge.linkedCaseTransaction?.id?.offenderChargeId}",
                     ),
                   )
                 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtCase.kt
@@ -124,8 +124,6 @@ class CourtCase(
     VICTIM_LIAISON_UNIT - not used
     CASE_INFO_PREFIX - not used
    */
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 
 ) : NomisAuditableEntityBasic() {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import org.hibernate.annotations.Generated
 import org.hibernate.annotations.JoinColumnOrFormula
 import org.hibernate.annotations.JoinColumnsOrFormulas
 import org.hibernate.annotations.JoinFormula
@@ -133,7 +134,9 @@ class CourtEvent(
     OUTCOME_DATE - not used
     OFFENDER_PROCEEDING_ID - not used
    */
-
+  @Column(name = "AUDIT_ADDITIONAL_INFO", insertable = false, updatable = false)
+  @Generated
+  var auditAdditionalInfo: String? = null,
 ) : NomisAuditableEntityBasic() {
 
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
@@ -133,8 +133,6 @@ class CourtEvent(
     OUTCOME_DATE - not used
     OFFENDER_PROCEEDING_ID - not used
    */
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 
 ) : NomisAuditableEntityBasic() {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEventCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEventCharge.kt
@@ -96,10 +96,6 @@ class CourtEventCharge(
 
   @OneToOne(mappedBy = "courtEventCharge", fetch = FetchType.LAZY)
   var linkedCaseTransaction: LinkCaseTxn? = null,
-
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
-
 ) : NomisAuditableEntityBasic() {
 
   @Column(name = "MODIFY_DATETIME", insertable = false, updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtOrder.kt
@@ -110,8 +110,6 @@ class CourtOrder(
     OFFENDER_PROCEEDING_ID - not used
     WORKFLOW_ID - not used
    */
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 
 ) {
   @Column(name = "CREATE_USER_ID", insertable = false, updatable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/LinkCaseTxn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/LinkCaseTxn.kt
@@ -62,8 +62,6 @@ data class LinkCaseTxn(
   @JoinColumn(name = "EVENT_ID", insertable = false, updatable = false)
   var courtEvent: CourtEvent,
 
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 ) : NomisAuditableEntityBasic() {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCharge.kt
@@ -136,8 +136,6 @@ class OffenderCharge(
     CHARGE_SEQ - not used
     ORDER_ID - not used
    */
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 
 ) : NomisAuditableEntityBasic() {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentence.kt
@@ -254,8 +254,6 @@ class OffenderSentence(
     AGGREGATE_TERM - not used
     WORKFLOW_ID - not used
    */
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 
   @Transient
   @Value("false")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceCharge.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceCharge.kt
@@ -50,9 +50,6 @@ data class OffenderSentenceCharge(
     updatable = false,
   )
   val offenderCharge: OffenderCharge,
-
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceTerm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderSentenceTerm.kt
@@ -80,9 +80,6 @@ data class OffenderSentenceTerm(
     ],
   )
   var sentenceTermType: SentenceTermType,
-
-  @Column(name = "AUDIT_ADDITIONAL_INFO")
-  val auditAdditionalInfo: String? = null,
 ) : NomisAuditableEntityBasic() {
 
   override fun equals(other: Any?): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -3240,7 +3240,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         val case = response.getByCaseInfoNumber("X0002")
         assertThat(case.courtEvents).hasSize(2)
         assertThat(case.courtEvents[0].id).isGreaterThan(0)
-        assertThat(case.courtEvents[0].isClone).isTrue()
         assertThat(case.courtEvents[1].id).isGreaterThan(0)
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -3072,7 +3072,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             assertThat(caseStatus.code).isEqualTo("A")
             assertThat(targetCombinedCase).isNull()
             assertThat(sourceCombinedCases).isEmpty()
-            assertThat(auditAdditionalInfo).isEqualTo("DPS Cloned from $remandCaseId")
           }
         }
       }
@@ -3162,7 +3161,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             assertThat(offenceDate).isEqualTo(LocalDate.parse("2020-01-02"))
             assertThat(offenceEndDate).isEqualTo(LocalDate.parse("2020-12-02"))
             assertThat(plea?.code).isEqualTo("G")
-            assertThat(auditAdditionalInfo).isEqualTo("DPS Cloned from ${sourceCharge.id}")
 
             assertThat(mostSeriousFlag).isTrue
 
@@ -3218,7 +3216,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
 
             assertThat(nextEventDate).isEqualTo(LocalDate.parse("2022-02-01"))
             assertThat(nextEventStartTime).isEqualTo(LocalDateTime.parse("2022-02-01T10:00"))
-            assertThat(auditAdditionalInfo).isEqualTo("DPS Cloned from ${sourceEvent.id}")
 
             // derived fields
             assertThat(nextEventRequestFlag).isTrue
@@ -3271,7 +3268,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             assertThat(horseDrawnVehicleCharge.plea?.code).isEqualTo("NG")
             assertThat(horseDrawnVehicleCharge.propertyValue).isEqualTo(BigDecimal.TEN)
             assertThat(horseDrawnVehicleCharge.totalPropertyValue).isEqualTo(BigDecimal.TWO)
-            assertThat(horseDrawnVehicleCharge.auditAdditionalInfo).contains("DPS Cloned from")
 
             val drunkCharge = courtEventCharges.find { it.id.offenderCharge.offence.id.offenceCode == "LG72004" }!!
             assertThat(drunkCharge.resultCode1?.code).isEqualTo("4506")
@@ -3335,7 +3331,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             assertThat(courtOrders[0].sentencePurposes).hasSize(1)
             assertThat(courtOrders[0].sentencePurposes[0].id.purposeCode).isEqualTo("PUNISH")
             assertThat(courtOrders[0].sentencePurposes[0].id.orderPartyCode).isEqualTo("CRT")
-            assertThat(courtOrders[0].auditAdditionalInfo).contains("DPS Cloned from")
           }
         }
       }
@@ -3407,7 +3402,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             assertThat(nomConsWithSentDetailRef).isEqualTo(4)
             assertThat(hdcExclusionFlag).isTrue
             assertThat(hdcExclusionReason).isEqualTo("ABDR")
-            assertThat(auditAdditionalInfo).contains("DPS Cloned from")
 
             //  booking already has a single sentenc with line 20
             assertThat(lineSequence).isEqualTo(21)
@@ -3507,7 +3501,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           with(case.sentences[0]) {
             assertThat(offenderSentenceCharges).hasSize(1)
             assertThat(offenderSentenceCharges[0].offenderCharge).isEqualTo(charge)
-            assertThat(offenderSentenceCharges[0].auditAdditionalInfo).contains("DPS Cloned from")
           }
         }
       }
@@ -3552,7 +3545,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
               assertThat(hours).isEqualTo(3)
               assertThat(sentenceTermType.code).isEqualTo("SEC86")
               assertThat(lifeSentenceFlag).isTrue
-              assertThat(auditAdditionalInfo).contains("DPS Cloned from")
             }
             with(offenderSentenceTerms[1]) {
               assertThat(id.termSequence).isEqualTo(2)


### PR DESCRIPTION
1. Revert original manual setting of AUDIT_ADDITIONAL_INFO that does not work - it has to be done via set_context
2. Keep flag (which will always be force) ready for fix to AUDIT_ADDITIONAL_INFO

TODO - use set_context to set AUDIT_ADDITIONAL_INFO