### PR TITLE
SDIT-2832 Refactor TAP API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapAddressService.kt
@@ -1,0 +1,216 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.EntityManager
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Address
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AddressUsage
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AddressUsageId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AddressUsageType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationAddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateAddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderAddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.CorporateInsertRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.TapAddressInsertRepository
+
+@Service
+class TapAddressService(
+  private val agencyLocationAddressRepository: AgencyLocationAddressRepository,
+  private val corporateAddressRepository: CorporateAddressRepository,
+  private val corporateInsertRepository: CorporateInsertRepository,
+  private val corporateRepository: CorporateRepository,
+  private val offenderAddressRepository: OffenderAddressRepository,
+  private val tapAddressInsertRepository: TapAddressInsertRepository,
+  private val tapHelpers: TapHelpers,
+  private val entityManager: EntityManager,
+  addressUsageTypeRepository: ReferenceCodeRepository<AddressUsageType>,
+) {
+
+  private val rotlAddressType = addressUsageTypeRepository.findByIdOrNull(AddressUsageType.pk("ROTL"))
+
+  fun getAddressDescription(address: Address?) = address?.addressId?.let {
+    when (address.addressOwnerClass) {
+      "CORP" -> corporateAddressRepository.findByIdOrNull(it)?.corporate?.corporateName
+      "AGY" -> agencyLocationAddressRepository.findByIdOrNull(it)?.agencyLocation?.description
+      else -> null
+    }
+  }
+
+  fun findOrCreateAddress(request: UpsertTapAddress, offender: Offender): Address {
+    // If we have an address id then use that
+    if (request.id != null) return tapHelpers.addressOrThrow(request.id)
+
+    if (request.addressText == null) throw BadDataException("Address text required to create a new address")
+
+    with(request.copyAndTrim()) {
+      return when (isCorporateAddress()) {
+        true -> findOrCreateCorporateAddress(name!!, addressText!!, postalCode)
+        false -> findOrCreateOffenderAddress(addressText!!, postalCode, offender)
+      }
+    }
+  }
+
+  fun findAddressOrThrow(request: UpsertTapAddress, offender: Offender): Address {
+    // If we have an address id then use that (which means the address was created in NOMIS or has already been syncd from DPS)
+    if (request.id != null) return tapHelpers.addressOrThrow(request.id)
+
+    if (request.addressText == null) throw BadDataException("Address text required to create a new address")
+
+    with(request.copyAndTrim()) {
+      return when (isCorporateAddress()) {
+        true -> findCorporateAddress(name!!, addressText!!, postalCode)
+        false -> findOffenderAddress(addressText!!, postalCode, offender)
+      }
+        ?: throw BadDataException("Address not found")
+    }
+  }
+
+  // Note that this assumes the address was created in DPS... a fair assumption because if the address was created in NOMIS we have the ID so never need to find it
+  private fun findOrCreateCorporateAddress(name: String, addressText: String, postalCode: String?): CorporateAddress {
+    val (premise, street) = formatAddressText(addressText)
+    val corporateName = name.toCorporateName()
+    return findCorporateAddress(corporateName, addressText, postalCode)
+      ?: let {
+        corporateInsertRepository.insertCorporateIfNotExists(corporateName)
+        val corporate = corporateRepository.findAllByCorporateName(corporateName).first()
+        tapAddressInsertRepository.insertAddressIfNotExists("CORP", corporate.id, premise, street, postalCode)
+          .also { entityManager.refresh(corporate) }
+
+        corporateRepository.findById(corporate.id).get()
+          .addresses.first { it.matchesDpsAddress(premise, street, postalCode) }
+      }
+  }
+
+  private fun formatAddressText(addressText: String): Pair<String, String?> {
+    val maxPremiseLength = 135
+
+    if (addressText.length <= maxPremiseLength) {
+      return addressText.trim() to null
+    }
+
+    val split = if (addressText.substring(maxPremiseLength, maxPremiseLength + 1) == " ") {
+      maxPremiseLength
+    } else {
+      addressText.substring(0, maxPremiseLength).lastIndexOf(" ")
+    }
+    return addressText.substring(0, split).trim() to addressText.substring(split, addressText.length).trim()
+  }
+
+  private fun findOffenderAddress(addressText: String, postalCode: String?, offender: Offender): OffenderAddress? = offenderAddressRepository.findByOffender_RootOffenderId(offender.rootOffenderId!!)
+    .firstOrNull {
+      it.toFullAddress(null) == addressText.trim() && it.postalCode == postalCode?.trim()
+    }
+
+  private fun findCorporateAddress(name: String, addressText: String, postalCode: String?): CorporateAddress? {
+    val corporateName = name.toCorporateName()
+    return corporateAddressRepository.findAllByCorporate_CorporateName(corporateName)
+      .firstOrNull {
+        // Need to check address with and without corporate name - it might be included on a DPS address
+        (it.toFullAddress(corporateName) == addressText.trim() || it.toFullAddress() == addressText.trim()) &&
+          it.postalCode == postalCode?.trim()
+      }
+  }
+
+  // Note that this assumes the address was created in DPS... a fair assumption because if the address was created in NOMIS we have the ID so never need to find it
+  private fun findOrCreateOffenderAddress(addressText: String, postalCode: String?, offender: Offender): OffenderAddress {
+    val (premise, street) = formatAddressText(addressText)
+    tapAddressInsertRepository.insertAddressIfNotExists("OFF", offender.rootOffenderId!!, premise, street, postalCode)
+
+    val address = offenderAddressRepository.findByOffender_RootOffenderId(offender.rootOffenderId!!)
+      .first { it.matchesDpsAddress(premise, street, postalCode) }
+    if (address.usages.none { it.addressUsage == rotlAddressType }) {
+      address.apply {
+        usages += AddressUsage(AddressUsageId(this, "ROTL"), true, rotlAddressType)
+      }
+    }
+
+    return address
+  }
+
+  private fun Address.matchesDpsAddress(premise: String?, street: String?, postalCode: String?): Boolean = (this.premise == premise && this.street == street && this.postalCode == postalCode && flat == null && locality == null && city == null && county == null && country == null)
+}
+
+internal fun Address.toFullAddress(description: String? = null): String {
+  val address = mutableListOf<String>()
+
+  fun MutableList<String>.addIfNotEmpty(value: String?) {
+    if (!value.isNullOrBlank()) {
+      add(value.trim())
+    }
+  }
+
+  fun String?.cleanAddressComponent(): String? {
+    // remove corporate/agency description from any address elements that might contain it
+    fun String?.withoutDescription() = description?.let { this?.replace(description, "") } ?: this
+
+    // remove trailing commas because they will be added back when the components are joined together
+    fun String?.withoutTrailingCommas() = this?.trim()?.trimEnd(',')
+
+    return this.withoutDescription().withoutTrailingCommas()
+  }
+
+  // Append "Flat" if there is one
+  if (!flat.isNullOrBlank()) {
+    val flatText = if (flat!!.contains("flat", ignoreCase = true)) "" else "Flat "
+    address.add("$flatText${flat!!.trim()}")
+  }
+
+  val cleanPremise = premise.cleanAddressComponent()
+  val cleanStreet = street.cleanAddressComponent()
+  val cleanLocality = locality.cleanAddressComponent()
+
+  // Don't separate a numeric premise from the street, only if it's a name
+  val hasPremise = !cleanPremise.isNullOrBlank()
+  val premiseIsNumber = cleanPremise?.all { char -> char.isDigit() } ?: false
+  val hasStreet = !cleanStreet.isNullOrBlank()
+  when {
+    hasPremise && premiseIsNumber && hasStreet -> address.add("$cleanPremise $cleanStreet")
+    hasPremise && !premiseIsNumber && hasStreet -> address.add("$cleanPremise, $cleanStreet")
+    hasPremise -> address.add(cleanPremise)
+    hasStreet -> address.add(cleanStreet)
+  }
+  // Add others if they exist
+  address.addIfNotEmpty(cleanLocality)
+  address.addIfNotEmpty(city?.description)
+  address.addIfNotEmpty(county?.description)
+  address.addIfNotEmpty(country?.description)
+
+  return address.joinToString(", ").trim()
+    .takeIf { it.isNotBlank() }
+    ?: description
+    // If the NOMIS address is empty that's fine - it just won't match the address we're looking for. Maybe another address will match or if not we'll throw.
+    ?: ""
+}
+
+private fun String.toCorporateName() = substring(0..(minOf(this.length, 40) - 1))
+
+@Schema(description = "Upsert temporary absence address")
+data class UpsertTapAddress(
+  @Schema(description = "Address ID - if entered then this is a known NOMIS address, if not a new address is required based on the other properties")
+  val id: Long? = null,
+
+  @Schema(description = "The name of a corporation or agency")
+  val name: String? = null,
+
+  @Schema(description = "The full address text")
+  val addressText: String? = null,
+
+  @Schema(description = "The postal code")
+  val postalCode: String? = null,
+) {
+  @Schema(hidden = true)
+  fun hasNullValues(): Boolean = id == null && name == null && addressText == null && postalCode == null
+
+  @Schema(hidden = true)
+  fun isCorporateAddress(): Boolean = !name.isNullOrBlank() && name != addressText
+
+  @Schema(hidden = true)
+  fun copyAndTrim(): UpsertTapAddress = this.copy(name = name?.trim(), addressText = addressText?.trim(), postalCode = postalCode?.trim())
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapHelpers.kt
@@ -1,0 +1,122 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.ArrestAgency
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Escort
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.EventStatus
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementApplicationStatus
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementApplicationType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementReason
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.TapSubType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.TapTransportType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.TapType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
+
+@Service
+class TapHelpers(
+  private val addressRepository: AddressRepository,
+  private val agencyLocationRepository: AgencyLocationRepository,
+  private val arrestAgencyRepository: ReferenceCodeRepository<ArrestAgency>,
+  private val escortRepository: ReferenceCodeRepository<Escort>,
+  private val eventStatusRepository: ReferenceCodeRepository<EventStatus>,
+  private val movementApplicationStatusRepository: ReferenceCodeRepository<MovementApplicationStatus>,
+  private val movementApplicationTypeRepository: ReferenceCodeRepository<MovementApplicationType>,
+  private val movementReasonRepository: ReferenceCodeRepository<MovementReason>,
+  private val offenderBookingRepository: OffenderBookingRepository,
+  private val offenderRepository: OffenderRepository,
+  private val offenderTapApplicationRepository: OffenderTapApplicationRepository,
+  private val tapScheduleOutRepository: OffenderTapScheduleOutRepository,
+  private val tapScheduleInRepository: OffenderTapScheduleInRepository,
+  private val tapSubTypeRepository: ReferenceCodeRepository<TapSubType>,
+  private val tapTypeRepository: ReferenceCodeRepository<TapType>,
+  private val transportTypeRepository: ReferenceCodeRepository<TapTransportType>,
+) {
+
+  companion object {
+    val MAX_TAP_COMMENT_LENGTH = 225
+  }
+
+  fun offenderOrThrow(offenderNo: String) = offenderRepository.findRootByNomsId(offenderNo)
+    ?: throw NotFoundException("Offender $offenderNo not found")
+
+  fun offenderBookingOrThrow(offenderNo: String) = offenderBookingRepository.findLatestByOffenderNomsId(offenderNo)
+    ?: throw NotFoundException("Offender $offenderNo not found with a booking")
+
+  fun movementApplicationOrThrow(movementApplicationId: Long) = offenderTapApplicationRepository.findByIdOrNull(movementApplicationId)
+    ?: throw BadDataException("Movement application $movementApplicationId does not exist")
+
+  fun tapScheduleOutOrThrow(eventId: Long) = tapScheduleOutRepository.findByIdOrNull(eventId)
+    ?: throw BadDataException("Tap schedule out $eventId does not exist")
+
+  fun tapScheduleInOrThrow(eventId: Long) = tapScheduleInRepository.findByIdOrNull(eventId)
+    ?: throw BadDataException("Tap schedule in $eventId does not exist")
+
+  fun movementReasonOrThrow(movementReason: String) = movementReasonRepository.findByIdOrNull(MovementReason.pk(movementReason))
+    ?: throw BadDataException("Event sub type $movementReason is invalid")
+
+  fun applicationStatusOrThrow(applicationStatus: String) = movementApplicationStatusRepository.findByIdOrNull(MovementApplicationStatus.pk(applicationStatus))
+    ?: throw BadDataException("Application status $applicationStatus is invalid")
+
+  fun escortOrThrow(escort: String) = escortRepository.findByIdOrNull(Escort.pk(escort))
+    ?: throw BadDataException("Escort code $escort is invalid")
+
+  fun transportTypeOrThrow(transportType: String) = transportTypeRepository.findByIdOrNull(TapTransportType.pk(transportType))
+    ?: throw BadDataException("Transport type $transportType is invalid")
+
+  fun addressOrThrow(addressId: Long) = addressRepository.findByIdOrNull(addressId)
+    ?: throw BadDataException("Address id $addressId is invalid")
+
+  fun agencyLocationOrThrow(agencyId: String) = agencyLocationRepository.findByIdOrNull(agencyId)
+    ?: throw BadDataException("Agency id $agencyId is invalid")
+
+  fun movementApplicationTypeOrThrow(applicationType: String) = movementApplicationTypeRepository.findByIdOrNull(MovementApplicationType.pk(applicationType))
+    ?: throw BadDataException("Application type $applicationType is invalid")
+
+  fun tapTypeOrThrow(tapType: String) = tapTypeRepository.findByIdOrNull(TapType.pk(tapType))
+    ?: throw BadDataException("Tap type $tapType is invalid")
+
+  fun tapSubTypeOrThrow(tapSubType: String) = tapSubTypeRepository.findByIdOrNull(TapSubType.pk(tapSubType))
+    ?: throw BadDataException("Tap sub type $tapSubType is invalid")
+
+  fun eventStatusOrThrow(eventStatus: String) = eventStatusRepository.findByIdOrNull(EventStatus.pk(eventStatus))
+    ?: throw BadDataException("Event status $eventStatus is invalid")
+
+  fun arrestAgencyOrThrow(arrestAgency: String) = arrestAgencyRepository.findByIdOrNull(ArrestAgency.pk(arrestAgency))
+    ?: throw BadDataException("Arrest Agency $arrestAgency is invalid")
+}
+
+internal fun List<OffenderTapApplication>.tapMovementOuts() = flatMap {
+  it.tapScheduleOuts.mapNotNull {
+    it.tapMovementOut
+  }
+}.toSet()
+
+internal fun List<OffenderTapApplication>.tapMovementIns() = flatMap {
+  it.tapScheduleOuts.flatMap {
+    it.tapScheduleIns.mapNotNull {
+      it.tapMovementIn
+    }
+  }
+}.toSet()
+
+internal fun OffenderTapMovementIn.unlinkWrongSchedules(): Boolean = when (tapScheduleIn) {
+  null -> false
+  in tapScheduleOut?.tapScheduleIns ?: emptyList() -> false
+  else -> {
+    tapScheduleOut = null
+    tapScheduleIn = null
+    true
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationModel.kt
@@ -1,0 +1,155 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.NomisAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.UpsertTapAddress
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "Tap application")
+data class TapApplication(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Whether this is the latest booking")
+  val latestBooking: Boolean,
+
+  @Schema(description = "Whether this is an active booking")
+  val activeBooking: Boolean,
+
+  @Schema(description = "Tap application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDate,
+
+  @Schema(description = "From date")
+  val fromDate: LocalDate,
+
+  @Schema(description = "Release time")
+  val releaseTime: LocalDateTime,
+
+  @Schema(description = "To date")
+  val toDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "Application status")
+  val applicationStatus: String,
+
+  @Schema(description = "Escort code")
+  val escortCode: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Prison ID")
+  val prisonId: String,
+
+  @Schema(description = "To agency ID")
+  val toAgencyId: String?,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "To full address")
+  val toFullAddress: String?,
+
+  @Schema(description = "To address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Contact person name")
+  val contactPersonName: String?,
+
+  @Schema(description = "Application type")
+  val applicationType: String,
+
+  @Schema(description = "Temporary absence type")
+  val tapType: String?,
+
+  @Schema(description = "Temporary absence sub type")
+  val tapSubType: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Upsert tap application request")
+data class UpsertTapApplication(
+  @Schema(description = "Existing PK, null if new")
+  val tapApplicationId: Long? = null,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDate,
+
+  @Schema(description = "From date")
+  val fromDate: LocalDate,
+
+  @Schema(description = "Release time")
+  val releaseTime: LocalDateTime,
+
+  @Schema(description = "To date")
+  val toDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "Application status")
+  val applicationStatus: String,
+
+  @Schema(description = "Escort code")
+  val escortCode: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Prison ID")
+  val prisonId: String,
+
+  @Schema(description = "Contact person name")
+  val contactPersonName: String?,
+
+  @Schema(description = "Application type")
+  val applicationType: String,
+
+  @Schema(description = "Temporary absence type")
+  val tapType: String?,
+
+  @Schema(description = "Temporary absence sub type")
+  val tapSubType: String?,
+
+  @Schema(description = "To address. If this is null, do not update the address. Otherwise use the addressId in the request.")
+  @Deprecated("Use toAddresses instead", ReplaceWith("toAddresses"))
+  val toAddress: UpsertTapAddress? = null,
+
+  @Schema(description = "To addresses linked to schedules. Makes sure they all exist in NOMIS so are available when upserting schedules.")
+  val toAddresses: List<UpsertTapAddress> = emptyList(),
+)
+
+@Schema(description = "Upsert tap application response")
+data class UpsertTapApplicationResponse(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement application ID")
+  val tapApplicationId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationResource.kt
@@ -1,0 +1,175 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
+
+@PreAuthorize("hasRole('ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW')")
+@RestController
+@Validated
+@RequestMapping("/movements/{offenderNo}/taps/application", produces = [MediaType.APPLICATION_JSON_VALUE])
+class TapApplicationResource(
+  private val service: TapApplicationService,
+) {
+  @GetMapping("/{applicationId}")
+  @Operation(
+    summary = "Get a specific tap application for an offender",
+    description = "Get a specific tap application for an offender. Note that this does not include any children such as the scheduled or actual movements. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap application returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender or application not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapApplication(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+    @Schema(description = "Application ID", example = "123") @PathVariable applicationId: Long,
+  ) = service.getTapApplication(offenderNo, applicationId)
+
+  @PutMapping
+  @Operation(
+    summary = "Inserts or updates a tap application for an offender",
+    description = "Creates or updates a tap application on the prisoner's latest booking. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Tap application created",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "One or more fields in the request contains invalid data",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun upsertTapApplication(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @RequestBody @Valid
+    request: UpsertTapApplication,
+  ): UpsertTapApplicationResponse = service.upsertTapApplication(offenderNo, request)
+
+  @DeleteMapping("/{applicationId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Delete a tap application for an offender.",
+    description = "Deletes a tap application. This should only be required where we have duplicates! Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Tap application deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Unable to delete the application. See error message for details",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deleteTapApplication(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @Schema(description = "TAP application ID", example = "12345")
+    @PathVariable
+    applicationId: Long,
+  ) = service.deleteTapApplication(offenderNo, applicationId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.truncateToUtf8Length
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapAddressService
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers.Companion.MAX_TAP_COMMENT_LENGTH
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.toFullAddress
+import java.time.LocalTime
+
+@Service
+@Transactional(readOnly = true)
+class TapApplicationService(
+  private val offenderBookingRepository: OffenderBookingRepository,
+  private val offenderRepository: OffenderRepository,
+  private val applicationRepository: OffenderTapApplicationRepository,
+  private val tapAddressService: TapAddressService,
+  private val tapHelpers: TapHelpers,
+) {
+  fun getTapApplication(offenderNo: String, applicationId: Long): TapApplication {
+    if (!offenderRepository.existsByNomsId(offenderNo)) {
+      throw NotFoundException("Offender with nomsId=$offenderNo not found")
+    }
+
+    val application = applicationRepository.findByTapApplicationIdAndOffenderBooking_Offender_NomsId(applicationId, offenderNo)
+      ?: throw NotFoundException("Tap application with id=$applicationId not found for offender with nomsId=$offenderNo")
+
+    return application.toResponse()
+  }
+
+  @Transactional
+  fun upsertTapApplication(offenderNo: String, request: UpsertTapApplication): UpsertTapApplicationResponse {
+    val offenderBooking = tapHelpers.offenderBookingOrThrow(offenderNo)
+    val eventSubType = tapHelpers.movementReasonOrThrow(request.eventSubType)
+    val applicationStatus = tapHelpers.applicationStatusOrThrow(request.applicationStatus)
+    val escort = request.escortCode?.let { tapHelpers.escortOrThrow(request.escortCode) }
+    val transportType = request.transportType?.let { tapHelpers.transportTypeOrThrow(request.transportType) }
+    val prison = tapHelpers.agencyLocationOrThrow(request.prisonId)
+    val applicationType = tapHelpers.movementApplicationTypeOrThrow(request.applicationType)
+    val tapType = request.tapType?.let { tapHelpers.tapTypeOrThrow(request.tapType) }
+    val tapSubType = request.tapSubType?.let { tapHelpers.tapSubTypeOrThrow(request.tapSubType) }
+    // Make sure all requested addresses exist, but just take the first one as NOMIS only supports a single address at the application level
+    val toAddress = request.toAddresses
+      .filterNot { it.hasNullValues() }
+      .map { tapAddressService.findOrCreateAddress(it, offenderBooking.offender) }
+      .firstOrNull()
+    val toAddressAgency = toAddress
+      .takeIf { it?.addressOwnerClass == "AGY" }
+      ?.let { it as AgencyLocationAddress }
+      ?.agencyLocation
+
+    val application = request.tapApplicationId
+      ?.let {
+        applicationRepository.findByIdOrNullForUpdate(request.tapApplicationId)
+          ?: throw NotFoundException("Tap application with id=$request.movementApplicationId not found for offender with nomsId=$offenderNo")
+      } ?: OffenderTapApplication(
+      offenderBooking = offenderBooking,
+      applicationDate = request.applicationDate.atTime(LocalTime.MIDNIGHT),
+      applicationTime = request.applicationDate.atTime(LocalTime.MIDNIGHT),
+      prison = prison,
+      applicationType = applicationType,
+      eventSubType = eventSubType,
+      fromDate = request.fromDate,
+      releaseTime = request.releaseTime,
+      toDate = request.toDate,
+      returnTime = request.returnTime,
+      applicationStatus = applicationStatus,
+      toAgency = toAddressAgency,
+      toAddress = toAddress,
+      toAddressOwnerClass = toAddress?.addressOwnerClass,
+    )
+
+    with(application) {
+      this.fromDate = request.fromDate
+      this.releaseTime = request.releaseTime
+      this.toDate = request.toDate
+      this.returnTime = request.returnTime
+      this.applicationStatus = applicationStatus
+      this.transportType = transportType
+      this.escort = escort
+      this.comment = request.comment?.truncateToUtf8Length(MAX_TAP_COMMENT_LENGTH, includeSeeDpsSuffix = true)
+      this.contactPersonName = request.contactPersonName
+      this.applicationType = applicationType
+      this.tapType = tapType
+      this.tapSubType = tapSubType
+      this.eventSubType = eventSubType
+      this.toAgency = toAddressAgency
+      this.toAddress = toAddress
+      this.toAddressOwnerClass = toAddress?.addressOwnerClass
+    }
+
+    if (application.isApproved() && application.toAddress == null) {
+      throw BadDataException("The application is approved but no address has been provided")
+    }
+
+    // NOMIS does not allow schedules on an unapproved single application - if we find one then remove it
+    if (!application.isApproved() && application.isSingle()) {
+      val schedule = application.tapScheduleOuts.firstOrNull()
+      if (schedule?.tapMovementOut != null) throw BadDataException("Attempt to remove a schedule from an unapproved application failed - the schedule (${schedule.eventId}) is attached to a movement (${schedule.tapMovementOut!!.id.offenderBooking.bookingId}/${schedule.tapMovementOut!!.id.sequence}).")
+      application.tapScheduleOuts.remove(schedule)
+    }
+
+    return applicationRepository.save(application)
+      .let { UpsertTapApplicationResponse(offenderBooking.bookingId, it.tapApplicationId) }
+  }
+
+  @Transactional
+  fun deleteTapApplication(offenderNo: String, applicationId: Long) {
+    applicationRepository.findByIdOrNull(applicationId)
+      ?.also { application ->
+        if (application.tapScheduleOuts.isNotEmpty()) {
+          throw ConflictException("Cannot delete tap applicationId $applicationId because it has tap schedules")
+        }
+
+        offenderBookingRepository.findByIdOrNull(application.offenderBooking.bookingId)
+          ?.takeIf { it.offender.nomsId != offenderNo }
+          ?.run { throw ConflictException("ApplicationId $applicationId exists on a different offender") }
+
+        applicationRepository.delete(application)
+      }
+  }
+
+  private fun OffenderTapApplication.toResponse() = TapApplication(
+    bookingId = offenderBooking.bookingId,
+    activeBooking = offenderBooking.active,
+    latestBooking = offenderBooking.bookingSequence == 1,
+    tapApplicationId = tapApplicationId,
+    eventSubType = eventSubType.code,
+    applicationDate = applicationDate.toLocalDate(),
+    fromDate = fromDate,
+    releaseTime = releaseTime,
+    toDate = toDate,
+    returnTime = returnTime,
+    applicationStatus = applicationStatus.code,
+    escortCode = escort?.code,
+    transportType = transportType?.code,
+    comment = comment,
+    toAddressId = toAddress?.addressId,
+    toAddressOwnerClass = toAddress?.addressOwnerClass,
+    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressPostcode = toAddress?.postalCode?.trim(),
+    prisonId = prison.id,
+    toAgencyId = toAgency?.id,
+    contactPersonName = contactPersonName,
+    applicationType = applicationType.code,
+    tapType = tapType?.code,
+    tapSubType = tapSubType?.code,
+    audit = toAudit(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementModel.kt
@@ -1,0 +1,219 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.NomisAudit
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "Tap Movement Out")
+data class TapMovementOut(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Tap application ID. Empty for unscheduled movements.")
+  val tapApplicationId: Long?,
+
+  @Schema(description = "Tap schedule out event ID. Empty for unscheduled movements.")
+  val tapScheduleOutId: Long?,
+
+  @Schema(description = "Movement sequence")
+  val sequence: Int,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason")
+  val movementReason: String,
+
+  @Schema(description = "Arresting Agency")
+  val arrestAgency: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "Escort text")
+  val escortText: String?,
+
+  @Schema(description = "From prison")
+  val fromPrison: String,
+
+  @Schema(description = "To agency")
+  val toAgency: String?,
+
+  @Schema(description = "Comment text")
+  val commentText: String?,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "Full to address")
+  val toFullAddress: String?,
+
+  @Schema(description = "To address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap movement in")
+data class TapMovementIn(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Tap application ID. Empty for unscheduled movements.")
+  val tapApplicationId: Long?,
+
+  @Schema(description = "Tap scheduled out event ID. Empty for unscheduled movements.")
+  val tapScheduleOutId: Long?,
+
+  @Schema(description = "Tap schedule in event ID. Empty for unscheduled movements.")
+  val tapScheduleInId: Long?,
+
+  @Schema(description = "Movement sequence")
+  val sequence: Int,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason")
+  val movementReason: String,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "Escort text")
+  val escortText: String?,
+
+  @Schema(description = "From agency")
+  val fromAgency: String?,
+
+  @Schema(description = "To prison")
+  val toPrison: String,
+
+  @Schema(description = "Comment text")
+  val commentText: String?,
+
+  @Schema(description = "From address ID")
+  val fromAddressId: Long?,
+
+  @Schema(description = "From address owner class")
+  val fromAddressOwnerClass: String?,
+
+  @Schema(description = "From address description")
+  val fromAddressDescription: String?,
+
+  @Schema(description = "From full address")
+  val fromFullAddress: String?,
+
+  @Schema(description = "From address postcode")
+  val fromAddressPostcode: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Create tap movement out")
+data class CreateTapMovementOut(
+  @Schema(description = "Tap scheduled out event ID")
+  val tapScheduleOutId: Long? = null,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason code (ref domain MOVE_RSN)")
+  val movementReason: String,
+
+  @Schema(description = "Arresting agency code")
+  val arrestAgency: String? = null,
+
+  @Schema(description = "Escort code")
+  val escort: String? = null,
+
+  @Schema(description = "Escort text")
+  val escortText: String? = null,
+
+  @Schema(description = "From prison code")
+  val fromPrison: String,
+
+  @Schema(description = "To agency code")
+  val toAgency: String? = null,
+
+  @Schema(description = "Comment")
+  val commentText: String? = null,
+
+  @Schema(description = "To city code (ref domain CITY)")
+  val toCity: String? = null,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long? = null,
+)
+
+@Schema(description = "Create tap movement out response")
+data class CreateTapMovementOutResponse(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement sequence")
+  val movementSequence: Int,
+)
+
+@Schema(description = "Create tap movement in request")
+data class CreateTapMovementIn(
+  @Schema(description = "Tap schedule in event ID")
+  val tapScheduleInId: Long? = null,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason")
+  val movementReason: String,
+
+  @Schema(description = "Arresting agency code")
+  val arrestAgency: String? = null,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "Escort text")
+  val escortText: String?,
+
+  @Schema(description = "From agency")
+  val fromAgency: String?,
+
+  @Schema(description = "To prison")
+  val toPrison: String,
+
+  @Schema(description = "Comment text")
+  val commentText: String?,
+
+  @Schema(description = "From address ID")
+  val fromAddressId: Long?,
+)
+
+@Schema(description = "Create tap movement in response")
+data class CreateTapMovementInResponse(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement sequence")
+  val movementSequence: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementResource.kt
@@ -1,0 +1,224 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
+
+@PreAuthorize("hasRole('ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW')")
+@RestController
+@Validated
+@RequestMapping("/movements/{offenderNo}/taps/movement", produces = [MediaType.APPLICATION_JSON_VALUE])
+class TapMovementResource(
+  private val service: TapMovementService,
+) {
+
+  @GetMapping("/out/{bookingId}/{movementSeq}")
+  @Operation(
+    summary = "Get a specific tap movement out for an offender",
+    description = "Get a specific tap movement out for an offender by booking ID and movement sequence. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap movement out returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender or tap movement out not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapMovementOut(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+    @Schema(description = "Booking ID", example = "123") @PathVariable bookingId: Long,
+    @Schema(description = "Movement Sequence", example = "1") @PathVariable movementSeq: Int,
+  ) = service.getTapMovementOut(offenderNo, bookingId, movementSeq)
+
+  @PostMapping("/out")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Inserts a tap movement out for an offender",
+    description = "Creates a tap movement out on the prisoner's latest booking. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Tap movement out created",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "One or more fields in the request contains invalid data",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun createTapMovementOut(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @RequestBody @Valid
+    request: CreateTapMovementOut,
+  ): CreateTapMovementOutResponse = service.createTapMovementOut(offenderNo, request)
+
+  @GetMapping("/in/{bookingId}/{movementSeq}")
+  @Operation(
+    summary = "Get a specific tap movement in for an offender",
+    description = "Get a specific tap movement in for an offender by booking ID and movement sequence. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap movement in returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender or tap movement in not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapMovementIn(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+    @Schema(description = "Booking ID", example = "123") @PathVariable bookingId: Long,
+    @Schema(description = "Movement Sequence", example = "1") @PathVariable movementSeq: Int,
+  ) = service.getTapMovementIn(offenderNo, bookingId, movementSeq)
+
+  @PostMapping("/in")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Inserts a tap movement in for an offender",
+    description = "Creates a tap movement in on the prisoner's latest booking. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Tap movement in created",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "One or more fields in the request contains invalid data",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun createTapMovementIn(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @RequestBody @Valid
+    request: CreateTapMovementIn,
+  ): CreateTapMovementInResponse = service.createTapMovementIn(offenderNo, request)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/movement/TapMovementService.kt
@@ -1,0 +1,196 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovementId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.activeExternalMovement
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.maxMovementSequence
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapAddressService
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.toFullAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.unlinkWrongSchedules
+
+@Service
+@Transactional(readOnly = true)
+class TapMovementService(
+  private val tapMovementOutRepository: OffenderTapMovementOutRepository,
+  private val tapMovementInRepository: OffenderTapMovementInRepository,
+  private val tapAddressService: TapAddressService,
+  private val tapHelpers: TapHelpers,
+  movementTypeRepository: ReferenceCodeRepository<MovementType>,
+) {
+  private val tapMovementType = movementTypeRepository.findByIdOrNull(MovementType.pk("TAP"))
+    ?: throw IllegalStateException("TAP movement type not found")
+
+  fun getTapMovementOut(offenderNo: String, bookingId: Long, movementSeq: Int): TapMovementOut {
+    tapHelpers.offenderOrThrow(offenderNo)
+
+    val tapMovementOut = tapMovementOutRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSeq)
+      ?: throw NotFoundException("Tap movement out with bookingId=$bookingId and sequence=$movementSeq not found for offender with nomsId=$offenderNo")
+
+    // Despite being non-nullable, Hibernate happily loads a null application if missing in NOMIS - if so then make the movement unscheduled
+    if (tapMovementOut.tapScheduleOut?.tapApplication == null) {
+      tapMovementOut.tapScheduleOut = null
+    }
+
+    return tapMovementOut.toResponse()
+  }
+
+  @Transactional
+  fun createTapMovementOut(offenderNo: String, request: CreateTapMovementOut): CreateTapMovementOutResponse {
+    val offenderBooking = tapHelpers.offenderBookingOrThrow(offenderNo)
+    val tapScheduleOut = request.tapScheduleOutId?.let { tapHelpers.tapScheduleOutOrThrow(request.tapScheduleOutId) }
+    val movementReason = tapHelpers.movementReasonOrThrow(request.movementReason)
+    val arrestAgency = request.arrestAgency?.let { tapHelpers.arrestAgencyOrThrow(request.arrestAgency) }
+    val escort = request.escort?.let { tapHelpers.escortOrThrow(request.escort) }
+    val fromPrison = tapHelpers.agencyLocationOrThrow(request.fromPrison)
+    val toAgency = request.toAgency?.let { tapHelpers.agencyLocationOrThrow(request.toAgency) }
+    val toAddress = request.toAddressId?.let { tapHelpers.addressOrThrow(request.toAddressId) }
+
+    return OffenderTapMovementOut(
+      id = OffenderExternalMovementId(offenderBooking, offenderBooking.maxMovementSequence() + 1),
+      tapScheduleOut = tapScheduleOut,
+      movementDate = request.movementDate,
+      movementTime = request.movementTime,
+      movementType = tapMovementType,
+      movementReason = movementReason,
+      arrestAgency = arrestAgency,
+      escort = escort,
+      escortText = request.escortText,
+      fromPrison = fromPrison,
+      toAgency = toAgency,
+      active = true,
+      commentText = request.commentText,
+      toCity = toAddress?.city,
+      toAddress = toAddress,
+    ).let {
+      offenderBooking.activeExternalMovement().forEach { it.active = false }
+      tapMovementOutRepository.save(it)
+    }.let {
+      CreateTapMovementOutResponse(
+        bookingId = offenderBooking.bookingId,
+        movementSequence = it.id.sequence,
+      )
+    }
+  }
+
+  fun getTapMovementIn(offenderNo: String, bookingId: Long, movementSeq: Int): TapMovementIn {
+    tapHelpers.offenderOrThrow(offenderNo)
+
+    val tapMovementIn = tapMovementInRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSeq)
+      ?: throw NotFoundException("Tap movement in with bookingId=$bookingId and sequence=$movementSeq not found for offender with nomsId=$offenderNo")
+
+    // Despite being non-nullable, Hibernate happily loads a null application if missing in NOMIS - if so then make the movement unscheduled
+    if (tapMovementIn.tapScheduleOut?.tapApplication == null) {
+      tapMovementIn.tapScheduleOut = null
+      tapMovementIn.tapScheduleIn = null
+    }
+
+    tapMovementIn.unlinkWrongSchedules()
+    return tapMovementIn.toResponse()
+  }
+
+  @Transactional
+  fun createTapMovementIn(offenderNo: String, request: CreateTapMovementIn): CreateTapMovementInResponse {
+    val offenderBooking = tapHelpers.offenderBookingOrThrow(offenderNo)
+    val tapScheduleIn = request.tapScheduleInId?.let { tapHelpers.tapScheduleInOrThrow(request.tapScheduleInId) }
+    val movementReason = tapHelpers.movementReasonOrThrow(request.movementReason)
+    val arrestAgency = request.arrestAgency?.let { tapHelpers.arrestAgencyOrThrow(request.arrestAgency) }
+    val escort = request.escort?.let { tapHelpers.escortOrThrow(request.escort) }
+    val fromAgency = request.fromAgency?.let { tapHelpers.agencyLocationOrThrow(request.fromAgency) }
+    val toPrison = tapHelpers.agencyLocationOrThrow(request.toPrison)
+    val fromAddress = request.fromAddressId?.let { tapHelpers.addressOrThrow(request.fromAddressId) }
+
+    return OffenderTapMovementIn(
+      id = OffenderExternalMovementId(offenderBooking, offenderBooking.maxMovementSequence() + 1),
+      tapScheduleIn = tapScheduleIn,
+      tapScheduleOut = tapScheduleIn?.tapScheduleOut,
+      movementDate = request.movementDate,
+      movementTime = request.movementTime,
+      movementType = tapMovementType,
+      movementReason = movementReason,
+      arrestAgency = arrestAgency,
+      escort = escort,
+      escortText = request.escortText,
+      fromAgency = fromAgency,
+      toPrison = toPrison,
+      active = true,
+      commentText = request.commentText,
+      fromCity = fromAddress?.city,
+      fromAddress = fromAddress,
+    ).let {
+      offenderBooking.activeExternalMovement().forEach { it.active = false }
+      tapMovementInRepository.save(it)
+    }.let {
+      CreateTapMovementInResponse(
+        bookingId = offenderBooking.bookingId,
+        movementSequence = it.id.sequence,
+      )
+    }
+  }
+  private fun OffenderTapMovementOut.toResponse(): TapMovementOut {
+    // The address may only exist on the schedule so check there too
+    val toAddress = toAddress
+      ?: toAgency?.addresses?.firstOrNull()
+      ?: tapScheduleOut?.toAddress
+    return TapMovementOut(
+      bookingId = id.offenderBooking.bookingId,
+      sequence = id.sequence,
+      tapScheduleOutId = tapScheduleOut?.eventId,
+      tapApplicationId = tapScheduleOut?.tapApplication?.tapApplicationId,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      arrestAgency = arrestAgency?.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromPrison = fromAgency!!.id,
+      toAgency = toAgency?.id,
+      commentText = commentText,
+      toAddressId = toAddress?.addressId,
+      toAddressOwnerClass = toAddress?.addressOwnerClass,
+      toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+      toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)) ?: toCity?.description,
+      toAddressPostcode = toAddress?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+
+  private fun OffenderTapMovementIn.toResponse(): TapMovementIn {
+    // The address may only exist on the outbound movement or the scheduled outbound movement so check there too
+    val address = fromAddress
+      ?: fromAgency?.addresses?.firstOrNull()
+      ?: tapScheduleOut?.tapMovementOut?.toAddress
+      ?: tapScheduleOut?.toAddress
+    return TapMovementIn(
+      bookingId = id.offenderBooking.bookingId,
+      sequence = id.sequence,
+      tapScheduleOutId = tapScheduleOut?.eventId,
+      tapScheduleInId = tapScheduleIn?.eventId,
+      tapApplicationId = tapScheduleOut?.tapApplication?.tapApplicationId,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromAgency = fromAgency?.id,
+      toPrison = toAgency!!.id,
+      commentText = commentText,
+      fromAddressId = address?.addressId,
+      fromAddressOwnerClass = address?.addressOwnerClass,
+      fromAddressDescription = tapAddressService.getAddressDescription(address),
+      fromFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(address)) ?: fromCity?.description,
+      fromAddressPostcode = address?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsModel.kt
@@ -1,0 +1,395 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.NomisAudit
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "Offender taps by booking, including applications, schedules and movements")
+data class OffenderTapsResponse(
+  @Schema(description = "List of bookings with their taps")
+  val bookings: List<BookingTaps>,
+)
+
+@Schema(description = "Booking taps")
+data class BookingTaps(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Tap applications")
+  val tapApplications: List<BookingTapApplication>,
+
+  @Schema(description = "Unscheduled tap movements OUT - those without an application or a schedule")
+  val unscheduledTapMovementOuts: List<BookingTapMovementOut>,
+
+  @Schema(description = "Unscheduled tap movements IN - those without an application or a schedule")
+  val unscheduledTapMovementIns: List<BookingTapMovementIn>,
+
+  @Schema(description = "Whether this is an active booking")
+  val activeBooking: Boolean,
+
+  @Schema(description = "Whether this is the latest booking")
+  val latestBooking: Boolean,
+)
+
+@Schema(description = "Tap application response")
+data class BookingTapApplication(
+  @Schema(description = "Tap application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDate,
+
+  @Schema(description = "From date")
+  val fromDate: LocalDate,
+
+  @Schema(description = "Release time")
+  val releaseTime: LocalDateTime,
+
+  @Schema(description = "To date")
+  val toDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "Application status")
+  val applicationStatus: String,
+
+  @Schema(description = "Escort code")
+  val escortCode: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Prison ID")
+  val prisonId: String,
+
+  @Schema(description = "To agency ID")
+  val toAgencyId: String?,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "To full address")
+  val toFullAddress: String?,
+
+  @Schema(description = "To address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Contact person name")
+  val contactPersonName: String?,
+
+  @Schema(description = "Application type")
+  val applicationType: String,
+
+  @Schema(description = "Tap type")
+  val tapType: String?,
+
+  @Schema(description = "Tap sub type")
+  val tapSubType: String?,
+
+  @Schema(description = "All taps")
+  val taps: List<BookingTap> = mutableListOf(),
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "A single instance of a tap including schedules and movements in and out")
+data class BookingTap(
+
+  @Schema(description = "Tap schedule out")
+  val tapScheduleOut: BookingTapScheduleOut? = null,
+
+  @Schema(description = "Tap schedule in")
+  val tapScheduleIn: BookingTapScheduleIn? = null,
+
+  @Schema(description = "Tap movement out")
+  val tapMovementOut: BookingTapMovementOut? = null,
+
+  @Schema(description = "Tap movement in")
+  val tapMovementIn: BookingTapMovementIn? = null,
+)
+
+@Schema(description = "Tap schedule out")
+data class BookingTapScheduleOut(
+  @Schema(description = "Event ID")
+  val eventId: Long,
+
+  @Schema(description = "Event date")
+  val eventDate: LocalDate,
+
+  @Schema(description = "Start time")
+  val startTime: LocalDateTime,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Event status")
+  val eventStatus: String,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "From prison")
+  val fromPrison: String?,
+
+  @Schema(description = "To agency")
+  val toAgency: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Return date")
+  val returnDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "To full address")
+  val toFullAddress: String?,
+
+  @Schema(description = "TO address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDateTime,
+
+  @Schema(description = "Application time")
+  val applicationTime: LocalDateTime?,
+
+  @Schema(description = "Contact person name")
+  val contactPersonName: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap schedule in")
+data class BookingTapScheduleIn(
+  @Schema(description = "Event ID")
+  val eventId: Long,
+
+  @Schema(description = "Event date")
+  val eventDate: LocalDate,
+
+  @Schema(description = "Start time")
+  val startTime: LocalDateTime,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Event status")
+  val eventStatus: String,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "From agency")
+  val fromAgency: String?,
+
+  @Schema(description = "To prison")
+  val toPrison: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap movement out")
+data class BookingTapMovementOut(
+  @Schema(description = "Movement sequence")
+  val sequence: Int,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason")
+  val movementReason: String,
+
+  @Schema(description = "Arresting Agency")
+  val arrestAgency: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "Escort text")
+  val escortText: String?,
+
+  @Schema(description = "From prison")
+  val fromPrison: String?,
+
+  @Schema(description = "To agency")
+  val toAgency: String?,
+
+  @Schema(description = "Comment text")
+  val commentText: String?,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "Full to address")
+  val toFullAddress: String?,
+
+  @Schema(description = "To address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap movement in")
+data class BookingTapMovementIn(
+  @Schema(description = "Movement sequence")
+  val sequence: Int,
+
+  @Schema(description = "Movement date")
+  val movementDate: LocalDate,
+
+  @Schema(description = "Movement time")
+  val movementTime: LocalDateTime,
+
+  @Schema(description = "Movement reason")
+  val movementReason: String,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "Escort text")
+  val escortText: String?,
+
+  @Schema(description = "From agency")
+  val fromAgency: String?,
+
+  @Schema(description = "To prison")
+  val toPrison: String?,
+
+  @Schema(description = "Comment text")
+  val commentText: String?,
+
+  @Schema(description = "From address ID")
+  val fromAddressId: Long?,
+
+  @Schema(description = "From address owner class")
+  val fromAddressOwnerClass: String?,
+
+  @Schema(description = "From address description")
+  val fromAddressDescription: String?,
+
+  @Schema(description = "From full address")
+  val fromFullAddress: String?,
+
+  @Schema(description = "From address postcode")
+  val fromAddressPostcode: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap counts")
+data class TapSummary(
+  @Schema(description = "The application counts")
+  val applications: ApplicationSummary,
+  @Schema(description = "The schedule out counts")
+  val scheduledOuts: ScheduledOutSummary,
+  @Schema(description = "The actual movement counts")
+  val movements: MovementSummary,
+)
+
+@Schema(description = "Offender tap application counts")
+data class ApplicationSummary(
+  @Schema(description = "The number of applications")
+  val count: Long,
+)
+
+@Schema(description = "Offender tap schedule OUT counts")
+data class ScheduledOutSummary(
+  @Schema(description = "The number of schedules OUT")
+  val count: Long,
+)
+
+@Schema(description = "Offender tap movement counts")
+data class MovementSummary(
+  @Schema(description = "The number of actual movements")
+  val count: Long,
+  @Schema(description = "The number of scheduled movements by direction")
+  val scheduled: MovementsByDirection,
+  @Schema(description = "The number of unscheduled movements by direction")
+  val unscheduled: MovementsByDirection,
+)
+
+@Schema(description = "Offender tap movement counts")
+data class MovementsByDirection(
+  @Schema(description = "The number of actual OUT movements")
+  val outCount: Long,
+  @Schema(description = "The number of actual IN movements")
+  val inCount: Long,
+)
+
+@Schema(description = "Offender taps ids by booking, including applications and scheduled absences")
+data class OffenderTapsIdsResponse(
+  @Schema(description = "List of TAP application IDs")
+  val applicationIds: List<Long>,
+
+  @Schema(description = "List of TAP scheduled OUT IDs")
+  val scheduleOutIds: List<Long>,
+
+  @Schema(description = "List of TAP scheduled IN IDs")
+  val scheduleInIds: List<Long>,
+
+  @Schema(description = "List of TAP scheduled movement OUT IDs")
+  val scheduledMovementOutIds: List<OffenderTapMovementId>,
+
+  @Schema(description = "List of TAP scheduled movement IN IDs")
+  val scheduledMovementInIds: List<OffenderTapMovementId>,
+
+  @Schema(description = "List of TAP unscheduled movement OUT IDs")
+  val unscheduledMovementOutIds: List<OffenderTapMovementId>,
+
+  @Schema(description = "List of TAP unscheduled movement IN IDs")
+  val unscheduledMovementInIds: List<OffenderTapMovementId>,
+)
+
+@Schema(description = "The ID of a single movement")
+data class OffenderTapMovementId(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement sequence")
+  val sequence: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsResource.kt
@@ -1,0 +1,166 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
+
+@PreAuthorize("hasRole('ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW')")
+@RestController
+@Validated
+@RequestMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+class OffenderTapsResource(
+  private val service: OffenderTapsService,
+) {
+  @GetMapping("/movements/{offenderNo}/taps")
+  @Operation(
+    summary = "Get tap applications, schedules and external movements for an offender",
+    description = "Get tap applications, schedules and external movements for an offender. This is used to migrate taps to DPS and for reconciliation. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender taps returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getAllOffenderTaps(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+  ): OffenderTapsResponse = service.getOffenderTaps(offenderNo)
+
+  @GetMapping("/movements/booking/{bookingId}/taps")
+  @Operation(
+    summary = "Get tap applications, schedules and external movements for a booking",
+    description = "Get tap applications, schedules and external movements for a booking. This is used to migrate taps to DPS and for reconciliation. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Booking taps returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Booking not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getAllBookingTaps(
+    @Schema(description = "Booking ID", example = "123456") @PathVariable bookingId: Long,
+  ): BookingTaps = service.getBookingTaps(bookingId)
+
+  @GetMapping("/movements/{offenderNo}/taps/summary")
+  @Operation(
+    summary = "Get tap applications, schedules and external movement counts for an offender",
+    description = "Get tap applications, schedules and external movement counts for an offender. This is used for reconciliation. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap counts returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapCounts(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+  ): TapSummary = service.getTapsSummary(offenderNo)
+
+  @GetMapping("/movements/{offenderNo}/taps/ids")
+  @Operation(
+    summary = "Get IDs for taps, schedules and movements for an offender",
+    description = "Get IDs taps, schedules and movements for an offender. This is used to migrate taps to DPS. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender taps IDs returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapsIds(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+  ): OffenderTapsIdsResponse = service.getTapsIds(offenderNo)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsService.kt
@@ -1,0 +1,411 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderExternalMovementRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapAddressService
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.tapMovementIns
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.tapMovementOuts
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.toFullAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.unlinkWrongSchedules
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class OffenderTapsService(
+  private val offenderRepository: OffenderRepository,
+  private val offenderBookingRepository: OffenderBookingRepository,
+  private val tapApplicationRepository: OffenderTapApplicationRepository,
+  private val tapScheduleOutRepository: OffenderTapScheduleOutRepository,
+  private val tapMovementOutRepository: OffenderTapMovementOutRepository,
+  private val tapMovementInRepository: OffenderTapMovementInRepository,
+  private val externalMovementsRepository: OffenderExternalMovementRepository,
+  private val tapHelpers: TapHelpers,
+  private val tapAddressService: TapAddressService,
+) {
+
+  fun getOffenderTaps(offenderNo: String): OffenderTapsResponse {
+    if (!offenderRepository.existsByNomsId(offenderNo)) {
+      throw NotFoundException("Offender with nomsId=$offenderNo not found")
+    }
+
+    // We need to run these queries before findAllByOffenderBooking_Offender_NomsId otherwise if Hibernate finds an entity of
+    // type OffenderTapMovementOut in the session where it's expecting an OffenderTapMovementIn it tries (and fails)
+    // to use the wrong type instead of respecting the @NotFound(IGNORE). So we run these queries before the entity is loaded
+    // into the session and the @NotFound is respected.
+    val allTapMovementOuts = tapMovementOutRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
+    val allTapMovementIns = tapMovementInRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
+
+    val tapApplications = tapApplicationRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
+      .also { it.fixMergedSchedules() }
+      .also { it.unlinkCorruptTapMovementIns() }
+
+    // To find the unscheduled movements we get all movements and remove those linked to a TAP application. This is necessary because of corrupt movements linked to the wrong application.
+    val unscheduledTapMovementOuts = allTapMovementOuts - tapApplications.tapMovementOuts()
+    val unscheduledTapMovementIns = allTapMovementIns - tapApplications.tapMovementIns()
+
+    data class Booking(val id: Long, val active: Boolean, val latest: Boolean)
+
+    val bookings = (
+      tapApplications.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) } +
+        unscheduledTapMovementOuts.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) } +
+        unscheduledTapMovementIns.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) }
+      ).toSet()
+
+    return OffenderTapsResponse(
+      bookings = bookings.map { (bookingId, active, latest) ->
+        toBookingTaps(
+          bookingId = bookingId,
+          active = active,
+          latest = latest,
+          tapApplications = tapApplications,
+          unscheduledTapMovementOuts = unscheduledTapMovementOuts,
+          unscheduledTapMovementIns = unscheduledTapMovementIns,
+        )
+      },
+    )
+  }
+
+  fun getBookingTaps(bookingId: Long): BookingTaps {
+    val booking = offenderBookingRepository.findByIdOrNull(bookingId)
+      ?: throw NotFoundException("Offender booking $bookingId not found")
+
+    // We need to run these queries before findAllByOffenderBooking_BookingId otherwise if Hibernate finds an entity of
+    // type OffenderTapMovementOut in the session where it's expecting an OffenderTapMovementIn it tries (and fails)
+    // to use the wrong type instead of respecting the @NotFound(IGNORE). So we run these queries before the entity is loaded
+    // into the session and the @NotFound is respected.
+    val allTapMovementOuts = tapMovementOutRepository.findAllByOffenderBooking_BookingId(bookingId)
+    val allTapMovementIns = tapMovementInRepository.findAllByOffenderBooking_BookingId(bookingId)
+
+    val movementApplications = tapApplicationRepository.findAllByOffenderBooking_BookingId(bookingId)
+      .also { it.fixMergedSchedules() }
+      .also { it.unlinkCorruptTapMovementIns() }
+
+    // To find the unscheduled movements we get all movements and remove those linked to a TAP application. This is necessary because of corrupt movements linked to the wrong application.
+    val unscheduledTapMovementOuts = allTapMovementOuts - movementApplications.tapMovementOuts()
+    val unscheduledTapMovementIns = allTapMovementIns - movementApplications.tapMovementIns()
+
+    return toBookingTaps(
+      bookingId = bookingId,
+      active = booking.active,
+      latest = booking.bookingSequence == 1,
+      tapApplications = movementApplications,
+      unscheduledTapMovementOuts = unscheduledTapMovementOuts,
+      unscheduledTapMovementIns = unscheduledTapMovementIns,
+    )
+  }
+
+  fun getTapsSummary(offenderNo: String): TapSummary {
+    tapHelpers.offenderOrThrow(offenderNo)
+    val scheduledIn = externalMovementsRepository.countOffenderScheduledIn(offenderNo)
+    val scheduledOut = externalMovementsRepository.countOffenderScheduledOut(offenderNo)
+    val unscheduledIn = externalMovementsRepository.countOffenderUnscheduledIn(offenderNo)
+    val unscheduledOut = externalMovementsRepository.countOffenderUnscheduledOut(offenderNo)
+    return TapSummary(
+      applications = ApplicationSummary(count = tapApplicationRepository.countByOffenderBooking_Offender_NomsId(offenderNo)),
+      scheduledOuts = ScheduledOutSummary(count = tapScheduleOutRepository.countByOffenderBooking_Offender_NomsId_AndTapApplicationIsNotNull(offenderNo)),
+      movements = MovementSummary(
+        count = scheduledIn + scheduledOut + unscheduledIn + unscheduledOut,
+        scheduled = MovementsByDirection(outCount = scheduledOut, inCount = scheduledIn),
+        unscheduled = MovementsByDirection(outCount = unscheduledOut, inCount = unscheduledIn),
+      ),
+    )
+  }
+
+  fun getTapsIds(offenderNo: String): OffenderTapsIdsResponse = getOffenderTaps(offenderNo).let {
+    OffenderTapsIdsResponse(
+      applicationIds = it.bookings.flatMap { it.tapApplications.map { it.tapApplicationId } },
+      scheduleOutIds = it.bookings.flatMap {
+        it.tapApplications.flatMap {
+          it.taps.flatMap {
+            listOfNotNull(
+              it.tapScheduleOut?.eventId,
+            )
+          }
+        }
+      },
+      scheduleInIds = it.bookings.flatMap {
+        it.tapApplications.flatMap {
+          it.taps.flatMap {
+            listOfNotNull(
+              it.tapScheduleIn?.eventId,
+            )
+          }
+        }
+      },
+      scheduledMovementOutIds = it.bookings.flatMap { booking ->
+        booking.tapApplications.flatMap {
+          it.taps.flatMap {
+            listOfNotNull(
+              it.tapMovementOut?.let { OffenderTapMovementId(booking.bookingId, it.sequence) },
+            )
+          }
+        }
+      },
+      scheduledMovementInIds = it.bookings.flatMap { booking ->
+        booking.tapApplications.flatMap {
+          it.taps.flatMap {
+            listOfNotNull(
+              it.tapMovementIn?.let { OffenderTapMovementId(booking.bookingId, it.sequence) },
+            )
+          }
+        }
+      },
+      unscheduledMovementOutIds = it.bookings.flatMap { booking ->
+        booking.unscheduledTapMovementOuts.map {
+          OffenderTapMovementId(
+            booking.bookingId,
+            it.sequence,
+          )
+        }
+      },
+      unscheduledMovementInIds = it.bookings.flatMap { booking ->
+        booking.unscheduledTapMovementIns.map {
+          OffenderTapMovementId(
+            booking.bookingId,
+            it.sequence,
+          )
+        }
+      },
+    )
+  }
+
+  private fun List<OffenderTapApplication>.fixMergedSchedules() {
+    // find any tap schedule ins on the wrong application and remove them (these are created during merges)
+    val tapScheduleInsWithWrongParent = this.flatMap { application ->
+      application.tapScheduleOuts.flatMap { it.tapScheduleIns }
+        .filter { it.tapApplication != null && it.tapApplication != application }
+    }
+
+    // detach the tap schedule ins with wrong application from their scheduled tap
+    this.flatMap { it.tapScheduleOuts }.forEach {
+      it.tapScheduleIns.removeAll(tapScheduleInsWithWrongParent)
+    }
+
+    // put the tap schedule ins onto the correct application and schedule out
+    tapScheduleInsWithWrongParent.forEach { mergedTapScheduleIn ->
+      this.find { it.tapApplicationId == mergedTapScheduleIn.tapApplication?.tapApplicationId }
+        ?.tapScheduleOuts
+        ?.firstOrNull { scheduleOut -> scheduleOut.tapScheduleIns.isEmpty() && scheduleOut.returnDate == mergedTapScheduleIn.eventDate }
+        ?.tapScheduleIns += mergedTapScheduleIn
+      mergedTapScheduleIn.tapApplication = null
+    }
+  }
+
+  /*
+   * Cut links to any tap movement ins that have ended up on the wrong application due to corrupt data
+   */
+  private fun List<OffenderTapApplication>.unlinkCorruptTapMovementIns() {
+    forEach {
+      it.tapScheduleOuts.forEach {
+        it.tapScheduleIns.forEach { tapScheduleIn ->
+          tapScheduleIn.tapMovementIn?.also { tapMovementIn ->
+            if (tapMovementIn.unlinkWrongSchedules()) {
+              tapScheduleIn.tapMovementIn = null
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Make a tap movement in unscheduled if the schedules have been corrupted
+  private fun toBookingTaps(
+    bookingId: Long,
+    active: Boolean,
+    latest: Boolean,
+    tapApplications: List<OffenderTapApplication>,
+    unscheduledTapMovementOuts: List<OffenderTapMovementOut>,
+    unscheduledTapMovementIns: List<OffenderTapMovementIn>,
+  ) = BookingTaps(
+    bookingId = bookingId,
+    activeBooking = active,
+    latestBooking = latest,
+    tapApplications = tapApplications.filter { it.offenderBooking.bookingId == bookingId }
+      .map { it.toResponse() },
+    unscheduledTapMovementOuts = unscheduledTapMovementOuts.filter { it.offenderBooking.bookingId == bookingId }
+      .map { mov -> mov.toUnscheduledResponse() },
+    unscheduledTapMovementIns = unscheduledTapMovementIns.filter { it.offenderBooking.bookingId == bookingId }
+      .map { mov -> mov.toUnscheduledResponse() },
+  )
+
+  private fun OffenderTapApplication.toResponse() = BookingTapApplication(
+    tapApplicationId = tapApplicationId,
+    eventSubType = eventSubType.code,
+    applicationDate = applicationDate.toLocalDate(),
+    fromDate = fromDate,
+    releaseTime = releaseTime,
+    toDate = toDate,
+    returnTime = returnTime,
+    applicationStatus = applicationStatus.code,
+    escortCode = escort?.code,
+    transportType = transportType?.code,
+    comment = comment,
+    toAddressId = toAddress?.addressId,
+    toAddressOwnerClass = toAddress?.addressOwnerClass,
+    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressPostcode = toAddress?.postalCode?.trim(),
+    prisonId = prison.id,
+    toAgencyId = toAgency?.id,
+    contactPersonName = contactPersonName,
+    applicationType = applicationType.code,
+    tapType = tapType?.code,
+    tapSubType = tapSubType?.code,
+    taps = tapScheduleOuts.map {
+      // Some old data has multiple scheduled IN movements for a single scheduled OUT - try to find the one with an actual movement IN
+      val tapScheduleIn = it.tapScheduleIns.firstOrNull { it.tapMovementIn != null }
+        ?: it.tapScheduleIns.firstOrNull()
+      val tapMovementIn = tapScheduleIn?.tapMovementIn
+      BookingTap(
+        tapScheduleOut = it.toResponse(returnTime),
+        tapScheduleIn = tapScheduleIn?.toResponse(),
+        tapMovementOut = it.tapMovementOut?.toResponse(),
+        tapMovementIn = tapMovementIn?.toResponse(),
+      )
+    },
+    audit = toAudit(),
+  )
+
+  private fun OffenderTapScheduleOut.toResponse(applicationReturnTime: LocalDateTime) = BookingTapScheduleOut(
+    eventId = eventId,
+    eventDate = eventDate ?: tapApplication.fromDate,
+    startTime = startTime ?: tapApplication.releaseTime,
+    eventSubType = eventSubType.code,
+    eventStatus = eventStatus.code,
+    comment = comment,
+    escort = escort?.code,
+    fromPrison = fromAgency?.id,
+    toAgency = toAgency?.id,
+    transportType = transportType?.code,
+    returnDate = returnDate,
+    returnTime = returnTime ?: applicationReturnTime,
+    toAddressId = toAddress?.addressId,
+    toAddressOwnerClass = toAddress?.addressOwnerClass,
+    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressPostcode = toAddress?.postalCode?.trim(),
+    applicationDate = applicationDate,
+    applicationTime = applicationTime,
+    contactPersonName = contactPersonName,
+    audit = toAudit(),
+  )
+
+  private fun OffenderTapScheduleIn.toResponse() = BookingTapScheduleIn(
+    eventId = eventId,
+    eventDate = eventDate ?: tapScheduleOut.tapApplication.fromDate,
+    startTime = startTime ?: tapScheduleOut.tapApplication.releaseTime,
+    eventSubType = eventSubType.code,
+    eventStatus = eventStatus.code,
+    comment = comment,
+    escort = escort?.code,
+    fromAgency = fromAgency?.id,
+    toPrison = toAgency?.id,
+    audit = toAudit(),
+  )
+
+  private fun OffenderTapMovementOut.toUnscheduledResponse(): BookingTapMovementOut {
+    val address = toAddress ?: toAgency?.addresses?.firstOrNull()
+    return BookingTapMovementOut(
+      sequence = id.sequence,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      arrestAgency = arrestAgency?.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromPrison = fromAgency?.id,
+      toAgency = toAgency?.id,
+      commentText = commentText,
+      toAddressId = address?.addressId,
+      toAddressOwnerClass = address?.addressOwnerClass,
+      toAddressDescription = tapAddressService.getAddressDescription(address),
+      toFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(address)) ?: toCity?.description,
+      toAddressPostcode = address?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+
+  private fun OffenderTapMovementIn.toUnscheduledResponse(): BookingTapMovementIn {
+    val address = fromAddress ?: fromAgency?.addresses?.firstOrNull()
+    return BookingTapMovementIn(
+      sequence = id.sequence,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromAgency = fromAgency?.id,
+      toPrison = toAgency?.id,
+      commentText = commentText,
+      fromAddressId = address?.addressId,
+      fromAddressOwnerClass = address?.addressOwnerClass,
+      fromAddressDescription = tapAddressService.getAddressDescription(address),
+      fromFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(fromAddress)) ?: fromCity?.description,
+      fromAddressPostcode = address?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+
+  private fun OffenderTapMovementOut.toResponse(): BookingTapMovementOut {
+    // The address may only exist on the schedule so check there too
+    val toAddress = toAddress ?: tapScheduleOut?.toAddress
+    return BookingTapMovementOut(
+      sequence = id.sequence,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      arrestAgency = arrestAgency?.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromPrison = fromAgency?.id,
+      toAgency = toAgency?.id,
+      commentText = commentText,
+      toAddressId = toAddress?.addressId,
+      toAddressOwnerClass = toAddress?.addressOwnerClass,
+      toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+      toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+      toAddressPostcode = toAddress?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+
+  private fun OffenderTapMovementIn.toResponse(): BookingTapMovementIn {
+    // The address may only exist on the outbound movement or the scheduled outbound movement so check there too
+    val address = fromAddress
+      ?: tapScheduleOut?.tapMovementOut?.toAddress
+      ?: tapScheduleOut?.toAddress
+    return BookingTapMovementIn(
+      sequence = id.sequence,
+      movementDate = movementDate,
+      movementTime = movementTime,
+      movementReason = movementReason.code,
+      escort = escort?.code,
+      escortText = escortText,
+      fromAgency = fromAgency?.id,
+      toPrison = toAgency?.id,
+      commentText = commentText,
+      fromAddressId = address?.addressId,
+      fromAddressOwnerClass = address?.addressOwnerClass,
+      fromAddressDescription = tapAddressService.getAddressDescription(address),
+      fromFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(address)),
+      fromAddressPostcode = address?.postalCode?.trim(),
+      audit = toAudit(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleModel.kt
@@ -1,0 +1,202 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.NomisAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.UpsertTapAddress
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "Tap schedule out response")
+data class TapScheduleOut(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event ID")
+  val eventId: Long,
+
+  @Schema(description = "Event date")
+  val eventDate: LocalDate,
+
+  @Schema(description = "Start time")
+  val startTime: LocalDateTime,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Event status")
+  val eventStatus: String,
+
+  @Schema(description = "Inbound event status")
+  val inboundEventStatus: String?,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "From prison")
+  val fromPrison: String?,
+
+  @Schema(description = "To agency")
+  val toAgency: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Return date")
+  val returnDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "To address ID")
+  val toAddressId: Long?,
+
+  @Schema(description = "To address owner class")
+  val toAddressOwnerClass: String?,
+
+  @Schema(description = "To address description")
+  val toAddressDescription: String?,
+
+  @Schema(description = "To full address")
+  val toFullAddress: String?,
+
+  @Schema(description = "To address postcode")
+  val toAddressPostcode: String?,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDateTime,
+
+  @Schema(description = "Application time")
+  val applicationTime: LocalDateTime?,
+
+  @Schema(description = "Contact person name")
+  val contactPersonName: String?,
+
+  @Schema(description = "Temporary absence type")
+  val tapAbsenceType: String?,
+
+  @Schema(description = "Temporary absence sub type")
+  val tapSubType: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Tap schedule in response")
+data class TapScheduleIn(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Movement application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event ID")
+  val eventId: Long,
+
+  @Schema(description = "Event ID")
+  val parentEventId: Long,
+
+  @Schema(description = "Event date")
+  val eventDate: LocalDate,
+
+  @Schema(description = "Start time")
+  val startTime: LocalDateTime,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Event status")
+  val eventStatus: String,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "From agency")
+  val fromAgency: String?,
+
+  @Schema(description = "To prison")
+  val toPrison: String?,
+
+  @Schema(description = "Audit data associated with the records")
+  val audit: NomisAudit,
+)
+
+@Schema(description = "Upsert tap schedule out request")
+data class UpsertTapScheduleOut(
+  @Schema(description = "Event ID")
+  val eventId: Long?,
+
+  @Schema(description = "Tap application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event date")
+  val eventDate: LocalDate,
+
+  @Schema(description = "Start time")
+  val startTime: LocalDateTime,
+
+  @Schema(description = "Event sub type")
+  val eventSubType: String,
+
+  @Schema(description = "Event status")
+  val eventStatus: String,
+
+  @Schema(description = "Event status of the return schedule")
+  val returnEventStatus: String?,
+
+  @Schema(description = "Comment")
+  val comment: String?,
+
+  @Schema(description = "Escort")
+  val escort: String?,
+
+  @Schema(description = "From prison")
+  val fromPrison: String,
+
+  @Schema(description = "To agency")
+  val toAgency: String?,
+
+  @Schema(description = "Transport type")
+  val transportType: String?,
+
+  @Schema(description = "Return date")
+  val returnDate: LocalDate,
+
+  @Schema(description = "Return time")
+  val returnTime: LocalDateTime,
+
+  @Schema(description = "To address")
+  val toAddress: UpsertTapAddress,
+
+  @Schema(description = "Application date")
+  val applicationDate: LocalDateTime,
+
+  @Schema(description = "Application time")
+  val applicationTime: LocalDateTime?,
+)
+
+@Schema(description = "Upsert scheduled tap response")
+data class UpsertTapScheduleOutResponse(
+  @Schema(description = "Booking ID")
+  val bookingId: Long,
+
+  @Schema(description = "Tap application ID")
+  val tapApplicationId: Long,
+
+  @Schema(description = "Event ID")
+  val eventId: Long,
+
+  @Schema(description = "Address ID")
+  val addressId: Long,
+
+  @Schema(description = "Address owner class")
+  val addressOwnerClass: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleResource.kt
@@ -1,0 +1,213 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
+
+@PreAuthorize("hasRole('ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW')")
+@RestController
+@Validated
+@RequestMapping("/movements/{offenderNo}/taps/schedule", produces = [MediaType.APPLICATION_JSON_VALUE])
+class TapScheduleResource(
+  private val service: TapScheduleService,
+) {
+
+  @GetMapping("/out/{eventId}")
+  @Operation(
+    summary = "Get a specific tap schedule out for an offender",
+    description = "Get a specific tap schedule out for an offender by event ID. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap schedule out returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender or tap schedule in not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapScheduleOut(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+    @Schema(description = "Event ID", example = "123") @PathVariable eventId: Long,
+  ) = service.getTapScheduleOut(offenderNo, eventId)
+
+  @GetMapping("/in/{eventId}")
+  @Operation(
+    summary = "Get a specific tap schedule in for an offender",
+    description = "Get a specific tap schedule in for an offender by event ID. Requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Offender tap schedule in returned",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires role NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender or tap schedule in not found",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)),
+        ],
+      ),
+    ],
+  )
+  fun getTapScheduleIn(
+    @Schema(description = "Offender number (NOMS ID)", example = "A1234BC") @PathVariable offenderNo: String,
+    @Schema(description = "Event ID", example = "123") @PathVariable eventId: Long,
+  ) = service.getTapScheduleIn(offenderNo, eventId)
+
+  @PutMapping("/out")
+  @Operation(
+    summary = "Inserts or updates a tap schedule ouy for an offender, and potentially its return",
+    description = "Creates or updates a tap schedule out on the prisoner's latest booking, and potentially its return. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Tap schedule out created or updated",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "One or more fields in the request contains invalid data",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner does not exist",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun upsertTapScheduleOut(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @RequestBody @Valid
+    request: UpsertTapScheduleOut,
+  ): UpsertTapScheduleOutResponse = service.upsertTapScheduleOut(offenderNo, request)
+
+  @DeleteMapping("/out/{eventId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Delete a tap schedule out for an offender.",
+    description = "Deletes a tap schedule out. This should only be required where we have duplicates! Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Tap schedule out deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint. Requires ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Unable to delete the schedule. See error message for details",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun deleteTapScheduleOut(
+    @Schema(description = "Offender no (aka prisoner number)", example = "A1234AK")
+    @PathVariable
+    offenderNo: String,
+    @Schema(description = "Scheduled TAP movement event ID", example = "12345")
+    @PathVariable
+    eventId: Long,
+  ) = service.deleteTapScheduleOut(offenderNo, eventId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
@@ -1,0 +1,223 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.truncateToUtf8Length
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.EventStatus.Companion.COMPLETED
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapAddressService
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers.Companion.MAX_TAP_COMMENT_LENGTH
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.toFullAddress
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class TapScheduleService(
+  private val offenderRepository: OffenderRepository,
+  private val offenderBookingRepository: OffenderBookingRepository,
+  private val scheduleOutRepository: OffenderTapScheduleOutRepository,
+  private val scheduleInRepository: OffenderTapScheduleInRepository,
+  private val tapAddressService: TapAddressService,
+  private val tapHelpers: TapHelpers,
+) {
+
+  fun getTapScheduleOut(offenderNo: String, eventId: Long): TapScheduleOut {
+    tapHelpers.offenderOrThrow(offenderNo)
+
+    val tapScheduleOut = scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offenderNo)
+      ?: throw NotFoundException("Tap scheduleout with eventId=$eventId not found for offender with nomsId=$offenderNo")
+
+    return tapScheduleOut.toResponse(tapScheduleOut.tapApplication.returnTime)
+  }
+
+  @Transactional
+  fun upsertTapScheduleOut(offenderNo: String, request: UpsertTapScheduleOut): UpsertTapScheduleOutResponse {
+    val offenderBooking = tapHelpers.offenderBookingOrThrow(offenderNo)
+    val application = tapHelpers.movementApplicationOrThrow(request.tapApplicationId)
+    val eventSubType = tapHelpers.movementReasonOrThrow(request.eventSubType)
+    val eventStatus = tapHelpers.eventStatusOrThrow(request.eventStatus)
+    val escort = request.escort?.let { tapHelpers.escortOrThrow(request.escort) }
+    val fromPrison = tapHelpers.agencyLocationOrThrow(request.fromPrison)
+    val toAgency = request.toAgency?.let { tapHelpers.agencyLocationOrThrow(request.toAgency) }
+    val transportType = request.transportType?.let { tapHelpers.transportTypeOrThrow(request.transportType) }
+    val toAddress = tapAddressService.findAddressOrThrow(request.toAddress, offenderBooking.offender)
+
+    if (request.eventId == null) {
+      if (application.isUnapproved()) {
+        throw ConflictException("Cannot add schedules to application ${application.tapApplicationId} because it's not approved (applicationStatus=${application.applicationStatus.code})")
+      }
+      if (application.isSingle() && application.hasSchedules()) {
+        throw ConflictException("Cannot add schedules to application ${application.tapApplicationId} because it already has a single schedule")
+      }
+    }
+
+    val schedule = request.eventId
+      ?.let { scheduleOutRepository.findById(request.eventId).get() }
+      ?.apply {
+        this.eventDate = request.eventDate
+        this.startTime = request.startTime
+        this.eventSubType = eventSubType
+        this.eventStatus = eventStatus
+        this.comment = request.comment?.truncateToUtf8Length(MAX_TAP_COMMENT_LENGTH, includeSeeDpsSuffix = true)
+        this.escort = escort
+        this.fromAgency = fromPrison
+        this.toAgency = toAgency
+        this.transportType = transportType
+        this.returnDate = request.returnDate
+        this.returnTime = request.returnTime
+        this.toAddressOwnerClass = toAddress.addressOwnerClass
+        this.toAddress = toAddress
+      }
+      ?: OffenderTapScheduleOut(
+        offenderBooking = offenderBooking,
+        eventDate = request.eventDate,
+        startTime = request.startTime,
+        eventSubType = eventSubType,
+        eventStatus = eventStatus,
+        comment = request.comment?.truncateToUtf8Length(MAX_TAP_COMMENT_LENGTH, includeSeeDpsSuffix = true),
+        escort = escort,
+        fromPrison = fromPrison,
+        toAgency = toAgency,
+        transportType = transportType,
+        returnDate = request.returnDate,
+        returnTime = request.returnTime,
+        tapApplication = application,
+        toAddressOwnerClass = toAddress.addressOwnerClass,
+        toAddress = toAddress,
+        applicationDate = request.applicationDate,
+        applicationTime = request.applicationTime,
+      )
+
+    val scheduledReturn = schedule.tapScheduleIns.firstOrNull()
+      ?.apply {
+        this.eventStatus = tapHelpers.eventStatusOrThrow(request.returnEventStatus ?: "SCH")
+        this.eventDate = request.returnDate
+        this.startTime = request.returnTime
+        this.eventSubType = eventSubType
+        this.escort = escort
+        this.fromAgency = toAgency
+        this.toAgency = fromPrison
+      }
+      ?: let {
+        if (request.eventStatus == "COMP") {
+          OffenderTapScheduleIn(
+            offenderBooking = offenderBooking,
+            tapApplication = application,
+            tapScheduleOut = schedule,
+            eventStatus = tapHelpers.eventStatusOrThrow(request.returnEventStatus ?: "SCH"),
+            eventDate = request.returnDate,
+            startTime = request.returnTime,
+            eventSubType = eventSubType,
+            escort = escort,
+            fromAgency = toAgency,
+            toPrison = fromPrison,
+          )
+        } else {
+          null
+        }
+      }
+
+    schedule.tapScheduleIns = scheduledReturn?.let { mutableListOf(scheduledReturn) } ?: mutableListOf()
+
+    scheduleOutRepository.save(schedule)
+
+    return UpsertTapScheduleOutResponse(
+      bookingId = offenderBooking.bookingId,
+      tapApplicationId = application.tapApplicationId,
+      eventId = schedule.eventId,
+      addressId = toAddress.addressId,
+      addressOwnerClass = toAddress.addressOwnerClass,
+    )
+  }
+
+  @Transactional
+  fun deleteTapScheduleOut(offenderNo: String, eventId: Long) {
+    scheduleOutRepository.findByIdOrNull(eventId)
+      ?.also { schedule ->
+        if (schedule.tapMovementOut != null) {
+          throw ConflictException("Cannot delete tap schedule out eventId $eventId because it has a movement ${schedule.tapMovementOut!!.id.offenderBooking.bookingId} / ${schedule.tapMovementOut!!.id.sequence}}")
+        }
+        if (schedule.eventStatus.code == COMPLETED) {
+          throw ConflictException("Cannot delete tap schedule out eventId $eventId because it has status $COMPLETED")
+        }
+        if (schedule.tapScheduleIns.isNotEmpty()) {
+          throw ConflictException("Cannot delete tap schedule out eventId $eventId because it has an inbound schedule ${schedule.tapScheduleIns[0].eventId}")
+        }
+
+        offenderBookingRepository.findByIdOrNull(schedule.offenderBooking.bookingId)
+          ?.takeIf { it.offender.nomsId != offenderNo }
+          ?.run { throw ConflictException("EventId $eventId exists on a different offender") }
+
+        scheduleOutRepository.delete(schedule)
+      }
+  }
+
+  fun getTapScheduleIn(offenderNo: String, eventId: Long): TapScheduleIn {
+    if (!offenderRepository.existsByNomsId(offenderNo)) {
+      throw NotFoundException("Offender with nomsId=$offenderNo not found")
+    }
+
+    val tapScheduleIn = scheduleInRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offenderNo)
+      ?: throw NotFoundException("Tap schedule in with eventId=$eventId not found for offender with nomsId=$offenderNo")
+
+    return tapScheduleIn.toResponse()
+  }
+
+  private fun OffenderTapScheduleOut.toResponse(applicationReturnTime: LocalDateTime) = TapScheduleOut(
+    bookingId = offenderBooking.bookingId,
+    tapApplicationId = tapApplication.tapApplicationId,
+    eventId = eventId,
+    eventDate = eventDate ?: tapApplication.fromDate,
+    startTime = startTime ?: tapApplication.releaseTime,
+    eventSubType = eventSubType.code,
+    eventStatus = eventStatus.code,
+    inboundEventStatus = tapScheduleIns.firstOrNull()?.eventStatus?.code,
+    comment = comment,
+    escort = escort?.code,
+    fromPrison = fromAgency?.id,
+    toAgency = toAgency?.id,
+    transportType = transportType?.code,
+    returnDate = returnDate,
+    returnTime = returnTime ?: applicationReturnTime,
+    toAddressId = toAddress?.addressId,
+    toAddressOwnerClass = toAddress?.addressOwnerClass,
+    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
+    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressPostcode = toAddress?.postalCode?.trim(),
+    applicationDate = applicationDate,
+    applicationTime = applicationTime,
+    contactPersonName = contactPersonName,
+    tapAbsenceType = tapApplication.tapType?.code,
+    tapSubType = tapApplication.tapSubType?.code,
+    audit = toAudit(
+      toAddress?.modifyDatetime?.takeIf { it.isAfter(modifyDatetime ?: createDatetime) },
+      toAddress?.modifyDatetime?.takeIf { it.isAfter(modifyDatetime ?: createDatetime) }?.let { toAddress?.modifyUserId },
+    ),
+  )
+
+  private fun OffenderTapScheduleIn.toResponse() = TapScheduleIn(
+    bookingId = offenderBooking.bookingId,
+    tapApplicationId = tapScheduleOut.tapApplication.tapApplicationId,
+    eventId = eventId,
+    parentEventId = tapScheduleOut.eventId,
+    eventDate = eventDate ?: tapScheduleOut.tapApplication.fromDate,
+    startTime = startTime ?: tapScheduleOut.tapApplication.releaseTime,
+    eventSubType = eventSubType.code,
+    eventStatus = eventStatus.code,
+    comment = comment,
+    escort = escort?.code,
+    fromAgency = fromAgency?.id,
+    toPrison = toAgency?.id,
+    audit = toAudit(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/OffenderTapsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/OffenderTapsResourceIntTest.kt
@@ -1,0 +1,1856 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.CorporateAddressDsl.Companion.SHEFFIELD
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.BookingTaps
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.OffenderTapMovementId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.OffenderTapsIdsResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.OffenderTapsResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.TapSummary
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class OffenderTapsResourceIntTest(
+  @Autowired private val scheduleOutRepository: OffenderTapScheduleOutRepository,
+  @Autowired private val scheduleInRepository: OffenderTapScheduleInRepository,
+  @Autowired private val offenderRepository: OffenderRepository,
+  @Autowired private val agencyLocationRepository: AgencyLocationRepository,
+  @Autowired private val corporateRepository: CorporateRepository,
+  @Autowired private val entityManager: EntityManager,
+) : IntegrationTestBase() {
+
+  private lateinit var offender: Offender
+  private lateinit var offenderAddress: OffenderAddress
+  private lateinit var booking: OffenderBooking
+  private lateinit var application: OffenderTapApplication
+  private lateinit var scheduleOut: OffenderTapScheduleOut
+  private lateinit var scheduleIn: OffenderTapScheduleIn
+  private lateinit var movementOut: OffenderTapMovementOut
+  private lateinit var movementIn: OffenderTapMovementIn
+  private lateinit var unscheduledMovementOut: OffenderTapMovementOut
+  private lateinit var unscheduledMovementIn: OffenderTapMovementIn
+  private lateinit var agencyLocation: AgencyLocation
+  private lateinit var orphanedScheduleOut: OffenderTapScheduleOut
+  private lateinit var orphanedScheduleIn: OffenderTapScheduleIn
+
+  private val offenderNo = "D6347ED"
+  private val today: LocalDateTime = LocalDateTime.now().roundToNearestSecond()
+  private val yesterday: LocalDateTime = today.minusDays(1)
+  private val twoDaysAgo: LocalDateTime = today.minusDays(2)
+
+  @AfterEach
+  fun `tear down`() {
+    // This must be removed before the offender booking due to a foreign key constraint (Hibernate is no longer managing this entity)
+    if (this::orphanedScheduleOut.isInitialized) {
+      scheduleOutRepository.delete(orphanedScheduleOut)
+    }
+    if (this::orphanedScheduleIn.isInitialized) {
+      scheduleInRepository.delete(orphanedScheduleIn)
+    }
+    offenderRepository.deleteAll()
+    if (this::agencyLocation.isInitialized) {
+      agencyLocationRepository.delete(agencyLocation)
+    }
+    corporateRepository.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps")
+  inner class GetOffenderTaps {
+    private lateinit var agencyAddress: AgencyLocationAddress
+
+    @Test
+    fun `should return unauthorised for missing token`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden for missing role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return forbidden for wrong role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps")
+        .headers(setAuthorisation("ROLE_INVALID"))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return not found if offender not found`() {
+      webTestClient.get()
+        .uri("/movements/UNKNOWN/taps")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("Offender with nomsId=UNKNOWN not found")
+        }
+    }
+
+    @Test
+    fun `should retrieve application`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication(
+              eventSubType = "C5",
+              applicationDate = twoDaysAgo,
+              applicationTime = twoDaysAgo,
+              fromDate = twoDaysAgo.toLocalDate(),
+              releaseTime = twoDaysAgo,
+              toDate = yesterday.toLocalDate(),
+              returnTime = yesterday,
+              applicationType = "SINGLE",
+              applicationStatus = "APP-SCH",
+              escort = "L",
+              transportType = "VAN",
+              comment = "Some comment application",
+              prison = "LEI",
+              toAgency = "HAZLWD",
+              toAddress = offenderAddress,
+              contactPersonName = "Derek",
+              tapType = "RR",
+              tapSubType = "RDR",
+            )
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].bookingId").isEqualTo(booking.bookingId)
+        .jsonPath("$.bookings[0].activeBooking").isEqualTo(true)
+        .jsonPath("$.bookings[0].latestBooking").isEqualTo(true)
+        .jsonPath("$.bookings[0].tapApplications[0].tapApplicationId").isEqualTo(application.tapApplicationId)
+        .jsonPath("$.bookings[0].tapApplications[0].eventSubType").isEqualTo("C5")
+        .jsonPath("$.bookings[0].tapApplications[0].applicationDate").value<String> {
+          assertThat(it).startsWith("${twoDaysAgo.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].fromDate").isEqualTo("${twoDaysAgo.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].releaseTime").value<String> {
+          assertThat(it).startsWith("${twoDaysAgo.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].toDate").isEqualTo("${yesterday.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].returnTime").value<String> {
+          assertThat(it).startsWith("${yesterday.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].applicationType").isEqualTo("SINGLE")
+        .jsonPath("$.bookings[0].tapApplications[0].applicationStatus").isEqualTo("APP-SCH")
+        .jsonPath("$.bookings[0].tapApplications[0].escortCode").isEqualTo("L")
+        .jsonPath("$.bookings[0].tapApplications[0].transportType").isEqualTo("VAN")
+        .jsonPath("$.bookings[0].tapApplications[0].comment").isEqualTo("Some comment application")
+        .jsonPath("$.bookings[0].tapApplications[0].prisonId").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].tapApplications[0].toAgencyId").isEqualTo("HAZLWD")
+        .jsonPath("$.bookings[0].tapApplications[0].toAddressId").isEqualTo(offenderAddress.addressId)
+        .jsonPath("$.bookings[0].tapApplications[0].toAddressOwnerClass").isEqualTo(offenderAddress.addressOwnerClass)
+        .jsonPath("$.bookings[0].tapApplications[0].toAddressOwnerDescription").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].toFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].toAddressPostcode").isEqualTo("S1 1AA")
+        .jsonPath("$.bookings[0].tapApplications[0].contactPersonName").isEqualTo("Derek")
+        .jsonPath("$.bookings[0].tapApplications[0].tapType").isEqualTo("RR")
+        .jsonPath("$.bookings[0].tapApplications[0].tapSubType").isEqualTo("RDR")
+    }
+
+    @Test
+    fun `should retrieve schedule outs`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                eventDate = twoDaysAgo.toLocalDate(),
+                startTime = twoDaysAgo,
+                eventSubType = "C5",
+                eventStatus = "SCH",
+                comment = "Tap schedule out",
+                escort = "L",
+                fromPrison = "LEI",
+                toAgency = "HAZLWD",
+                transportType = "VAN",
+                returnDate = yesterday.toLocalDate(),
+                returnTime = yesterday,
+                toAddress = offenderAddress,
+                contactPersonName = "Derek",
+              )
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.eventId").isEqualTo(scheduleOut.eventId)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.eventDate").isEqualTo("${twoDaysAgo.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.startTime").value<String> {
+          assertThat(it).startsWith("${twoDaysAgo.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.eventSubType").isEqualTo("C5")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.eventStatus").isEqualTo("SCH")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.comment").isEqualTo("Tap schedule out")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.escort").isEqualTo("L")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.fromPrison").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAgency").isEqualTo("HAZLWD")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.transportType").isEqualTo("VAN")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.returnDate").isEqualTo("${yesterday.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.returnTime").value<String> {
+          assertThat(it).startsWith("${yesterday.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressId").isEqualTo("${offenderAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressOwnerClass").isEqualTo("OFF")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("S1 1AA")
+    }
+
+    @Test
+    fun `should retrieve corporate address`() {
+      lateinit var corporateAddress: CorporateAddress
+      nomisDataBuilder.build {
+        corporate(corporateName = "Boots") {
+          corporateAddress = address(postcode = "S2 2AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = corporateAddress,
+              )
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressId").isEqualTo("${corporateAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressOwnerClass").isEqualTo("CORP")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").isEqualTo("Boots")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("S2 2AA")
+    }
+
+    @Test
+    fun `should retrieve agency address`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = agencyAddress,
+              )
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve schedule out's external movements`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut(
+                  date = twoDaysAgo,
+                  fromPrison = "LEI",
+                  toAgency = "HAZLWD",
+                  movementReason = "C5",
+                  arrestAgency = "POL",
+                  escort = "L",
+                  escortText = "SE",
+                  comment = "Tap OUT comment for scheduled absence",
+                  toAddress = offenderAddress,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.sequence").isEqualTo(movementOut.id.sequence)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.movementDate").isEqualTo("${twoDaysAgo.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.movementTime").value<String> {
+          assertThat(it).startsWith("${twoDaysAgo.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.movementReason").isEqualTo("C5")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.arrestAgency").isEqualTo("POL")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.escort").isEqualTo("L")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.escortText").isEqualTo("SE")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.fromPrison").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAgency").isEqualTo("HAZLWD")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.commentText").isEqualTo("Tap OUT comment for scheduled absence")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressId").isEqualTo("${offenderAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressOwnerClass").isEqualTo("OFF")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressDescription").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressPostcode").isEqualTo("S1 1AA")
+    }
+
+    @Test
+    fun `should retrieve corporate address from external movement`() {
+      lateinit var corporateAddress: CorporateAddress
+      nomisDataBuilder.build {
+        corporate(corporateName = "Boots") {
+          corporateAddress = address(postcode = "S2 2AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut(
+                  toAddress = corporateAddress,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressId").isEqualTo("${corporateAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressOwnerClass").isEqualTo("CORP")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressDescription").isEqualTo("Boots")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressPostcode").isEqualTo("S2 2AA")
+    }
+
+    @Test
+    fun `should retrieve agency address from external movement`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut(
+                  toAddress = agencyAddress,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve address from schedule if not on movement`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = agencyAddress,
+              ) {
+                movementOut = tapMovementOut(
+                  toAddress = null,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.toAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve tap schedule in`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                scheduleIn = tapScheduleIn(
+                  eventDate = yesterday.toLocalDate(),
+                  startTime = yesterday,
+                  eventSubType = "R25",
+                  eventStatus = "SCH",
+                  comment = "Tap schedule in",
+                  escort = "U",
+                  fromAgency = "HAZLWD",
+                  toPrison = "LEI",
+                )
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.eventId").isEqualTo(scheduleIn.eventId)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.eventDate").isEqualTo("${yesterday.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.startTime").value<String> {
+          assertThat(it).startsWith("${yesterday.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.eventSubType").isEqualTo("R25")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.eventStatus").isEqualTo("SCH")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.comment").isEqualTo("Tap schedule in")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.escort").isEqualTo("U")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.fromAgency").isEqualTo("HAZLWD")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.toPrison").isEqualTo("LEI")
+    }
+
+    @Test
+    fun `should retrieve tap schedule out's external movements`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn(
+                    date = yesterday,
+                    fromAgency = "HAZLWD",
+                    toPrison = "LEI",
+                    movementReason = "R25",
+                    escort = "U",
+                    escortText = "SE",
+                    comment = "Tap IN comment",
+                    fromAddress = offenderAddress,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.sequence").isEqualTo(movementIn.id.sequence)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.movementDate").isEqualTo("${yesterday.toLocalDate()}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.movementTime").value<String> {
+          assertThat(it).startsWith("${yesterday.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.movementReason").isEqualTo("R25")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.escort").isEqualTo("U")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.escortText").isEqualTo("SE")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAgency").isEqualTo("HAZLWD")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.toPrison").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.commentText").isEqualTo("Tap IN comment")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressId").isEqualTo("${offenderAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressOwnerClass").isEqualTo("OFF")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressDescription").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressPostcode").isEqualTo("S1 1AA")
+    }
+
+    @Test
+    fun `should retrieve corporate address from return movement`() {
+      lateinit var corporateAddress: CorporateAddress
+      nomisDataBuilder.build {
+        corporate(corporateName = "Boots") {
+          corporateAddress = address(postcode = "S2 2AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn(
+                    fromAddress = corporateAddress,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressId").isEqualTo("${corporateAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressOwnerClass").isEqualTo("CORP")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressDescription").isEqualTo("Boots")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromFullAddress").isEqualTo("41 High Street, Sheffield")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressPostcode").isEqualTo("S2 2AA")
+    }
+
+    @Test
+    fun `should retrieve agency address from return movement`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn(
+                    fromAddress = agencyAddress,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve address from outbound movement if not on return movement`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut(
+                  toAddress = agencyAddress,
+                )
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn(
+                    fromAddress = null,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve address from scheduled outbound movement if not on either movement`() {
+      lateinit var agencyAddress: AgencyLocationAddress
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(agencyLocationId = "BIGHHO", description = "Big Hospital") {
+          agencyAddress = address(postcode = "LS3 3AA")
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = agencyAddress,
+              ) {
+                movementOut = tapMovementOut(
+                  toAddress = null,
+                )
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn(
+                    fromAddress = null,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressId").isEqualTo("${agencyAddress.addressId}")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressDescription").isEqualTo("Big Hospital")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromFullAddress").isEqualTo("2 Gloucester Terrace, Stanningley Road, Leeds, West Yorkshire, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.fromAddressPostcode").isEqualTo("LS3 3AA")
+    }
+
+    @Test
+    fun `should retrieve unscheduled tap movements with agency address`() {
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(
+          agencyLocationId = "NGENHO",
+          description = "Northern General Hospital",
+          type = "HOSPITAL",
+        ) {
+          agencyAddress = address(
+            type = "BUS",
+            street = "Herries Road",
+            postcode = "S5 7AU",
+            city = SHEFFIELD,
+            county = "S.YORKSHIRE",
+            country = "ENG",
+          )
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            unscheduledMovementOut = tapMovementOut(
+              date = yesterday,
+              movementReason = "C5",
+              escort = "U",
+              escortText = "SE",
+              comment = "Tap OUT comment",
+              fromPrison = "LEI",
+              toAgency = "NGENHO",
+              toCity = null,
+              toAddress = null,
+            )
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].sequence").isEqualTo(unscheduledMovementOut.id.sequence)
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].movementDate").isEqualTo("${yesterday.toLocalDate()}")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].movementTime").value<String> {
+          assertThat(it).startsWith("${yesterday.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].movementReason").isEqualTo("C5")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].escort").isEqualTo("U")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].escortText").isEqualTo("SE")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].fromPrison").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAgency").isEqualTo("NGENHO")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].commentText").isEqualTo("Tap OUT comment")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressId").isEqualTo(agencyAddress.addressId)
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressDescription").isEqualTo("Northern General Hospital")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toFullAddress").isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressPostcode").isEqualTo("S5 7AU")
+    }
+
+    @Test
+    fun `should retrieve city description if no address on unscheduled tap movement`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            unscheduledMovementOut = tapMovementOut(
+              toCity = SHEFFIELD,
+              toAgency = null,
+              toAddress = null,
+            )
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressId").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressOwnerClass").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressDescription").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toFullAddress").isEqualTo("Sheffield")
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].toAddressPostcode").doesNotExist()
+    }
+
+    @Test
+    fun `should retrieve unscheduled tap movement in with agency address`() {
+      nomisDataBuilder.build {
+        agencyLocation = agencyLocation(
+          agencyLocationId = "NGENHO",
+          description = "Northern General Hospital",
+          type = "HOSPITAL",
+        ) {
+          agencyAddress = address(
+            type = "BUS",
+            street = "Herries Road",
+            postcode = "S5 7AU",
+            city = SHEFFIELD,
+            county = "S.YORKSHIRE",
+            country = "ENG",
+          )
+        }
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking {
+            unscheduledMovementOut = tapMovementOut()
+            unscheduledMovementIn = tapMovementIn(
+              date = today,
+              movementReason = "C5",
+              escort = "U",
+              escortText = "SE",
+              comment = "Tap IN comment",
+              toPrison = "LEI",
+              fromAgency = "NGENHO",
+              fromCity = null,
+              fromAddress = null,
+            )
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].sequence")
+        .isEqualTo(unscheduledMovementIn.id.sequence)
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].movementDate")
+        .isEqualTo("${today.toLocalDate()}")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].movementTime").value<String> {
+          assertThat(it).startsWith("${today.toLocalDate()}")
+        }
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].movementReason").isEqualTo("C5")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].escort").isEqualTo("U")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].escortText").isEqualTo("SE")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAgency").isEqualTo("NGENHO")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].toPrison").isEqualTo("LEI")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].commentText").isEqualTo("Tap IN comment")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressId")
+        .isEqualTo(agencyAddress.addressId)
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressOwnerClass").isEqualTo("AGY")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressDescription").isEqualTo("Northern General Hospital")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromFullAddress").isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressPostcode").isEqualTo("S5 7AU")
+    }
+
+    @Test
+    fun `should retrieve city description from unscheduled tap movement in`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            unscheduledMovementOut = tapMovementOut()
+            unscheduledMovementIn = tapMovementIn(
+              fromCity = SHEFFIELD,
+              fromAddress = null,
+            )
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressId").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressOwnerClass").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressDescription").doesNotExist()
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromFullAddress").isEqualTo("Sheffield")
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].fromAddressPostcode").doesNotExist()
+    }
+
+    @Test
+    fun `should retrieve all tap schedules and movements`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+            unscheduledMovementOut = tapMovementOut()
+            unscheduledMovementIn = tapMovementIn()
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].bookingId").isEqualTo(booking.bookingId)
+        .jsonPath("$.bookings[0].tapApplications.length()").isEqualTo(1)
+        .jsonPath("$.bookings[0].tapApplications[0].tapApplicationId").isEqualTo(application.tapApplicationId)
+        .jsonPath("$.bookings[0].tapApplications[0].taps.length()").isEqualTo(1)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.eventId").isEqualTo(scheduleOut.eventId)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementOut.sequence").isEqualTo(movementOut.id.sequence)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.eventId").isEqualTo(scheduleIn.eventId)
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapMovementIn.sequence").isEqualTo(movementIn.id.sequence)
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts.length()").isEqualTo(1)
+        .jsonPath("$.bookings[0].unscheduledTapMovementOuts[0].sequence").isEqualTo(unscheduledMovementOut.id.sequence)
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns.length()").isEqualTo(1)
+        .jsonPath("$.bookings[0].unscheduledTapMovementIns[0].sequence").isEqualTo(unscheduledMovementIn.id.sequence)
+    }
+
+    @Test
+    fun `should take return time from the application if not on the schedule`() {
+      val tomorrow = LocalDateTime.now().plusDays(1).withNano(0)
+
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication(returnTime = tomorrow) {
+              scheduleOut = tapScheduleOut()
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by nulling the return time on the schedule
+         */
+        entityManager.createQuery(
+          """
+            update OffenderTapScheduleOut ost
+            set ost.returnTime = null
+            where eventId = ${scheduleOut.eventId}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.returnTime").isEqualTo(tomorrow)
+    }
+
+    @Test
+    fun `should handle movement address that does not exist any more`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            tapApplication(toAddress = offenderAddress) {
+              tapScheduleOut(toAddress = offenderAddress) {
+                tapScheduleIn()
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by deleting the address
+         */
+        entityManager.createQuery(
+          """
+            delete from Address where addressId = ${offenderAddress.addressId}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].toAddressId").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressId").doesNotExist()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleIn.fromAddressId").doesNotExist()
+    }
+
+    @Test
+    fun `should format address`() {
+      lateinit var corporateAddress: CorporateAddress
+      nomisDataBuilder.build {
+        corporate(corporateName = "Boots") {
+          corporateAddress = address(
+            premise = "Boots",
+            street = "High Street",
+            locality = "Sheffield",
+            country = "ENG",
+            postcode = "S2 2AA",
+          )
+        }
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = corporateAddress,
+              )
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").isEqualTo("Boots")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("High Street, Sheffield, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("S2 2AA")
+    }
+
+    @Test
+    fun `should format address with whitespace instead of postcode`() {
+      lateinit var corporateAddress: CorporateAddress
+      nomisDataBuilder.build {
+        corporate(corporateName = "Boots") {
+          corporateAddress = address(
+            street = "High Street",
+            locality = "Sheffield",
+            country = "ENG",
+            postcode = " ",
+          )
+        }
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                toAddress = corporateAddress,
+              )
+            }
+          }
+        }
+      }
+
+      webTestClient.getOffenderTaps()
+        .expectBody()
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").isEqualTo("Boots")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("41 High Street, Sheffield, England")
+        .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("")
+    }
+  }
+
+  @Nested
+  @DisplayName("Migration with merged data")
+  inner class GetOffenderTapsForMergedData {
+    lateinit var mergedBooking: OffenderBooking
+    lateinit var mergedApplication: OffenderTapApplication
+    lateinit var mergedTapScheduleOut: OffenderTapScheduleOut
+    lateinit var mergedTapScheduleIn: OffenderTapScheduleIn
+    lateinit var mergedTapMovementOut: OffenderTapMovementOut
+    lateinit var mergedTapMovementIn: OffenderTapMovementIn
+
+    lateinit var tapScheduleOut2: OffenderTapScheduleOut
+    lateinit var tapScheduleIn2: OffenderTapScheduleIn
+    lateinit var mergedTapScheduleOut2: OffenderTapScheduleOut
+    lateinit var mergedTapScheduleIn2: OffenderTapScheduleIn
+    lateinit var mergedTapMovementOut2: OffenderTapMovementOut
+    lateinit var mergedTapMovementIn2: OffenderTapMovementIn
+
+    val today = LocalDate.now()
+    val tomorrow = today.plusDays(1)
+
+    @BeforeEach
+    fun setUp() {
+      // Simulate a scenario where a prisoner is merged into another
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          // This booking was moved from the old prisoner during the merge
+          mergedBooking = booking(bookingSequence = 2) {
+            receive(twoDaysAgo)
+            mergedApplication = tapApplication {
+              mergedTapScheduleOut = tapScheduleOut(eventDate = today) {
+                mergedTapMovementOut = tapMovementOut()
+                mergedTapScheduleIn = tapScheduleIn(eventDate = today) {
+                  mergedTapMovementIn = tapMovementIn()
+                }
+              }
+              mergedTapScheduleOut2 = tapScheduleOut(eventDate = tomorrow) {
+                mergedTapMovementOut2 = tapMovementOut()
+                mergedTapScheduleIn2 = tapScheduleIn(eventDate = tomorrow) {
+                  mergedTapMovementIn2 = tapMovementIn()
+                }
+              }
+            }
+            release(yesterday)
+          }
+          // This is the latest booking
+          booking = booking(bookingSequence = 1) {
+            receive(yesterday)
+            // these are the only details copied from the merged booking during the merge
+            application = tapApplication {
+              // make the schedules out of order to prove that date handling works
+              tapScheduleOut2 = tapScheduleOut(eventDate = tomorrow) {
+                tapScheduleIn2 = tapScheduleIn(eventDate = tomorrow)
+              }
+              scheduleOut = tapScheduleOut(eventDate = today) {
+                scheduleIn = tapScheduleIn(eventDate = today)
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data copied during the merge in the same way as NOMIS does
+         * - pointing at the original booking's scheduled TAP instead of its own
+         * - pointing at the new application, whereas the original scheduled return has null application
+         */
+        entityManager.createQuery(
+          """
+            update OffenderTapScheduleIn ostr
+            set ostr.tapScheduleOut = (from OffenderTapScheduleOut where eventId = ${mergedTapScheduleOut.eventId}),
+            ostr.tapApplication = (from OffenderTapApplication  where tapApplicationId = ${application.tapApplicationId})
+            where eventId = ${scheduleIn.eventId}
+          """.trimIndent(),
+        ).executeUpdate()
+
+        // Also corrupt the same data for the 2nd scheduled absence from the application to test repeating applications
+        entityManager.createQuery(
+          """
+            update OffenderTapScheduleIn ostr
+            set ostr.tapScheduleOut = (from OffenderTapScheduleOut where eventId = ${mergedTapScheduleOut2.eventId}),
+            ostr.tapApplication = (from OffenderTapApplication  where tapApplicationId = ${application.tapApplicationId})
+            where eventId = ${tapScheduleIn2.eventId}
+          """.trimIndent(),
+        ).executeUpdate()
+
+        // Also corrupt the merged movements by removing the link to the schedules in the same way the NOMIS merge process does
+        entityManager.createQuery(
+          """
+            update OffenderTapMovementOut ota
+            set ota.tapScheduleOut = null
+            where id.offenderBooking.id = ${mergedBooking.bookingId}
+            and id.sequence in (${mergedTapMovementOut.id.sequence}, ${mergedTapMovementOut2.id.sequence})
+          """.trimIndent(),
+        ).executeUpdate()
+        entityManager.createQuery(
+          """
+            update OffenderTapMovementIn otar
+            set otar.tapScheduleIn = null
+            where id.offenderBooking.id = ${mergedBooking.bookingId} 
+            and id.sequence in (${mergedTapMovementIn.id.sequence}, ${mergedTapMovementIn2.id.sequence})
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+    }
+
+    @Test
+    fun `should retrieve the tap movement out from the merged booking's first application schedule`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          val book = bookings.first()
+          val application = book.tapApplications.first()
+          assertThat(book.bookingId).isEqualTo(mergedBooking.bookingId)
+          assertThat(book.activeBooking).isEqualTo(false)
+          assertThat(book.latestBooking).isEqualTo(false)
+          assertThat(book.tapApplications.size).isEqualTo(1)
+          assertThat(application.tapApplicationId).isEqualTo(mergedApplication.tapApplicationId)
+          with(application.taps.first()) {
+            assertThat(tapScheduleOut!!.eventId).isEqualTo(mergedTapScheduleOut.eventId)
+            assertThat(tapMovementOut).isNull()
+            assertThat(tapScheduleIn!!.eventId).isEqualTo(mergedTapScheduleIn.eventId)
+            assertThat(tapMovementIn).isNull()
+          }
+          // The actual movements were unlinked by the merge process so should appear as unscheduled
+          assertThat(bookings.first().unscheduledTapMovementOuts[0].sequence).isEqualTo(mergedTapMovementOut.id.sequence)
+          assertThat(bookings.first().unscheduledTapMovementIns[0].sequence).isEqualTo(mergedTapMovementIn.id.sequence)
+        }
+    }
+
+    @Test
+    fun `should retrieve the tap movement out from the merged booking's second application schedule`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          with(bookings.first().tapApplications.first().taps[1]) {
+            assertThat(tapScheduleOut!!.eventId).isEqualTo(mergedTapScheduleOut2.eventId)
+            assertThat(tapMovementOut).isNull()
+            assertThat(tapScheduleIn!!.eventId).isEqualTo(mergedTapScheduleIn2.eventId)
+            assertThat(tapMovementIn).isNull()
+          }
+          // The actual movements were unlinked by the merge process so should appear as unscheduled
+          assertThat(bookings.first().unscheduledTapMovementOuts[1].sequence).isEqualTo(mergedTapMovementOut2.id.sequence)
+          assertThat(bookings.first().unscheduledTapMovementIns[1].sequence).isEqualTo(mergedTapMovementIn2.id.sequence)
+        }
+    }
+
+    @Test
+    fun `should retrieve the tap movement out from the TAP copied onto the latest booking`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          val book = bookings[1]
+          val application = book.tapApplications.first()
+          assertThat(book.bookingId).isEqualTo(booking.bookingId)
+          assertThat(book.activeBooking).isEqualTo(true)
+          assertThat(book.latestBooking).isEqualTo(true)
+          assertThat(book.tapApplications.size).isEqualTo(1)
+          assertThat(application.tapApplicationId).isEqualTo(application.tapApplicationId)
+          with(application.taps[1]) {
+            assertThat(tapScheduleOut!!.eventId).isEqualTo(scheduleOut.eventId)
+            assertThat(tapMovementOut).isNull()
+            assertThat(tapScheduleIn!!.eventId).isEqualTo(scheduleIn.eventId)
+            assertThat(tapMovementIn).isNull()
+          }
+        }
+    }
+
+    @Test
+    fun `should retrieve the tap schedule from the second TAP copied onto the latest booking`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          with(bookings[1].tapApplications.first().taps[0]) {
+            assertThat(tapScheduleOut!!.eventId).isEqualTo(tapScheduleOut2.eventId)
+            assertThat(tapMovementOut).isNull()
+            assertThat(tapScheduleIn!!.eventId).isEqualTo(tapScheduleIn2.eventId)
+            assertThat(tapMovementIn).isNull()
+          }
+        }
+    }
+
+    @Test
+    fun `reconciliation should reflect the merged movements correctly`() {
+      webTestClient.getOffenderSummaryOk(offenderNo)
+        .apply {
+          assertThat(applications.count).isEqualTo(2)
+          assertThat(scheduledOuts.count).isEqualTo(4)
+          assertThat(movements.count).isEqualTo(4)
+          // The merged movements are treated as unscheduled because the merge process removes the link to the underlying scheduled movement
+          assertThat(movements.scheduled.outCount).isEqualTo(0)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.outCount).isEqualTo(2)
+          assertThat(movements.unscheduled.inCount).isEqualTo(2)
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("Migration for deleted schedule with movements")
+  inner class GetOffenderTapsForDeletedScheduleWthMovement {
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            receive(yesterday)
+            // TAP for which we will remove the schedule OUT from the DB
+            tapApplication {
+              scheduleOut = tapScheduleOut(eventDate = today.toLocalDate()) {
+                tapMovementOut()
+                orphanedScheduleIn = tapScheduleIn(eventDate = today.toLocalDate()) {
+                  tapMovementIn()
+                }
+              }
+            }
+            // Another TAP that should be included in the migration
+            tapApplication {
+              tapScheduleOut(eventDate = yesterday.toLocalDate()) {
+                tapMovementOut()
+                tapScheduleIn(eventDate = yesterday.toLocalDate()) {
+                  tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Emulate the scenario where a schedule OUT is deleted after movements are created
+         */
+        entityManager.createNativeQuery(
+          """
+            delete from OFFENDER_IND_SCHEDULES
+            where EVENT_ID = ${scheduleOut.eventId}
+          """.trimIndent(),
+        ).executeUpdate()
+
+        // Reload the scheduled return to reflect the update
+        orphanedScheduleIn = scheduleInRepository.findByIdOrNull(orphanedScheduleIn.eventId) ?: throw IllegalStateException("Failed to reload scheduled return movement - this should not happen")
+      }
+    }
+
+    @Test
+    fun `should include the TAP with deleted schedule OUT as unscheduled`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          val book = bookings.first()
+          assertThat(book.tapApplications.size).isEqualTo(2)
+          // The TAP with the deleted scheduled absence is not included in the migration as a scheduled movement
+          assertThat(book.tapApplications[0].taps).isEmpty()
+          // The control TAP is migrated
+          with(book.tapApplications[1].taps.first()) {
+            assertThat(tapScheduleOut).isNotNull()
+            assertThat(tapMovementOut).isNotNull()
+            assertThat(tapScheduleIn).isNotNull()
+            assertThat(tapMovementIn).isNotNull()
+          }
+          // The TAP with deleted scheduled absence has both movements included as unscheduled
+          assertThat(book.unscheduledTapMovementOuts.size).isEqualTo(1)
+          assertThat(book.unscheduledTapMovementIns.size).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `reconciliation should include the TAP with deleted scheduled OUT as unscheduled`() {
+      webTestClient.getOffenderSummaryOk(offenderNo)
+        .apply {
+          assertThat(applications.count).isEqualTo(2)
+          assertThat(scheduledOuts.count).isEqualTo(1)
+          assertThat(movements.count).isEqualTo(4)
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(1)
+          assertThat(movements.unscheduled.outCount).isEqualTo(1)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("Migration for multiple schedule IN movements")
+  inner class GetOffenderTapsForMultipleScheduledInMovements {
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            receive(yesterday)
+            tapApplication {
+              scheduleOut = tapScheduleOut(eventDate = today.toLocalDate()) {
+                tapMovementOut()
+                // We used to pick up this scheduled IN record - we should pick up the next one with an external movement
+                tapScheduleIn()
+                scheduleIn = tapScheduleIn(eventDate = today.toLocalDate()) {
+                  tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return the scheduled IN movement with an actual movement attached`() {
+      webTestClient.getOffenderTapsWithResponse()
+        .apply {
+          val book = bookings.first()
+          assertThat(book.tapApplications.size).isEqualTo(1)
+          // The correct scheduled IN movement is chosen
+          with(bookings[0].tapApplications[0].taps[0]) {
+            assertThat(tapScheduleIn!!.eventId).isEqualTo(scheduleIn.eventId)
+            assertThat(tapMovementIn).isNotNull
+          }
+        }
+    }
+
+    @Test
+    fun `reconciliation should include only one of the scheduled IN movements`() {
+      webTestClient.getOffenderSummaryOk(offenderNo)
+        .apply {
+          assertThat(scheduledOuts.count).isEqualTo(1)
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(1)
+          assertThat(movements.unscheduled.outCount).isEqualTo(0)
+          assertThat(movements.unscheduled.inCount).isEqualTo(0)
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/booking/{bookingId}/taps")
+  inner class GetBookingTaps {
+    @Test
+    fun `should return unauthorized for missing token`() {
+      webTestClient.get()
+        .uri("/movements/booking/12345/taps")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden for missing role`() {
+      webTestClient.get()
+        .uri("/movements/booking/12345/taps")
+        .headers(setAuthorisation(roles = listOf()))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return forbidden for wrong role`() {
+      webTestClient.get()
+        .uri("/movements/booking/12345/taps")
+        .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return not found for unknown booking id`() {
+      webTestClient.getBookingTaps(12345)
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("Offender booking 12345 not found")
+        }
+    }
+
+    @Test
+    fun `should return only the requested booking`() {
+      lateinit var secondBooking: OffenderBooking
+      lateinit var firstApplication: OffenderTapApplication
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            firstApplication = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+            unscheduledMovementOut = tapMovementOut()
+            unscheduledMovementIn = tapMovementIn()
+          }
+          secondBooking = booking {
+            application = tapApplication {
+              tapScheduleOut()
+            }
+          }
+        }
+      }
+
+      webTestClient.getBookingTapsOk()
+        .apply {
+          assertThat(bookingId).isEqualTo(booking.bookingId)
+          assertThat(activeBooking).isTrue()
+          assertThat(latestBooking).isTrue()
+          assertThat(tapApplications).hasSize(1)
+          assertThat(tapApplications[0].tapApplicationId).isEqualTo(firstApplication.tapApplicationId)
+          assertThat(tapApplications[0].taps).hasSize(1)
+          assertThat(tapApplications[0].taps[0].tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
+          assertThat(tapApplications[0].taps[0].tapScheduleIn?.eventId).isEqualTo(scheduleIn.eventId)
+          assertThat(tapApplications[0].taps[0].tapMovementOut?.sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(tapApplications[0].taps[0].tapMovementIn?.sequence).isEqualTo(movementIn.id.sequence)
+          assertThat(unscheduledTapMovementOuts).extracting<Int> { it.sequence }.containsExactly(unscheduledMovementOut.id.sequence)
+          assertThat(unscheduledTapMovementIns).extracting<Int> { it.sequence }.containsExactly(unscheduledMovementIn.id.sequence)
+        }
+
+      webTestClient.getBookingTapsOk(secondBooking.bookingId)
+        .apply {
+          assertThat(bookingId).isEqualTo(secondBooking.bookingId)
+          assertThat(tapApplications).hasSize(1)
+          assertThat(unscheduledTapMovementOuts).isEmpty()
+          assertThat(unscheduledTapMovementIns).isEmpty()
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/summary")
+  inner class GetOffenderTapsSummary {
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `should return basic counts`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking {
+              tapApplication {
+                tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+              tapMovementOut()
+              tapMovementIn()
+            }
+          }
+        }
+
+        webTestClient.getOffenderSummaryOk(offenderNo)
+          .apply {
+            assertThat(applications.count).isEqualTo(1)
+            assertThat(scheduledOuts.count).isEqualTo(1)
+            assertThat(movements.count).isEqualTo(4)
+            assertThat(movements.scheduled.outCount).isEqualTo(1)
+            assertThat(movements.scheduled.inCount).isEqualTo(1)
+            assertThat(movements.unscheduled.outCount).isEqualTo(1)
+            assertThat(movements.unscheduled.inCount).isEqualTo(1)
+          }
+      }
+
+      @Test
+      fun `should handle zero counts`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking()
+          }
+        }
+
+        webTestClient.getOffenderSummaryOk(offenderNo)
+          .apply {
+            assertThat(applications.count).isEqualTo(0)
+            assertThat(scheduledOuts.count).isEqualTo(0)
+            assertThat(movements.count).isEqualTo(0)
+            assertThat(movements.scheduled.outCount).isEqualTo(0)
+            assertThat(movements.scheduled.inCount).isEqualTo(0)
+            assertThat(movements.unscheduled.outCount).isEqualTo(0)
+            assertThat(movements.unscheduled.inCount).isEqualTo(0)
+          }
+      }
+
+      @Test
+      fun `should handle multiple bookings and movements`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking {
+              tapApplication()
+            }
+            booking {
+              tapApplication {
+                tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn()
+                }
+              }
+            }
+            booking {
+              tapMovementOut()
+              tapMovementIn()
+              tapMovementOut()
+            }
+            booking()
+          }
+          offender(nomsId = "ANY") {
+            booking {
+              tapApplication()
+            }
+          }
+        }
+
+        webTestClient.getOffenderSummaryOk(offenderNo)
+          .apply {
+            assertThat(applications.count).isEqualTo(2)
+            assertThat(scheduledOuts.count).isEqualTo(1)
+            assertThat(movements.count).isEqualTo(4)
+            assertThat(movements.scheduled.outCount).isEqualTo(1)
+            assertThat(movements.scheduled.inCount).isEqualTo(0)
+            assertThat(movements.unscheduled.outCount).isEqualTo(2)
+            assertThat(movements.unscheduled.inCount).isEqualTo(1)
+          }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return not found for unknown offender`() {
+        webTestClient.getOffenderSummary(offenderNo = "UNKNOWN")
+          .expectStatus().isNotFound
+      }
+    }
+
+    @Nested
+    inner class DeletedScheduleOut {
+      @Test
+      fun `should ignore scheduled movements where there is no application`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking {
+              tapApplication {
+                orphanedScheduleOut = tapScheduleOut()
+              }
+              tapApplication {
+                tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          /*
+           * Corrupt the data by nulling one of the schedule's tap application - such data exists in NOMIS but we ignore them from the migration and reconciliation
+           */
+          entityManager.createQuery(
+            """
+            update OffenderTapScheduleOut ost
+            set ost.tapApplication = null
+            where eventId = ${orphanedScheduleOut.eventId}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.getOffenderSummaryOk(offenderNo)
+          .apply {
+            assertThat(applications.count).isEqualTo(2)
+            // We don't count the orphaned schedule in the reconciliation
+            assertThat(scheduledOuts.count).isEqualTo(1)
+            assertThat(movements.count).isEqualTo(2)
+          }
+      }
+    }
+
+    @Nested
+    inner class LinkFromMovementInToScheduleOutBroken {
+      @Test
+      fun `should handle case where parent event ID missing from movement IN`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking {
+              tapApplication {
+                tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+              tapApplication {
+                tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          /*
+           * Corrupt the data by nulling the movement IN parent event ID (which should point at the schedule OUT)
+           */
+          entityManager.createQuery(
+            """
+            update OffenderTapMovementIn otar
+            set otar.tapScheduleOut = null
+            where otar.id.offenderBooking.id = ${movementIn.id.offenderBooking.bookingId}
+            and otar.id.sequence = ${movementIn.id.sequence}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.getOffenderSummaryOk(offenderNo)
+          .apply {
+            assertThat(applications.count).isEqualTo(2)
+            assertThat(scheduledOuts.count).isEqualTo(2)
+            // Includes the movement IN that doesn't have a parent event id
+            assertThat(movements.count).isEqualTo(4)
+          }
+      }
+    }
+
+    @Nested
+    inner class LinkFromScheduleOutToApplicationMissing {
+      @Test
+      fun `should handle case where movement application missing from schedule OUT`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "A9797LL") {
+            booking {
+              application = tapApplication {
+                orphanedScheduleOut = tapScheduleOut {
+                  tapMovementOut()
+                  orphanedScheduleIn = tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          /*
+           * Corrupt the data by nulling the application on the schedule OUT and deleting the application
+           */
+          entityManager.createNativeQuery(
+            """
+            update OFFENDER_IND_SCHEDULES ois set OFFENDER_MOVEMENT_APP_ID = null
+            where ois.EVENT_ID = ${orphanedScheduleOut.eventId}
+            """.trimIndent(),
+          ).executeUpdate()
+
+          entityManager.createNativeQuery(
+            """
+            delete from OFFENDER_MOVEMENT_APPS oma
+            where oma.OFFENDER_MOVEMENT_APP_ID = ${application.tapApplicationId}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.getOffenderSummaryOk("A9797LL")
+          .apply {
+            assertThat(applications.count).isEqualTo(0)
+            assertThat(scheduledOuts.count).isEqualTo(0)
+            assertThat(movements.scheduled.outCount).isEqualTo(0)
+            assertThat(movements.scheduled.inCount).isEqualTo(0)
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/summary")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/summary")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/summary")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/ids")
+  inner class GetTapsIds {
+    private lateinit var booking2: OffenderBooking
+    private lateinit var application2: OffenderTapApplication
+    private lateinit var scheduleOut2: OffenderTapScheduleOut
+    private lateinit var scheduleIn2: OffenderTapScheduleIn
+    private lateinit var movementOut2: OffenderTapMovementOut
+    private lateinit var movementIn2: OffenderTapMovementIn
+    private lateinit var unscheduledMovementOut2: OffenderTapMovementOut
+    private lateinit var unscheduledMovementIn2: OffenderTapMovementIn
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+            unscheduledMovementOut = tapMovementOut()
+            unscheduledMovementIn = tapMovementIn()
+          }
+          booking2 = booking {
+            application2 = tapApplication {
+              scheduleOut2 = tapScheduleOut {
+                movementOut2 = tapMovementOut()
+                scheduleIn2 = tapScheduleIn {
+                  movementIn2 = tapMovementIn()
+                }
+              }
+            }
+            unscheduledMovementOut2 = tapMovementOut()
+            unscheduledMovementIn2 = tapMovementIn()
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return all IDs`() {
+      webTestClient.getTapIds()
+        .apply {
+          assertThat(applicationIds).containsExactlyInAnyOrder(
+            application.tapApplicationId,
+            application2.tapApplicationId,
+          )
+          assertThat(scheduleOutIds).containsExactlyInAnyOrder(
+            scheduleOut.eventId,
+            scheduleOut2.eventId,
+          )
+          assertThat(scheduleInIds).containsExactlyInAnyOrder(
+            scheduleIn.eventId,
+            scheduleIn2.eventId,
+          )
+          assertThat(scheduledMovementOutIds).containsExactlyInAnyOrder(
+            OffenderTapMovementId(movementOut.id.offenderBooking.bookingId, movementOut.id.sequence),
+            OffenderTapMovementId(movementOut2.id.offenderBooking.bookingId, movementOut2.id.sequence),
+          )
+          assertThat(scheduledMovementInIds).containsExactlyInAnyOrder(
+            OffenderTapMovementId(movementIn.id.offenderBooking.bookingId, movementIn.id.sequence),
+            OffenderTapMovementId(movementIn2.id.offenderBooking.bookingId, movementIn2.id.sequence),
+          )
+          assertThat(unscheduledMovementOutIds).containsExactlyInAnyOrder(
+            OffenderTapMovementId(
+              unscheduledMovementOut.id.offenderBooking.bookingId,
+              unscheduledMovementOut.id.sequence,
+            ),
+            OffenderTapMovementId(
+              unscheduledMovementOut2.id.offenderBooking.bookingId,
+              unscheduledMovementOut2.id.sequence,
+            ),
+          )
+          assertThat(unscheduledMovementInIds).containsExactlyInAnyOrder(
+            OffenderTapMovementId(
+              unscheduledMovementIn.id.offenderBooking.bookingId,
+              unscheduledMovementIn.id.sequence,
+            ),
+            OffenderTapMovementId(
+              unscheduledMovementIn2.id.offenderBooking.bookingId,
+              unscheduledMovementIn2.id.sequence,
+            ),
+          )
+        }
+    }
+
+    @Test
+    fun `should return correct summary counts`() {
+      webTestClient.getOffenderSummaryOk(offenderNo)
+        .apply {
+          assertThat(applications.count).isEqualTo(2)
+          assertThat(scheduledOuts.count).isEqualTo(2)
+          assertThat(movements.scheduled.outCount).isEqualTo(2)
+          assertThat(movements.scheduled.inCount).isEqualTo(2)
+          assertThat(movements.unscheduled.outCount).isEqualTo(2)
+          assertThat(movements.unscheduled.inCount).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `should return unauthorised for missing token`() {
+      webTestClient.get()
+        .uri("/movements/${offender.nomsId}/taps/ids")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden for missing role`() {
+      webTestClient.get()
+        .uri("/movements/${offender.nomsId}/taps/ids")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return forbidden for wrong role`() {
+      webTestClient.get()
+        .uri("/movements/${offender.nomsId}/taps/ids")
+        .headers(setAuthorisation("ROLE_INVALID"))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+  }
+
+  private fun WebTestClient.getTapIds() = get()
+    .uri("/movements/${offender.nomsId}/taps/ids")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<OffenderTapsIdsResponse>()
+
+  private fun WebTestClient.getOffenderTaps() = get()
+    .uri("/movements/${offender.nomsId}/taps")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+
+  private fun WebTestClient.getOffenderTapsWithResponse() = getOffenderTaps()
+    .expectBodyResponse<OffenderTapsResponse>()
+
+  private fun WebTestClient.getBookingTaps(bookingId: Long) = get()
+    .uri("/movements/booking/$bookingId/taps")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.getBookingTapsOk(bookingId: Long = booking.bookingId) = getBookingTaps(bookingId)
+    .expectStatus().isOk
+    .expectBodyResponse<BookingTaps>()
+
+  private fun WebTestClient.getOffenderSummary(offenderNo: String) = get()
+    .uri("/movements/$offenderNo/taps/summary")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.getOffenderSummaryOk(offenderNo: String) = getOffenderSummary(offenderNo)
+    .expectStatus().isOk
+    .expectBodyResponse<TapSummary>()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapApplicationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapApplicationResourceIntTest.kt
@@ -1,0 +1,1438 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.CorporateAddressDsl.Companion.SHEFFIELD
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.CorporateAddressDsl.Companion.SWANSEA
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderAddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers.Companion.MAX_TAP_COMMENT_LENGTH
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application.TapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application.UpsertTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application.UpsertTapApplicationResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.UpsertTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.UpsertTapScheduleOutResponse
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class TapApplicationResourceIntTest(
+  @Autowired val applicationRepository: OffenderTapApplicationRepository,
+  @Autowired val scheduleOutRepository: OffenderTapScheduleOutRepository,
+  @Autowired val scheduleInRepository: OffenderTapScheduleInRepository,
+  @Autowired val corporateRepository: CorporateRepository,
+  @Autowired val offenderAddressRepository: OffenderAddressRepository,
+  @Autowired val agencyLocationRepository: AgencyLocationRepository,
+  @Autowired val offenderRepository: OffenderRepository,
+) : IntegrationTestBase() {
+
+  private lateinit var offender: Offender
+  private lateinit var offenderAddress: OffenderAddress
+  private lateinit var corporateAddress: CorporateAddress
+  private lateinit var booking: OffenderBooking
+  private lateinit var application: OffenderTapApplication
+  private lateinit var scheduleOut: OffenderTapScheduleOut
+  private lateinit var agencyLocation: AgencyLocation
+
+  private val offenderNo = "D6347ED"
+  private val today: LocalDateTime = LocalDateTime.now().roundToNearestSecond()
+  private val yesterday: LocalDateTime = today.minusDays(1)
+  private val twoDaysAgo: LocalDateTime = today.minusDays(2)
+  private lateinit var orphanedSchedule: OffenderTapScheduleOut
+  private lateinit var orphanedScheduleReturn: OffenderTapScheduleIn
+
+  @AfterEach
+  fun `tear down`() {
+    // This must be removed before the offender booking due to a foreign key constraint (Hibernate is no longer managing this entity)
+    if (this::orphanedSchedule.isInitialized) {
+      scheduleOutRepository.delete(orphanedSchedule)
+    }
+    if (this::orphanedScheduleReturn.isInitialized) {
+      scheduleInRepository.delete(orphanedScheduleReturn)
+    }
+    offenderRepository.deleteAll()
+    if (this::agencyLocation.isInitialized) {
+      agencyLocationRepository.delete(agencyLocation)
+    }
+    corporateRepository.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/application/{applicationId}")
+  inner class GetTapsApplication {
+    private lateinit var inactiveBooking: OffenderBooking
+    private lateinit var inactiveBookingApplication: OffenderTapApplication
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address(postcode = "S1 1AA")
+          booking = booking(bookingSequence = 1) {
+            application = tapApplication(
+              eventSubType = "C5",
+              applicationDate = twoDaysAgo,
+              applicationTime = twoDaysAgo,
+              fromDate = twoDaysAgo.toLocalDate(),
+              releaseTime = twoDaysAgo,
+              toDate = yesterday.toLocalDate(),
+              returnTime = yesterday,
+              applicationType = "SINGLE",
+              applicationStatus = "APP-SCH",
+              escort = "L",
+              transportType = "VAN",
+              comment = "Some comment application",
+              prison = "LEI",
+              toAgency = "HAZLWD",
+              toAddress = offenderAddress,
+              contactPersonName = "Derek",
+              tapType = "RR",
+              tapSubType = "RDR",
+            ) {
+              tapScheduleOut {
+                tapMovementOut()
+                tapScheduleIn {
+                  tapMovementIn()
+                }
+              }
+            }
+            tapMovementOut()
+            tapMovementIn()
+          }
+          inactiveBooking = booking(bookingSequence = 2) {
+            receive(twoDaysAgo)
+            inactiveBookingApplication = tapApplication()
+            release(yesterday)
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return unauthorised for missing token`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/application/1")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden for missing role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/application/1")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return forbidden for wrong role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/application/1")
+        .headers(setAuthorisation("ROLE_INVALID"))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return not found if offender not found`() {
+      webTestClient.get()
+        .uri("/movements/UNKNOWN/taps/application/1")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("UNKNOWN").contains("not found")
+        }
+    }
+
+    @Test
+    fun `should return not found if application not found`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/application/9999")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("9999").contains("not found")
+        }
+    }
+
+    @Test
+    fun `should retrieve application`() {
+      webTestClient.getApplicationOk()
+        .apply {
+          assertThat(bookingId).isEqualTo(booking.bookingId)
+          assertThat(activeBooking).isEqualTo(true)
+          assertThat(latestBooking).isEqualTo(true)
+          assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+          assertThat(eventSubType).isEqualTo("C5")
+          assertThat(applicationDate).isEqualTo(twoDaysAgo.toLocalDate())
+          assertThat(fromDate).isEqualTo(twoDaysAgo.toLocalDate())
+          assertThat(releaseTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+          assertThat(toDate).isEqualTo(yesterday.toLocalDate())
+          assertThat(returnTime).isCloseTo(yesterday, within(1, ChronoUnit.MINUTES))
+          assertThat(applicationType).isEqualTo("SINGLE")
+          assertThat(applicationStatus).isEqualTo("APP-SCH")
+          assertThat(escortCode).isEqualTo("L")
+          assertThat(transportType).isEqualTo("VAN")
+          assertThat(comment).isEqualTo("Some comment application")
+          assertThat(prisonId).isEqualTo("LEI")
+          assertThat(toAgencyId).isEqualTo("HAZLWD")
+          assertThat(toAddressId).isEqualTo(offenderAddress.addressId)
+          assertThat(toAddressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+          assertThat(toAddressDescription).isNull()
+          assertThat(toFullAddress).isEqualTo("41 High Street, Sheffield")
+          assertThat(toAddressPostcode).isEqualTo("S1 1AA")
+          assertThat(contactPersonName).isEqualTo("Derek")
+          assertThat(tapType).isEqualTo("RR")
+          assertThat(tapSubType).isEqualTo("RDR")
+        }
+    }
+
+    @Test
+    fun `should retrieve application on inactive booking`() {
+      webTestClient.getApplicationOk(inactiveBookingApplication.tapApplicationId)
+        .apply {
+          assertThat(bookingId).isEqualTo(inactiveBooking.bookingId)
+          assertThat(activeBooking).isEqualTo(false)
+          assertThat(latestBooking).isEqualTo(false)
+          assertThat(tapApplicationId).isEqualTo(inactiveBookingApplication.tapApplicationId)
+        }
+    }
+
+    @Test
+    fun `should retrieve latest booking even if inactive`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = "A9843AA") {
+          booking = booking(bookingSequence = 1, active = false) {
+            application = tapApplication()
+          }
+        }
+      }
+
+      webTestClient.getApplicationOk()
+        .apply {
+          assertThat(activeBooking).isEqualTo(false)
+          assertThat(latestBooking).isEqualTo(true)
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /movements/{offenderNo}/taps/application")
+  inner class UpsertTapApplicationTest {
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteOffenders()
+    }
+
+    @Nested
+    inner class Create {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking()
+          }
+        }
+      }
+
+      @Test
+      fun `should create application`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(toAddresses = listOf(UpsertTapAddress(addressText = "some street", postalCode = "S1 9ZZ"))),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+                assertThat(eventSubType.code).isEqualTo("C5")
+                assertThat(applicationDate.toLocalDate()).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(fromDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(releaseTime).isEqualTo(twoDaysAgo)
+                assertThat(toDate).isEqualTo(yesterday.toLocalDate())
+                assertThat(returnTime).isEqualTo(yesterday)
+                assertThat(applicationType.code).isEqualTo("SINGLE")
+                assertThat(applicationStatus.code).isEqualTo("APP-SCH")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(transportType?.code).isEqualTo("VAN")
+                assertThat(comment).isEqualTo("Some comment application")
+                assertThat(prison.id).isEqualTo("LEI")
+                assertThat(toAgency).isNull()
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("some street")
+                assertThat(toAddress?.postalCode).isEqualTo("S1 9ZZ")
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+                assertThat(contactPersonName).isEqualTo("Derek")
+                assertThat(tapType?.code).isEqualTo("RR")
+                assertThat(tapSubType?.code).isEqualTo("RDR")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should create all addresses requested`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            toAddresses = listOf(
+              UpsertTapAddress(addressText = "some street"),
+              UpsertTapAddress(name = "Kwikfit", addressText = "another street", postalCode = "S1 9ZZ"),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // the first address is written to the application
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("some street")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("OFF")
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+              }
+              // the first address was created
+              with(offenderAddressRepository.findByOffender_RootOffenderId(offender.rootOffenderId!!)) {
+                val address = find { it.premise == "some street" }!!
+                assertThat(address.street).isNull()
+                assertThat(address.postalCode).isNull()
+              }
+              // the second address was created
+              with(corporateRepository.findAllByCorporateName("Kwikfit").first()) {
+                assertThat(addresses.first().premise).isEqualTo("another street")
+                assertThat(addresses.first().postalCode).isEqualTo("S1 9ZZ")
+                assertThat(addresses.first().street).isNull()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should create addresses with long corporate name`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Hm Prison Service The Chief Estates Surveyor", addressText = "another street", postalCode = "S1 9ZZ"),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // the first address is written to the application
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("another street")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+              }
+              // the address and corporation were created
+              with(corporateRepository.findAllByCorporateName("Hm Prison Service The Chief Estates Surv").first()) {
+                assertThat(addresses.first().premise).isEqualTo("another street")
+                assertThat(addresses.first().postalCode).isEqualTo("S1 9ZZ")
+                assertThat(addresses.first().street).isNull()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should not create corporate or address if already exists`() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+          offender = offender(nomsId = "A9876CA") {
+            booking = booking()
+          }
+        }
+
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Boots", addressText = "Scotland Street, Sheffield", postalCode = "S1 3GG"),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // the address is used on the application
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("Scotland Street, Sheffield")
+                assertThat(toAddress?.postalCode).isEqualTo("S1 3GG")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+              // the corporate was not duplicated
+              with(corporateRepository.findAllByCorporateName("Boots")) {
+                assertThat(size).isEqualTo(1)
+                // The corporate address was not duplicated
+                assertThat(first().addresses.size).isEqualTo(1)
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should not create corporate or address where there is already a duplicate corporate`() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            address(premise = "Different address", street = null, locality = null, postcode = "S4 4SS")
+          }
+          corporate(corporateName = "Boots") {
+            address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+          offender = offender(nomsId = "A9876CB") {
+            booking = booking()
+          }
+        }
+
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Boots", addressText = "Scotland Street, Sheffield", postalCode = "S1 3GG"),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // the address is used on the application
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("Scotland Street, Sheffield")
+                assertThat(toAddress?.postalCode).isEqualTo("S1 3GG")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+              }
+              // the corporate was not duplicated
+              with(corporateRepository.findAllByCorporateName("Boots")) {
+                assertThat(size).isEqualTo(2)
+                // The corporate address was not duplicated
+                assertThat(this[0].addresses.size).isEqualTo(1)
+                assertThat(this[1].addresses.size).isEqualTo(1)
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should handle multiple new addresses on a corporate`() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            address(premise = "Some address", street = null, locality = null, postcode = "S1 1XX")
+          }
+          offender = offender(nomsId = "A9876CB") {
+            booking = booking()
+          }
+        }
+
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Boots", addressText = "New address 1, Sheffield", postalCode = "S2 2XX"),
+              UpsertTapAddress(name = "Boots", addressText = "New address 2, Sheffield", postalCode = "S3 3XX"),
+            ),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // one of the new addresses is used on the application
+                assertThat(toAddress?.postalCode).isIn("S2 2XX", "S3 3XX")
+              }
+              // the new addresses have been saved on the corporates
+              with(corporateRepository.findAllByCorporateName("Boots")) {
+                assertThat(flatMap { it.addresses.map { it.postalCode } })
+                  .containsExactlyInAnyOrder("S1 1XX", "S2 2XX", "S3 3XX")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should truncate comments`() {
+        // comment is 300 long
+        webTestClient.upsertApplicationOk(anUpsertApplicationRequest().copy(comment = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(comment!!.length).isEqualTo(MAX_TAP_COMMENT_LENGTH)
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should allow create of a pending application without an address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest().copy(
+            applicationStatus = "PEN",
+            toAddresses = listOf(UpsertTapAddress()),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+                assertThat(applicationStatus.code).isEqualTo("PEN")
+                assertThat(toAddress).isNull()
+                assertThat(toAddressOwnerClass).isNull()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should create a new offender address where corporate name same as address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest().copy(
+            toAddresses = listOf(UpsertTapAddress(name = "Boston", addressText = "Boston")),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+                assertThat(toAddress?.premise).isEqualTo("Boston")
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should handle trailing blanks in corporate address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest().copy(
+            toAddresses = listOf(UpsertTapAddress(name = "HSL ", addressText = "Bowness , Cumbria ", postalCode = "LA23 3AS ")),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(toAddress?.premise).isEqualTo("Bowness , Cumbria")
+                assertThat(toAddress?.postalCode).isEqualTo("LA23 3AS")
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+              }
+              assertThat(corporateRepository.findAllByCorporateName("HSL").size).isEqualTo(1)
+            }
+          }
+      }
+
+      @Test
+      fun `should allow corporate name in address text`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest().copy(
+            toAddresses = listOf(UpsertTapAddress(name = "HSL", addressText = "HSL, Bowness, Cumbria", postalCode = "LA23 3AS")),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(toAddress?.premise).isEqualTo("HSL, Bowness, Cumbria")
+                assertThat(toAddress?.postalCode).isEqualTo("LA23 3AS")
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+              }
+              assertThat(corporateRepository.findAllByCorporateName("HSL").size).isEqualTo(1)
+            }
+          }
+      }
+
+      @Nested
+      inner class Validation {
+        @Test
+        fun `should return not found if offender unknown`() {
+          webTestClient.upsertApplication(offenderNo = "UNKNOWN")
+            .isNotFound
+            .expectBody().jsonPath("userMessage").value<String> {
+              assertThat(it).contains("UNKNOWN").contains("not found")
+            }
+        }
+
+        @Test
+        fun `should return not found if offender has no bookings`() {
+          nomisDataBuilder.build {
+            offender = offender(nomsId = "C1234DE") {
+              offenderAddress = address()
+            }
+          }
+
+          webTestClient.upsertApplication()
+            .isNotFound
+            .expectBody().jsonPath("userMessage").value<String> {
+              assertThat(it).contains("C1234DE").contains("not found")
+            }
+        }
+
+        @Test
+        fun `should return bad request for invalid event sub type`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(eventSubType = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid application type`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(applicationType = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid application status`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(applicationStatus = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid escort code`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(escortCode = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid transport type`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(transportType = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid prison ID`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(prisonId = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid tap type`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(tapType = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for invalid tap sub type`() {
+          webTestClient.upsertApplicationBadRequestUnknown(anUpsertApplicationRequest().copy(tapSubType = "UNKNOWN"))
+        }
+
+        @Test
+        fun `should return bad request for an approved application without an address`() {
+          webTestClient.upsertApplicationBadRequest(
+            request = anUpsertApplicationRequest().copy(
+              applicationStatus = "APP-UNSCH",
+              toAddresses = listOf(),
+            ),
+          )
+        }
+
+        @Test
+        fun `should return bad request for an approved application with a null address`() {
+          webTestClient.upsertApplicationBadRequest(
+            request = anUpsertApplicationRequest().copy(
+              applicationStatus = "APP-UNSCH",
+              toAddresses = listOf(UpsertTapAddress()),
+            ),
+          )
+        }
+      }
+
+      @Nested
+      inner class Security {
+        @Test
+        fun `should return unauthorised for missing token`() {
+          webTestClient.post()
+            .uri("/movements/$offenderNo/taps/application")
+            .bodyValue(anUpsertApplicationRequest())
+            .exchange()
+            .expectStatus().isUnauthorized
+        }
+
+        @Test
+        fun `should return forbidden for missing role`() {
+          webTestClient.post()
+            .uri("/movements/$offenderNo/taps/application")
+            .headers(setAuthorisation(roles = listOf()))
+            .bodyValue(anUpsertApplicationRequest())
+        }
+
+        @Test
+        fun `should return forbidden for wrong role`() {
+          webTestClient.post()
+            .uri("/movements/$offenderNo/taps/application")
+            .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+        }
+      }
+    }
+
+    @Nested
+    inner class Update {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(
+                eventSubType = "C4",
+                applicationDate = twoDaysAgo,
+                applicationTime = twoDaysAgo,
+                fromDate = yesterday.toLocalDate(),
+                releaseTime = yesterday,
+                toDate = today.toLocalDate(),
+                returnTime = today,
+                applicationType = "REPEATING",
+                applicationStatus = "PEN",
+                escort = "U",
+                transportType = "TAX",
+                comment = "Old comment application",
+                prison = "LEI",
+                toAgency = null,
+                toAddress = offenderAddress,
+                contactPersonName = "Adam",
+                tapType = "PP",
+                tapSubType = "ROR",
+              ) {
+                tapScheduleOut(
+                  toAddress = offenderAddress,
+                  toAgency = "HAZLWD",
+                ) {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+              tapMovementOut()
+              tapMovementIn()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should update application`() {
+        webTestClient.upsertApplicationOk(request = anUpsertApplicationRequest(id = application.tapApplicationId, toAddresses = listOf(UpsertTapAddress(id = offenderAddress.addressId))))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+                assertThat(eventSubType.code).isEqualTo("C5")
+                assertThat(applicationDate.toLocalDate()).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(fromDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(releaseTime).isEqualTo(twoDaysAgo)
+                assertThat(toDate).isEqualTo(yesterday.toLocalDate())
+                assertThat(returnTime).isEqualTo(yesterday)
+                assertThat(applicationType.code).isEqualTo("SINGLE")
+                assertThat(applicationStatus.code).isEqualTo("APP-SCH")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(transportType?.code).isEqualTo("VAN")
+                assertThat(comment).isEqualTo("Some comment application")
+                assertThat(prison.id).isEqualTo("LEI")
+                assertThat(toAgency?.id).isNull()
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+                assertThat(contactPersonName).isEqualTo("Derek")
+                assertThat(tapType?.code).isEqualTo("RR")
+                assertThat(tapSubType?.code).isEqualTo("RDR")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should return not found if unknown application id sent`() {
+        webTestClient.upsertApplication(request = anUpsertApplicationRequest(id = 9999))
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return 423 if application is locked for update`() {
+        repository.runInTransaction {
+          applicationRepository.findByIdOrNullForUpdate(application.tapApplicationId)
+
+          webTestClient.upsertApplication(request = anUpsertApplicationRequest(id = application.tapApplicationId))
+            .isEqualTo(423)
+            .expectBody<ErrorResponse>().returnResult().responseBody!!
+            .apply {
+              assertThat(this.status).isEqualTo(423)
+            }
+        }
+      }
+    }
+
+    @Nested
+    inner class UpdateAddress {
+      private lateinit var scheduleAddress: OffenderAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            scheduleAddress = address()
+            booking = booking {
+              application = tapApplication(
+                toAddress = offenderAddress,
+              ) {
+                tapScheduleOut(
+                  toAddress = scheduleAddress,
+                  toAgency = "HAZLWD",
+                ) {
+                  tapMovementOut()
+                  tapScheduleIn {
+                    tapMovementIn()
+                  }
+                }
+              }
+              tapMovementOut()
+              tapMovementIn()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should update address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = application.tapApplicationId,
+            toAddresses = listOf(
+              UpsertTapAddress(id = offenderAddress.addressId),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should update address and create new addresses`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = application.tapApplicationId,
+            toAddresses = listOf(
+              UpsertTapAddress(addressText = "some street", postalCode = "S1 9ZZ"),
+              UpsertTapAddress(name = "Kwikfit", addressText = "another street", postalCode = "S2 8YY"),
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // The first new address is written to the application
+                assertThat(toAddress?.addressId).isNotNull
+                assertThat(toAddress?.premise).isEqualTo("some street")
+                assertThat(toAddress?.postalCode).isEqualTo("S1 9ZZ")
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+              }
+              // the first address was created
+              with(offenderAddressRepository.findByOffender_RootOffenderId(offender.rootOffenderId!!)) {
+                val address = find { it.premise == "some street" }!!
+                assertThat(address.street).isNull()
+                assertThat(address.postalCode).isEqualTo("S1 9ZZ")
+              }
+              // the second address was created
+              with(corporateRepository.findAllByCorporateName("Kwikfit").first()) {
+                assertThat(addresses.first().premise).isEqualTo("another street")
+                assertThat(addresses.first().postalCode).isEqualTo("S2 8YY")
+                assertThat(addresses.first().street).isNull()
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class UpdateButNotAgencyAddressAndNoSchedules {
+
+      private lateinit var agencyAddress: AgencyLocationAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          agencyLocation = agencyLocation(
+            agencyLocationId = "NGENHO",
+            description = "Northern General Hospital",
+            type = "HOSPITAL",
+          ) {
+            agencyAddress = address(
+              type = "BUS",
+              street = "Herries Road",
+              postcode = "S5 7AU",
+              city = SHEFFIELD,
+              county = "S.YORKSHIRE",
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(
+                toAgency = "NGENHO",
+                toAddress = agencyAddress,
+              )
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should not update address`() {
+        webTestClient.upsertApplicationOk(request = anUpsertApplicationRequest(id = application.tapApplicationId, toAddresses = listOf(UpsertTapAddress(id = agencyAddress.addressId))))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("AGY")
+                assertThat(toAgency?.id).isEqualTo("NGENHO")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class UpdatePendingApplicationNoAddress {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(
+                applicationStatus = "APP-UNSCH",
+                toAddress = offenderAddress,
+              )
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should allow update and remove address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(id = application.tapApplicationId).copy(
+            applicationStatus = "PEN",
+            toAddresses = listOf(UpsertTapAddress()),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(application.tapApplicationId)!!) {
+                assertThat(applicationStatus.code).isEqualTo("PEN")
+                assertThat(toAddress).isNull()
+                assertThat(toAddressOwnerClass).isNull()
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class IgnoreSimilarNomisCorporateAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(
+            corporateName = "Swansea (Town Visit)",
+          ) {
+            corporateAddress = address(
+              type = "BUS",
+              flat = null,
+              premise = "Swansea",
+              street = null,
+              locality = null,
+              postcode = null,
+              city = SWANSEA,
+              county = null,
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking()
+          }
+        }
+      }
+
+      @Test
+      fun `should create application with new address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = null,
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Swansea (Town Visit)", addressText = "Swansea"),
+            ),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // We didn't pick up the existing similar NOMIS address
+                assertThat(toAddress?.addressId).isNotEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.premise).isEqualTo("Swansea")
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should create schedule with same address as application`() {
+        var applicationAddressId: Long = 0
+        var applicationId: Long = 0
+
+        // Create the application
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = null,
+            toAddresses = listOf(
+              UpsertTapAddress(name = "Swansea (Town Visit)", addressText = "Swansea"),
+            ),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // save the application address ID
+                applicationAddressId = toAddress!!.addressId
+                applicationId = tapApplicationId
+              }
+            }
+          }
+
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            eventId = null,
+            tapApplicationId = applicationId,
+            toAddress = UpsertTapAddress(name = "Swansea (Town Visit)", addressText = "Swansea"),
+          ),
+        ).apply {
+          repository.runInTransaction {
+            with(scheduleOutRepository.findByIdOrNull(eventId)!!) {
+              // check the schedule address is the same as the application address
+              assertThat(toAddress?.addressId).isEqualTo(applicationAddressId)
+              assertThat(toAddress?.premise).isEqualTo("Swansea")
+              assertThat(toAddressOwnerClass).isEqualTo("CORP")
+            }
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class IgnoreSimilarNomisOffenderAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              flat = null,
+              premise = "Swansea",
+              street = null,
+              locality = null,
+              postcode = null,
+              city = SWANSEA,
+              county = null,
+              country = "ENG",
+            )
+            booking = booking()
+          }
+        }
+      }
+
+      @Test
+      fun `should create application with new address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = null,
+            toAddresses = listOf(
+              UpsertTapAddress(addressText = "Swansea"),
+            ),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // We didn't pick up the existing similar NOMIS address
+                assertThat(toAddress?.addressId).isNotEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.premise).isEqualTo("Swansea")
+                assertThat(toAddressOwnerClass).isEqualTo("OFF")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should create schedule with same address as application`() {
+        var applicationAddressId: Long = 0
+        var applicationId: Long = 0
+
+        // Create the application
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(
+            id = null,
+            toAddresses = listOf(
+              UpsertTapAddress(addressText = "Swansea"),
+            ),
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(tapApplicationId)!!) {
+                // save the application address ID
+                applicationAddressId = toAddress!!.addressId
+                applicationId = tapApplicationId
+              }
+            }
+          }
+
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            eventId = null,
+            tapApplicationId = applicationId,
+            toAddress = UpsertTapAddress(addressText = "Swansea"),
+          ),
+        ).apply {
+          repository.runInTransaction {
+            with(scheduleOutRepository.findByIdOrNull(eventId)!!) {
+              // check the schedule address is the same as the application address
+              assertThat(toAddress?.addressId).isEqualTo(applicationAddressId)
+              assertThat(toAddress?.premise).isEqualTo("Swansea")
+              assertThat(toAddressOwnerClass).isEqualTo("OFF")
+            }
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class UpdateToNotApproved {
+      @Test
+      fun `should remove schedule for single`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication(
+                applicationType = "SINGLE",
+                applicationStatus = "APP-SCH",
+              ) {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(id = application.tapApplicationId).copy(
+            applicationStatus = "PEN",
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(application.tapApplicationId)!!) {
+                assertThat(applicationStatus.code).isEqualTo("PEN")
+                assertThat(tapScheduleOuts).isEmpty()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should not remove schedule for repeating`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication(
+                applicationType = "REPEATING",
+                applicationStatus = "APP-SCH",
+              ) {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest(id = application.tapApplicationId).copy(
+            applicationType = "REPEATING",
+            applicationStatus = "PEN",
+          ),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(application.tapApplicationId)!!) {
+                assertThat(applicationStatus.code).isEqualTo("PEN")
+                assertThat(tapScheduleOuts.first()).isNotNull()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should return bad request if schedule has a movement`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication(
+                applicationType = "SINGLE",
+                applicationStatus = "APP-SCH",
+              ) {
+                scheduleOut = tapScheduleOut {
+                  tapMovementOut()
+                  tapScheduleIn()
+                }
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertApplicationBadRequest(
+          request = anUpsertApplicationRequest(id = application.tapApplicationId).copy(
+            applicationStatus = "PEN",
+          ),
+        )
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /movements/{offenderNo}/taps/application/{applicationId}")
+  inner class DeleteApplication {
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication()
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `should delete application`() {
+        webTestClient.deleteApplication()
+          .expectStatus().isNoContent
+
+        repository.runInTransaction {
+          assertThat(applicationRepository.findByIdOrNull(application.tapApplicationId)).isNull()
+        }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return 204 if unknown application id sent`() {
+        webTestClient.deleteApplication(applicationId = 9999)
+          .expectStatus().isNoContent
+      }
+
+      @Test
+      fun `should return conflict for unknown offender`() {
+        webTestClient.deleteApplication(offenderNo = "UNKNOWN")
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 for wrong offender`() {
+        nomisDataBuilder.build {
+          offender(nomsId = "A7897WW")
+        }
+
+        webTestClient.deleteApplication(offenderNo = "A7897WW")
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 if application has scheduled movements`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.deleteApplication()
+          .expectStatus().isEqualTo(409)
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/application/${application.tapApplicationId}")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/application/${application.tapApplicationId}")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/application/${application.tapApplicationId}")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+  }
+
+  private fun WebTestClient.getApplicationOk(applicationId: Long = application.tapApplicationId) = get()
+    .uri("/movements/${offender.nomsId}/taps/application/$applicationId")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapApplication>()
+
+  private fun WebTestClient.deleteApplication(offenderNo: String = offender.nomsId, applicationId: Long = application.tapApplicationId): WebTestClient.ResponseSpec = delete()
+    .uri("/movements/$offenderNo/taps/application/$applicationId")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.upsertApplicationOk(request: UpsertTapApplication = anUpsertApplicationRequest()) = upsertApplication(request)
+    .isOk
+    .expectBodyResponse<UpsertTapApplicationResponse>()
+
+  private fun WebTestClient.upsertApplicationBadRequest(request: UpsertTapApplication = anUpsertApplicationRequest()) = upsertApplication(request)
+    .isBadRequest
+
+  private fun WebTestClient.upsertApplicationBadRequestUnknown(request: UpsertTapApplication = anUpsertApplicationRequest()) = upsertApplicationBadRequest(request)
+    .expectBody().jsonPath("userMessage").value<String> {
+      assertThat(it).contains("UNKNOWN").contains("invalid")
+    }
+
+  private fun WebTestClient.upsertApplication(
+    request: UpsertTapApplication = anUpsertApplicationRequest(),
+    offenderNo: String = offender.nomsId,
+  ) = put()
+    .uri("/movements/$offenderNo/taps/application")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun WebTestClient.upsertTapScheduleOutOk(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+  ) = upsertTapScheduleOut(request)
+    .isOk
+    .expectBodyResponse<UpsertTapScheduleOutResponse>()
+
+  private fun WebTestClient.upsertTapScheduleOut(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+    offenderNo: String = offender.nomsId,
+  ) = put()
+    .uri("/movements/$offenderNo/taps/schedule/out")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun anUpsertApplicationRequest(
+    id: Long? = null,
+    toAddresses: List<UpsertTapAddress> = listOf(UpsertTapAddress(addressText = "some street")),
+  ) = UpsertTapApplication(
+    tapApplicationId = id,
+    eventSubType = "C5",
+    applicationDate = twoDaysAgo.toLocalDate(),
+    fromDate = twoDaysAgo.toLocalDate(),
+    releaseTime = twoDaysAgo,
+    toDate = yesterday.toLocalDate(),
+    returnTime = yesterday,
+    applicationType = "SINGLE",
+    applicationStatus = "APP-SCH",
+    escortCode = "L",
+    transportType = "VAN",
+    comment = "Some comment application",
+    prisonId = "LEI",
+    contactPersonName = "Derek",
+    tapType = "RR",
+    tapSubType = "RDR",
+    toAddresses = toAddresses,
+  )
+
+  private fun anUpsertTapScheduleOut(
+    tapApplicationId: Long? = null,
+    eventId: Long? = null,
+    returnEventStatus: String? = null,
+    eventStatus: String = "SCH",
+    toAddress: UpsertTapAddress = UpsertTapAddress(id = offenderAddress.addressId),
+    comment: String = "Some comment tap schedule out",
+  ) = UpsertTapScheduleOut(
+    eventId = eventId,
+    tapApplicationId = tapApplicationId ?: application.tapApplicationId,
+    eventDate = twoDaysAgo.toLocalDate(),
+    startTime = twoDaysAgo,
+    eventSubType = "C5",
+    eventStatus = eventStatus,
+    comment = comment,
+    escort = "L",
+    fromPrison = "LEI",
+    toAgency = "HAZLWD",
+    transportType = "VAN",
+    returnDate = yesterday.toLocalDate(),
+    returnTime = yesterday,
+    toAddress = toAddress,
+    applicationDate = twoDaysAgo,
+    applicationTime = twoDaysAgo,
+    returnEventStatus = returnEventStatus,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapMovementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapMovementResourceIntTest.kt
@@ -1,0 +1,2425 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.CorporateAddressDsl.Companion.SHEFFIELD
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovementId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderExternalMovementRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapMovementOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.CreateTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.CreateTapMovementInResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.CreateTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.CreateTapMovementOutResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.TapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.movement.TapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.OffenderTapsResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.TapSummary
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.TapScheduleOut
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class TapMovementResourceIntTest(
+  @Autowired val scheduleOutRepository: OffenderTapScheduleOutRepository,
+  @Autowired val scheduleInRepository: OffenderTapScheduleInRepository,
+  @Autowired val movementOutRepository: OffenderTapMovementOutRepository,
+  @Autowired val movementInRepository: OffenderTapMovementInRepository,
+  @Autowired val offenderExternalMovementRepository: OffenderExternalMovementRepository,
+  @Autowired val corporateRepository: CorporateRepository,
+  @Autowired val agencyLocationRepository: AgencyLocationRepository,
+  @Autowired val offenderRepository: OffenderRepository,
+  @Autowired private val entityManager: EntityManager,
+
+) : IntegrationTestBase() {
+  private lateinit var offender: Offender
+  private lateinit var offenderAddress: OffenderAddress
+  private lateinit var corporateAddress: CorporateAddress
+  private lateinit var booking: OffenderBooking
+  private lateinit var application: OffenderTapApplication
+  private lateinit var scheduleOut: OffenderTapScheduleOut
+  private lateinit var scheduleIn: OffenderTapScheduleIn
+  private lateinit var movementOut: OffenderTapMovementOut
+  private lateinit var movementIn: OffenderTapMovementIn
+  private lateinit var agencyLocation: AgencyLocation
+
+  private val offenderNo = "D6347ED"
+  private val today: LocalDateTime = LocalDateTime.now().roundToNearestSecond()
+  private val twoDaysAgo: LocalDateTime = today.minusDays(2)
+  private lateinit var orphanedSchedule: OffenderTapScheduleOut
+  private lateinit var orphanedScheduleIn: OffenderTapScheduleIn
+
+  @AfterEach
+  fun `tear down`() {
+    // This must be removed before the offender booking due to a foreign key constraint (Hibernate is no longer managing this entity)
+    if (this::orphanedSchedule.isInitialized) {
+      scheduleOutRepository.delete(orphanedSchedule)
+    }
+    if (this::orphanedScheduleIn.isInitialized) {
+      scheduleInRepository.delete(orphanedScheduleIn)
+    }
+    offenderRepository.deleteAll()
+    if (this::agencyLocation.isInitialized) {
+      agencyLocationRepository.delete(agencyLocation)
+    }
+    corporateRepository.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/movement/out/{bookingId}/{movementSeq}")
+  inner class GetTapMovementOut {
+
+    @Nested
+    inner class GetUnscheduledTapMovementOut {
+      private lateinit var agencyAddress: AgencyLocationAddress
+      private lateinit var cityBooking: OffenderBooking
+      private lateinit var agencyBooking: OffenderBooking
+      private lateinit var cityTapMovementOut: OffenderTapMovementOut
+      private lateinit var agencyTapMovementOut: OffenderTapMovementOut
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          agencyLocation = agencyLocation(
+            agencyLocationId = "NGENHO",
+            description = "Northern General Hospital",
+            type = "HOSPITAL",
+          ) {
+            agencyAddress = address(
+              type = "BUS",
+              premise = "2",
+              street = "Herries Road",
+              postcode = "S5 7AU",
+              city = SHEFFIELD,
+              county = "S.YORKSHIRE",
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            cityBooking = booking {
+              cityTapMovementOut = tapMovementOut(
+                date = twoDaysAgo,
+                fromPrison = "LEI",
+                toAgency = null,
+                movementReason = "C5",
+                arrestAgency = "POL",
+                escort = "L",
+                escortText = "SE",
+                comment = "Tap OUT comment",
+                toCity = "25343",
+              )
+            }
+            agencyBooking = booking {
+              agencyTapMovementOut = tapMovementOut(
+                date = twoDaysAgo,
+                fromPrison = "LEI",
+                toAgency = "NGENHO",
+                toCity = null,
+              )
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should return unauthorised for missing token`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/out/${cityBooking.bookingId}/1")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/out/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/out/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation("ROLE_INVALID"))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return not found if offender not found`() {
+        webTestClient.get()
+          .uri("/movements/UNKNOWN/taps/movement/out/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if tap movement out not found`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/out/9999/1")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should retrieve unscheduled tap movement out with city for address`() {
+        webTestClient.getTapMovementOutOk(bookingId = cityBooking.bookingId, movementSeq = cityTapMovementOut.id.sequence)
+          .apply {
+            assertThat(bookingId).isEqualTo(cityBooking.bookingId)
+            assertThat(sequence).isEqualTo(cityTapMovementOut.id.sequence)
+            assertThat(tapScheduleOutId).isNull()
+            assertThat(tapApplicationId).isNull()
+            assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+            assertThat(movementTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+            assertThat(movementReason).isEqualTo("C5")
+            assertThat(arrestAgency).isEqualTo("POL")
+            assertThat(escort).isEqualTo("L")
+            assertThat(escortText).isEqualTo("SE")
+            assertThat(fromPrison).isEqualTo("LEI")
+            assertThat(toAgency).isNull()
+            assertThat(commentText).isEqualTo("Tap OUT comment")
+            assertThat(toAddressId).isNull()
+            assertThat(toAddressOwnerClass).isNull()
+            assertThat(toFullAddress).isEqualTo("Sheffield")
+            assertThat(toAddressPostcode).isNull()
+          }
+      }
+
+      @Test
+      fun `should retrieve unscheduled tap movement out with agency for address`() {
+        webTestClient.getTapMovementOutOk(bookingId = agencyBooking.bookingId, movementSeq = agencyTapMovementOut.id.sequence)
+          .apply {
+            assertThat(bookingId).isEqualTo(agencyBooking.bookingId)
+            assertThat(sequence).isEqualTo(agencyTapMovementOut.id.sequence)
+            assertThat(tapScheduleOutId).isNull()
+            assertThat(tapApplicationId).isNull()
+            assertThat(toAgency).isEqualTo("NGENHO")
+            assertThat(toAddressId).isEqualTo(agencyAddress.addressId)
+            assertThat(toAddressOwnerClass).isEqualTo("AGY")
+            assertThat(toFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+            assertThat(toAddressDescription).isEqualTo("Northern General Hospital")
+            assertThat(toAddressPostcode).isEqualTo("S5 7AU")
+          }
+      }
+    }
+
+    @Nested
+    inner class GetScheduledTapMovementOut {
+
+      @Nested
+      inner class WithoutAddress {
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            offender = offender(nomsId = offenderNo) {
+              booking = booking {
+                application = tapApplication {
+                  scheduleOut = tapScheduleOut {
+                    movementOut = tapMovementOut(
+                      date = twoDaysAgo,
+                      fromPrison = "LEI",
+                      toAgency = "HAZLWD",
+                      movementReason = "C5",
+                      arrestAgency = "POL",
+                      escort = "L",
+                      escortText = "SE",
+                      comment = "Tap OUT comment",
+                      toAddress = null,
+                    )
+                    scheduleIn = tapScheduleIn {
+                      movementIn = tapMovementIn()
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        @Test
+        fun `should retrieve scheduled tap movement out`() {
+          webTestClient.getTapMovementOutOk()
+            .apply {
+              assertThat(bookingId).isEqualTo(booking.bookingId)
+              assertThat(sequence).isEqualTo(movementOut.id.sequence)
+              assertThat(tapScheduleOutId).isEqualTo(scheduleOut.eventId)
+              assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+              assertThat(movementDate).isEqualTo("${twoDaysAgo.toLocalDate()}")
+              assertThat(movementTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+              assertThat(movementReason).isEqualTo("C5")
+              assertThat(arrestAgency).isEqualTo("POL")
+              assertThat(escort).isEqualTo("L")
+              assertThat(escortText).isEqualTo("SE")
+              assertThat(fromPrison).isEqualTo("LEI")
+              assertThat(toAgency).isEqualTo("HAZLWD")
+              assertThat(commentText).isEqualTo("Tap OUT comment")
+              assertThat(toAddressId).isNull()
+              assertThat(toAddressDescription).isNull()
+              assertThat(toAddressOwnerClass).isNull()
+              assertThat(toFullAddress).isNull()
+              assertThat(toAddressPostcode).isNull()
+            }
+        }
+      }
+
+      @Nested
+      inner class WithOffenderAddress {
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, not movement")
+        inner class WithAddressOnScheduledOutButNotMovement {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                offenderAddress = address(
+                  flat = "Flat 1",
+                  premise = "41",
+                  street = "High Street",
+                  locality = "Hillsborough",
+                  city = "25343",
+                  county = "S.YORKSHIRE",
+                  country = "ENG",
+                  postcode = "S1 1AB",
+                )
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = offenderAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = null,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from tap schedule out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(bookingId).isEqualTo(booking.bookingId)
+                assertThat(sequence).isEqualTo(movementOut.id.sequence)
+                assertThat(toAddressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+                assertThat(toFullAddress).isEqualTo("Flat 1, 41 High Street, Hillsborough, Sheffield, South Yorkshire, England")
+                assertThat(toAddressPostcode).isEqualTo("S1 1AB")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on both schedule and movement")
+        inner class WithAddressOnMovement {
+          private lateinit var scheduleAddress: OffenderAddress
+          private lateinit var movementAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduleAddress = address()
+                movementAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduleAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = movementAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should take the address from the tap movement out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(toAddressId).isEqualTo(movementAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo(movementAddress.addressOwnerClass)
+              }
+          }
+        }
+      }
+
+      @Nested
+      @DisplayName("With corporate address")
+      inner class WithCorporateAddress {
+        private lateinit var corporateAddress: CorporateAddress
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, not movement")
+        inner class WithAddressOnScheduledOutButNotMovement {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              corporate(
+                corporateName = "Boots",
+              ) {
+                corporateAddress = address(
+                  type = "BUS",
+                  flat = "3B",
+                  premise = "Brown Court",
+                  street = "Scotland Street",
+                  locality = "Hunters Bar",
+                  postcode = "S1 3GG",
+                  city = SHEFFIELD,
+                  county = "S.YORKSHIRE",
+                  country = "ENG",
+                )
+              }
+              offender = offender(nomsId = offenderNo) {
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = corporateAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = null,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should take corporate address from tap schedule out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(bookingId).isEqualTo(booking.bookingId)
+                assertThat(sequence).isEqualTo(movementOut.id.sequence)
+                assertThat(toAddressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+                assertThat(toAddressDescription).isEqualTo("Boots")
+                assertThat(toFullAddress).isEqualTo("Flat 3B, Brown Court, Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+                assertThat(toAddressPostcode).isEqualTo("S1 3GG")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on both schedule and movement")
+        inner class WithAddressOnMovement {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              nomisDataBuilder.build {
+                corporate(
+                  corporateName = "Boots",
+                ) {
+                  corporateAddress = address(
+                    type = "BUS",
+                    flat = "3B",
+                    premise = "Brown Court",
+                    street = "Scotland Street",
+                    locality = "Hunters Bar",
+                    postcode = "S1 3GG",
+                    city = SHEFFIELD,
+                    county = "S.YORKSHIRE",
+                    country = "ENG",
+                  )
+                }
+                offender = offender(nomsId = offenderNo) {
+                  offenderAddress = address()
+                  booking = booking {
+                    application = tapApplication {
+                      scheduleOut = tapScheduleOut(
+                        toAddress = offenderAddress,
+                      ) {
+                        movementOut = tapMovementOut(
+                          toAddress = corporateAddress,
+                        )
+                        scheduleIn = tapScheduleIn {
+                          movementIn = tapMovementIn()
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should take corporate address from tap movement out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(toAddressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("CORP")
+                assertThat(toAddressDescription).isEqualTo("Boots")
+                assertThat(toFullAddress).isEqualTo("Flat 3B, Brown Court, Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+                assertThat(toAddressPostcode).isEqualTo("S1 3GG")
+              }
+          }
+        }
+      }
+
+      @Test
+      fun `should not remove corporate name from address if they are identical`() {
+        nomisDataBuilder.build {
+          corporate(
+            corporateName = "Newcastle City Centre",
+          ) {
+            corporateAddress = address(
+              type = "BUS",
+              flat = null,
+              premise = "Newcastle City Centre",
+              street = null,
+              locality = null,
+              postcode = null,
+              city = null,
+              county = null,
+              country = null,
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  toAddress = corporateAddress,
+                )
+              }
+            }
+          }
+        }
+
+        webTestClient.getTapScheduleOut()
+          .apply {
+            assertThat(toAddressId).isEqualTo(corporateAddress.addressId)
+            assertThat(toAddressOwnerClass).isEqualTo("CORP")
+            assertThat(toAddressDescription).isEqualTo("Newcastle City Centre")
+            assertThat(toFullAddress).isEqualTo("Newcastle City Centre")
+          }
+      }
+
+      @Nested
+      @DisplayName("With agency address")
+      inner class WithAgencyAddress {
+        private lateinit var agencyAddress: AgencyLocationAddress
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            agencyLocation = agencyLocation(
+              agencyLocationId = "NGENHO",
+              description = "Northern General Hospital",
+              type = "HOSPITAL",
+            ) {
+              agencyAddress = address(
+                type = "BUS",
+                street = "Herries Road",
+                postcode = "S5 7AU",
+                city = SHEFFIELD,
+                county = "S.YORKSHIRE",
+                country = "ENG",
+              )
+            }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, not movement")
+        inner class WithAddressOnScheduledOutButNotMovement {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = agencyAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = null,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should take agency address from tap schedule out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(bookingId).isEqualTo(booking.bookingId)
+                assertThat(sequence).isEqualTo(movementOut.id.sequence)
+                assertThat(toAddressId).isEqualTo(agencyAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("AGY")
+                assertThat(toAddressDescription).isEqualTo("Northern General Hospital")
+                assertThat(toFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+                assertThat(toAddressPostcode).isEqualTo("S5 7AU")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on both schedule and movement")
+        inner class WithAddressOnMovement {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                offenderAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = offenderAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = agencyAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should take agency address from tap movement out`() {
+            webTestClient.getTapMovementOutOk()
+              .apply {
+                assertThat(bookingId).isEqualTo(booking.bookingId)
+                assertThat(sequence).isEqualTo(movementOut.id.sequence)
+                assertThat(toAddressId).isEqualTo(agencyAddress.addressId)
+                assertThat(toAddressOwnerClass).isEqualTo("AGY")
+                assertThat(toAddressDescription).isEqualTo("Northern General Hospital")
+                assertThat(toFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+                assertThat(toAddressPostcode).isEqualTo("S5 7AU")
+              }
+          }
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /movements/{offenderNo}/taps/movement/out")
+  inner class CreateTapMovementOutTest {
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut()
+            }
+          }
+        }
+      }
+    }
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteOffenders()
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `should create tap movement out`() {
+        webTestClient.createTapMovementOutOk()
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            // Note there is already an admission external movement on sequence 1
+            assertThat(movementSequence).isEqualTo(2)
+            repository.runInTransaction {
+              with(movementOutRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSequence)!!) {
+                assertThat(active).isTrue
+                assertThat(tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
+                assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(movementTime).isEqualTo(twoDaysAgo)
+                assertThat(movementReason.code).isEqualTo("C5")
+                assertThat(arrestAgency?.code).isEqualTo("POL")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(escortText).isEqualTo("SE")
+                assertThat(fromAgency?.id).isEqualTo("LEI")
+                assertThat(toAgency?.id).isEqualTo("HAZLWD")
+                assertThat(commentText).isEqualTo("comment tap movement out")
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toCity?.code).isEqualTo(offenderAddress.city?.code)
+              }
+              with(offenderExternalMovementRepository.findByIdOrNull(OffenderExternalMovementId(booking, 1))!!) {
+                assertThat(active).isFalse
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return not found if offender unknown`() {
+        webTestClient.createTapMovementOut(offenderNo = "UNKNOWN")
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if offender has no bookings`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+          }
+        }
+
+        webTestClient.createTapMovementOut()
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("C1234DE").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return bad request if tap schedule out does not exist`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+
+        webTestClient.createTapMovementOut(request = aCreateTapMovementOutRequest(tapScheduleOutId = 9999))
+          .isBadRequest
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("does not exist")
+          }
+      }
+
+      @Test
+      fun `should return bad request for invalid movement reason`() {
+        webTestClient.createTapMovementOutBadRequestUnknown(aCreateTapMovementOutRequest().copy(movementReason = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid arrest agency`() {
+        webTestClient.createTapMovementOutBadRequestUnknown(aCreateTapMovementOutRequest().copy(arrestAgency = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid escort`() {
+        webTestClient.createTapMovementOutBadRequestUnknown(aCreateTapMovementOutRequest().copy(escort = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid from prison`() {
+        webTestClient.createTapMovementOutBadRequestUnknown(aCreateTapMovementOutRequest().copy(fromPrison = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to agency`() {
+        webTestClient.createTapMovementOutBadRequestUnknown(aCreateTapMovementOutRequest().copy(toAgency = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to address id`() {
+        webTestClient.createTapMovementOutBadRequest(aCreateTapMovementOutRequest().copy(toAddressId = 9999))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("invalid")
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/out")
+          .bodyValue(aCreateTapMovementOutRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/out")
+          .headers(setAuthorisation(roles = listOf()))
+          .bodyValue(aCreateTapMovementOutRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/out")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .bodyValue(aCreateTapMovementOutRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class CreateUnscheduledTapMovementOut {
+      @Test
+      fun `should create unscheduled tap movement out`() {
+        webTestClient.createTapMovementOutOk(aCreateTapMovementOutRequest(tapScheduleOutId = null))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            // Note there is already an admission external movement on sequence 1
+            assertThat(movementSequence).isEqualTo(2)
+            repository.runInTransaction {
+              with(movementOutRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSequence)!!) {
+                assertThat(active).isTrue
+                assertThat(tapScheduleOut).isNull()
+                assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(movementTime).isEqualTo(twoDaysAgo)
+              }
+              with(offenderExternalMovementRepository.findByIdOrNull(OffenderExternalMovementId(booking, 1))!!) {
+                assertThat(active).isFalse
+              }
+            }
+          }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/movement/in/{bookingId}/{movementSeq}")
+  inner class GetTapMovementIn {
+
+    @Nested
+    inner class GetUnscheduledTapMovementIn {
+      private lateinit var agencyAddress: AgencyLocationAddress
+      private lateinit var cityBooking: OffenderBooking
+      private lateinit var agencyBooking: OffenderBooking
+      private lateinit var cityTapMovementIn: OffenderTapMovementIn
+      private lateinit var agencyTapMovementIn: OffenderTapMovementIn
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          agencyLocation = agencyLocation(
+            agencyLocationId = "NGENHO",
+            description = "Northern General Hospital",
+            type = "HOSPITAL",
+          ) {
+            agencyAddress = address(
+              type = "BUS",
+              premise = "2",
+              street = "Herries Road",
+              postcode = "S5 7AU",
+              city = SHEFFIELD,
+              county = "S.YORKSHIRE",
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            cityBooking = booking {
+              cityTapMovementIn = tapMovementIn(
+                date = twoDaysAgo,
+                fromAgency = null,
+                toPrison = "LEI",
+                movementReason = "C5",
+                escort = "L",
+                escortText = "SE",
+                comment = "Tap IN comment",
+                fromCity = "25343",
+              )
+            }
+            agencyBooking = booking {
+              agencyTapMovementIn = tapMovementIn(
+                date = twoDaysAgo,
+                toPrison = "LEI",
+                fromAgency = "NGENHO",
+                fromCity = null,
+              )
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should return unauthorised for missing token`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/in/${cityBooking.bookingId}/1")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/in/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/in/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation("ROLE_INVALID"))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return not found if offender not found`() {
+        webTestClient.get()
+          .uri("/movements/UNKNOWN/taps/movement/in/${cityBooking.bookingId}/1")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if tap movement in not found`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/movement/in/9999/1")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should retrieve unscheduled tap movement in with city address`() {
+        webTestClient.getTapMovementInOk(bookingId = cityBooking.bookingId, movementSeq = cityTapMovementIn.id.sequence)
+          .apply {
+            assertThat(bookingId).isEqualTo(cityBooking.bookingId)
+            assertThat(sequence).isEqualTo(cityTapMovementIn.id.sequence)
+            assertThat(tapScheduleOutId).isNull()
+            assertThat(tapScheduleInId).isNull()
+            assertThat(tapApplicationId).isNull()
+            assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+            assertThat(movementTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+            assertThat(movementReason).isEqualTo("C5")
+            assertThat(escort).isEqualTo("L")
+            assertThat(escortText).isEqualTo("SE")
+            assertThat(fromAgency).isNull()
+            assertThat(toPrison).isEqualTo("LEI")
+            assertThat(commentText).isEqualTo("Tap IN comment")
+            assertThat(fromAddressId).isNull()
+            assertThat(fromAddressOwnerClass).isNull()
+            assertThat(fromFullAddress).isEqualTo("Sheffield")
+            assertThat(fromAddressPostcode).isNull()
+          }
+      }
+
+      @Test
+      fun `should retrieve unscheduled tap movement in with agency address`() {
+        webTestClient.getTapMovementInOk(bookingId = agencyBooking.bookingId, movementSeq = agencyTapMovementIn.id.sequence)
+          .apply {
+            assertThat(bookingId).isEqualTo(agencyBooking.bookingId)
+            assertThat(sequence).isEqualTo(agencyTapMovementIn.id.sequence)
+            assertThat(tapScheduleOutId).isNull()
+            assertThat(tapScheduleInId).isNull()
+            assertThat(tapApplicationId).isNull()
+            assertThat(fromAgency).isEqualTo("NGENHO")
+            assertThat(toPrison).isEqualTo("LEI")
+            assertThat(fromAddressId).isEqualTo(agencyAddress.addressId)
+            assertThat(fromAddressOwnerClass).isEqualTo("AGY")
+            assertThat(fromFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+            assertThat(fromAddressDescription).isEqualTo("Northern General Hospital")
+            assertThat(fromAddressPostcode).isEqualTo("S5 7AU")
+          }
+      }
+    }
+
+    @Nested
+    inner class GetScheduledTapMovementIn {
+
+      @Nested
+      inner class WithoutAddress {
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            offender = offender(nomsId = offenderNo) {
+              booking = booking {
+                application = tapApplication {
+                  scheduleOut = tapScheduleOut {
+                    movementOut = tapMovementOut()
+                    scheduleIn = tapScheduleIn {
+                      movementIn = tapMovementIn(
+                        date = twoDaysAgo,
+                        fromAgency = "HAZLWD",
+                        toPrison = "LEI",
+                        movementReason = "C5",
+                        escort = "L",
+                        escortText = "SE",
+                        comment = "Tap IN comment",
+                        fromAddress = null,
+                      )
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        @Test
+        fun `should retrieve scheduled tap movement in`() {
+          webTestClient.getTapMovementInOk()
+            .apply {
+              assertThat(bookingId).isEqualTo(booking.bookingId)
+              assertThat(sequence).isEqualTo(movementIn.id.sequence)
+              assertThat(tapScheduleOutId).isEqualTo(scheduleOut.eventId)
+              assertThat(tapScheduleInId).isEqualTo(scheduleIn.eventId)
+              assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+              assertThat(movementDate).isEqualTo("${twoDaysAgo.toLocalDate()}")
+              assertThat(movementTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+              assertThat(movementReason).isEqualTo("C5")
+              assertThat(escort).isEqualTo("L")
+              assertThat(escortText).isEqualTo("SE")
+              assertThat(fromAgency).isEqualTo("HAZLWD")
+              assertThat(toPrison).isEqualTo("LEI")
+              assertThat(commentText).isEqualTo("Tap IN comment")
+              assertThat(fromAddressId).isNull()
+              assertThat(fromAddressOwnerClass).isNull()
+              assertThat(fromFullAddress).isNull()
+              assertThat(fromAddressPostcode).isNull()
+            }
+        }
+      }
+
+      @Nested
+      inner class WithOffenderAddress {
+
+        @Nested
+        inner class WithAddressOnScheduledOutOnly {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                offenderAddress = address(
+                  flat = "Flat 1",
+                  premise = "41",
+                  street = "High Street",
+                  locality = "Hillsborough",
+                  city = "25343",
+                  county = "S.YORKSHIRE",
+                  country = "ENG",
+                  postcode = "S1 1AB",
+                )
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = offenderAddress,
+                    ) {
+                      movementOut = tapMovementOut()
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from tap scheduled OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(offenderAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+                assertThat(fromFullAddress).isEqualTo("Flat 1, 41 High Street, Hillsborough, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S1 1AB")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on tap scheduled OUT and tap movement OUT but not tap movement IN")
+        inner class WithAddressOnScheduledOutAndMovementOutButNotMovementIn {
+          private lateinit var scheduledOutAddress: OffenderAddress
+          private lateinit var movementOutAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                movementOutAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = movementOutAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = null,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from tap movement OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(movementOutAddress.addressId)
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, movement OUT and movement IN")
+        inner class WithAddressOnMovementAndSchedules {
+          private lateinit var scheduledOutAddress: OffenderAddress
+          private lateinit var movementOutAddress: OffenderAddress
+          private lateinit var movementInAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                movementOutAddress = address()
+                movementInAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = movementOutAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = movementInAddress,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from movement IN`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(movementInAddress.addressId)
+              }
+          }
+        }
+      }
+
+      @Nested
+      inner class WithCorporateAddress {
+        private lateinit var corporateAddress: CorporateAddress
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            corporate(
+              corporateName = "Boots",
+            ) {
+              corporateAddress = address(
+                type = "BUS",
+                flat = "3B",
+                premise = "Brown Court",
+                street = "Scotland Street",
+                locality = "Hunters Bar",
+                postcode = "S1 3GG",
+                city = SHEFFIELD,
+                county = "S.YORKSHIRE",
+                country = "ENG",
+              )
+            }
+          }
+        }
+
+        @Nested
+        inner class WithAddressOnScheduledOutOnly {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                offenderAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = corporateAddress,
+                    ) {
+                      movementOut = tapMovementOut()
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve corporate address from tap scheduled OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(corporateAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("CORP")
+                assertThat(fromAddressDescription).isEqualTo("Boots")
+                assertThat(fromFullAddress).isEqualTo("Flat 3B, Brown Court, Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S1 3GG")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT and movement OUT but not movement IN")
+        inner class WithAddressOnScheduledOutAndMovementOutButNotMovementIn {
+          private lateinit var scheduledOutAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = corporateAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = null,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from movement OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(corporateAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("CORP")
+                assertThat(fromAddressDescription).isEqualTo("Boots")
+                assertThat(fromFullAddress).isEqualTo("Flat 3B, Brown Court, Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S1 3GG")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, movement OUT and movement IN")
+        inner class WithAddressOnMovementAndSchedules {
+          private lateinit var scheduledOutAddress: OffenderAddress
+          private lateinit var movementOutAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                movementOutAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = movementOutAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = corporateAddress,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from movement IN`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(corporateAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("CORP")
+                assertThat(fromAddressDescription).isEqualTo("Boots")
+                assertThat(fromFullAddress).isEqualTo("Flat 3B, Brown Court, Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S1 3GG")
+              }
+          }
+        }
+      }
+
+      @Nested
+      inner class WithAgencyAddress {
+        private lateinit var agencyAddress: AgencyLocationAddress
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            agencyLocation = agencyLocation(
+              agencyLocationId = "NGENHO",
+              description = "Northern General Hospital",
+              type = "HOSPITAL",
+            ) {
+              agencyAddress = address(
+                type = "BUS",
+                street = "Herries Road",
+                postcode = "S5 7AU",
+                city = SHEFFIELD,
+                county = "S.YORKSHIRE",
+                country = "ENG",
+              )
+            }
+          }
+        }
+
+        @Nested
+        inner class WithAddressOnScheduledOutOnly {
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                offenderAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = agencyAddress,
+                    ) {
+                      movementOut = tapMovementOut()
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn()
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from scheduled OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(agencyAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("AGY")
+                assertThat(fromAddressDescription).isEqualTo("Northern General Hospital")
+                assertThat(fromFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S5 7AU")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT and movement OUT but not movement IN")
+        inner class WithAddressOnScheduledOutAndMovementOutButNotMovementIn {
+          private lateinit var scheduledOutAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = agencyAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = null,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from movement OUT`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(agencyAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("AGY")
+                assertThat(fromAddressDescription).isEqualTo("Northern General Hospital")
+                assertThat(fromFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S5 7AU")
+              }
+          }
+        }
+
+        @Nested
+        @DisplayName("With address on scheduled OUT, movement OUT and movement IN")
+        inner class WithAddressOnMovementAndSchedules {
+          private lateinit var scheduledOutAddress: OffenderAddress
+          private lateinit var movementOutAddress: OffenderAddress
+
+          @BeforeEach
+          fun setUp() {
+            nomisDataBuilder.build {
+              offender = offender(nomsId = offenderNo) {
+                scheduledOutAddress = address()
+                movementOutAddress = address()
+                booking = booking {
+                  application = tapApplication {
+                    scheduleOut = tapScheduleOut(
+                      toAddress = scheduledOutAddress,
+                    ) {
+                      movementOut = tapMovementOut(
+                        toAddress = movementOutAddress,
+                      )
+                      scheduleIn = tapScheduleIn {
+                        movementIn = tapMovementIn(
+                          fromAddress = agencyAddress,
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          @Test
+          fun `should retrieve address from movement IN`() {
+            webTestClient.getTapMovementInOk()
+              .apply {
+                assertThat(fromAddressId).isEqualTo(agencyAddress.addressId)
+                assertThat(fromAddressOwnerClass).isEqualTo("AGY")
+                assertThat(fromAddressDescription).isEqualTo("Northern General Hospital")
+                assertThat(fromFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+                assertThat(fromAddressPostcode).isEqualTo("S5 7AU")
+              }
+          }
+        }
+      }
+
+      @Nested
+      inner class GetScheduledReturnWithBrokenParentLink {
+
+        @BeforeEach
+        fun setUp() {
+          nomisDataBuilder.build {
+            offender = offender(nomsId = offenderNo) {
+              booking = booking {
+                application = tapApplication {
+                  scheduleOut = tapScheduleOut {
+                    movementOut = tapMovementOut()
+                    scheduleIn = tapScheduleIn {
+                      movementIn = tapMovementIn()
+                    }
+                  }
+                }
+              }
+            }
+
+            // there's a bug in NOMIS where the external movement parent event id is null if you perform any unscheduled
+            // external movements inbetween confirming the scheduled OUT/IN movements
+            movementIn.tapScheduleOut = null
+          }
+        }
+
+        @Test
+        fun `should retrieve scheduled tap movement in as unscheduled`() {
+          webTestClient.getTapMovementInOk()
+            .apply {
+              assertThat(bookingId).isEqualTo(booking.bookingId)
+              assertThat(sequence).isEqualTo(movementIn.id.sequence)
+              assertThat(tapScheduleOutId).isNull()
+              assertThat(tapScheduleInId).isNull()
+              assertThat(tapApplicationId).isNull()
+            }
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /movements/{offenderNo}/taps/movement/in")
+  inner class CreateTapMovementInTest {
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn()
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteOffenders()
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `should create tap movement in`() {
+        webTestClient.createTapMovementInOk()
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            // Note there is already an admission external movement on sequence 1 and the tap movement out on sequence 2
+            assertThat(movementSequence).isEqualTo(3)
+            repository.runInTransaction {
+              with(movementInRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSequence)!!) {
+                assertThat(active).isTrue
+                assertThat(tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
+                assertThat(tapScheduleIn?.eventId).isEqualTo(scheduleIn.eventId)
+                assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(movementTime).isEqualTo(twoDaysAgo)
+                assertThat(movementReason.code).isEqualTo("C5")
+                assertThat(arrestAgency?.code).isEqualTo("POL")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(escortText).isEqualTo("SE")
+                assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+                assertThat(toAgency?.id).isEqualTo("LEI")
+                assertThat(commentText).isEqualTo("comment tap movement in")
+                assertThat(fromAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(fromCity?.code).isEqualTo(offenderAddress.city?.code)
+              }
+              with(offenderExternalMovementRepository.findByIdOrNull(OffenderExternalMovementId(booking, 1))!!) {
+                assertThat(active).isFalse
+              }
+              with(offenderExternalMovementRepository.findByIdOrNull(OffenderExternalMovementId(booking, 2))!!) {
+                assertThat(active).isFalse
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return not found if offender unknown`() {
+        webTestClient.createTapMovementIn(offenderNo = "UNKNOWN")
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if offender has no bookings`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+          }
+        }
+
+        webTestClient.createTapMovementIn()
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("C1234DE").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return bad request if tap schedule out does not exist`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+
+        webTestClient.createTapMovementIn(request = aCreateTapMovementInRequest(tapScheduleInId = 9999))
+          .isBadRequest
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("does not exist")
+          }
+      }
+
+      @Test
+      fun `should return bad request for invalid movement reason`() {
+        webTestClient.createTapMovementInBadRequestUnknown(aCreateTapMovementInRequest().copy(movementReason = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid arrest agency`() {
+        webTestClient.createTapMovementInBadRequestUnknown(aCreateTapMovementInRequest().copy(arrestAgency = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid escort`() {
+        webTestClient.createTapMovementInBadRequestUnknown(aCreateTapMovementInRequest().copy(escort = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid from agency`() {
+        webTestClient.createTapMovementInBadRequestUnknown(aCreateTapMovementInRequest().copy(fromAgency = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to prison`() {
+        webTestClient.createTapMovementInBadRequestUnknown(aCreateTapMovementInRequest().copy(toPrison = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to address id`() {
+        webTestClient.createTapMovementInBadRequest(aCreateTapMovementInRequest().copy(fromAddressId = 9999))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("invalid")
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/in")
+          .bodyValue(aCreateTapMovementInRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/in")
+          .headers(setAuthorisation(roles = listOf()))
+          .bodyValue(aCreateTapMovementInRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.post()
+          .uri("/movements/$offenderNo/taps/movement/in")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .bodyValue(aCreateTapMovementInRequest(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class CreateUnscheduledTapMovementIn {
+      @Test
+      fun `should create unscheduled tap movement in`() {
+        webTestClient.createTapMovementInOk(aCreateTapMovementInRequest(tapScheduleInId = null))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            // Note there is already an admission external movement on sequence 1 and the tap movement out on sequence 2
+            assertThat(movementSequence).isEqualTo(3)
+            repository.runInTransaction {
+              with(movementInRepository.findById_OffenderBooking_BookingIdAndId_Sequence(bookingId, movementSequence)!!) {
+                assertThat(active).isTrue
+                assertThat(tapScheduleOut).isNull()
+                assertThat(tapScheduleIn).isNull()
+                assertThat(movementDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(movementTime).isEqualTo(twoDaysAgo)
+              }
+              with(offenderExternalMovementRepository.findByIdOrNull(OffenderExternalMovementId(booking, 1))!!) {
+                assertThat(active).isFalse
+              }
+            }
+          }
+      }
+    }
+  }
+
+  /*
+   * The general approach where we have movements IN attached to different schedules to the correct scheduled OUT/IN
+   * is to treat the movement as unscheduled.
+   *
+   * This test suite corrupts data to emulate the various flavours of this error that we've seen with production data.
+   *
+   * The goal for each scenario is that the movement is considered unscheduled when either syncing the individual movement
+   * or resyncing all of the offender's movements.
+   */
+  @Nested
+  inner class GetUnscheduledTapMovementOutDueToBadData {
+
+    @Test
+    fun `scheduled OUT has been deleted`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                orphanedScheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by deleting the scheduled OUT
+         */
+        entityManager.createNativeQuery(
+          """
+              delete from OFFENDER_IND_SCHEDULES
+              where EVENT_ID = ${scheduleOut.eventId}
+          """.trimIndent(),
+        ).executeUpdate()
+
+        // Reload the scheduled return to reflect the update
+        orphanedScheduleIn = scheduleInRepository.findByIdOrNull(orphanedScheduleIn.eventId) ?: throw IllegalStateException("Failed to reload scheduled return movement - this should not happen")
+      }
+
+      // Sync movement OUT is unscheduled
+      webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+        }
+
+      // Sync the movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender, the movements are unscheduled
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].tapApplications[0].taps).isEmpty()
+          assertThat(bookings[0].unscheduledTapMovementOuts[0].sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts reflect both movements as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(0)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.outCount).isEqualTo(1)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `movement IN has different schedule IN to the schedule OUT`() {
+      lateinit var wrongScheduleIn: OffenderTapScheduleIn
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+            tapApplication {
+              tapScheduleOut {
+                wrongScheduleIn = tapScheduleIn()
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by linking the movement IN with the wrong scheduled return
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS oem
+              set EVENT_ID = ${wrongScheduleIn.eventId}
+              where OFFENDER_BOOK_ID=${booking.bookingId} and MOVEMENT_SEQ=${movementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement OUT is scheduled
+      webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+          assertThat(tapScheduleOutId).isEqualTo(scheduleOut.eventId)
+        }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender matches the sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].tapApplications[0].taps[0].tapMovementOut!!.sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts the IN movement as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    /*
+     * This test demonstrates that a resync will not work but a normal sync will find that the movement is unscheduled.
+     */
+    @Test
+    fun `movement IN is unscheduled but points at schedule OUT instead of IN - FAILS`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                scheduleIn = tapScheduleIn()
+              }
+            }
+            movementIn = tapMovementIn()
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by pointing the movement IN at the schedule OUT
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS 
+              set EVENT_ID = ${scheduleOut.eventId}
+              where OFFENDER_BOOK_ID = ${booking.bookingId} and MOVEMENT_SEQ = ${movementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is the same as the sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts the IN movement as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `movement IN does not point at schedule OUT`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by pointing the movement IN at nothing
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set PARENT_EVENT_ID = null
+              where OFFENDER_BOOK_ID = ${booking.bookingId} and MOVEMENT_SEQ = ${movementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement OUT is scheduled
+      webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+          assertThat(tapScheduleOutId).isEqualTo(scheduleOut.eventId)
+        }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is same as for sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].tapApplications[0].taps[0].tapMovementOut!!.sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts OUT as scheduled and IN as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `movement IN points at a schedule IN that doesn't exist`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by pointing the movement IN at a schedule that doesn't exist
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set PARENT_EVENT_ID = 99999
+              where OFFENDER_BOOK_ID = ${booking.bookingId} and MOVEMENT_SEQ = ${movementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement OUT is scheduled
+      webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+          assertThat(tapScheduleOutId).isEqualTo(scheduleOut.eventId)
+        }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is same as for sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].tapApplications[0].taps[0].tapMovementOut!!.sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts the OUT movement as scheduled and IN as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `unscheduled movement IN points at a schedule IN but it shouldn't`() {
+      lateinit var wrongTapMovementIn: OffenderTapMovementIn
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                orphanedScheduleIn = tapScheduleIn()
+              }
+            }
+            wrongTapMovementIn = tapMovementIn()
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by pointing the unscheduled movement IN at the schedule IN
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set EVENT_ID = ${orphanedScheduleIn.eventId}
+              where OFFENDER_BOOK_ID = ${booking.bookingId} and MOVEMENT_SEQ = ${wrongTapMovementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+
+        // Reload the scheduled return to reflect the update
+        orphanedScheduleIn = scheduleInRepository.findByIdOrNull(orphanedScheduleIn.eventId) ?: throw IllegalStateException("Failed to reload scheduled return movement - this should not happen")
+      }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = wrongTapMovementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is same as for sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(wrongTapMovementIn.id.sequence)
+        }
+
+      // Reconciliation counts the movement as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `unscheduled movement IN points at a schedule OUT and IN but it shouldn't`() {
+      lateinit var wrongTapMovementIn: OffenderTapMovementIn
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn()
+              }
+            }
+            wrongTapMovementIn = tapMovementIn()
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by pointing the unscheduled movement IN at an unrelated schedule IN and a schedule OUT that doesn't exist
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set EVENT_ID = ${scheduleIn.eventId}, PARENT_EVENT_ID=99999
+              where OFFENDER_BOOK_ID = ${booking.bookingId} and MOVEMENT_SEQ = ${wrongTapMovementIn.id.sequence}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = wrongTapMovementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is same as for sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(wrongTapMovementIn.id.sequence)
+        }
+
+      // Reconciliation counts the OUT movement as scheduled and IN as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(1)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `scheduled movements points at a schedule without an application`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      repository.runInTransaction {
+        /*
+         * Corrupt the data by removing the application from the schedules
+         */
+        entityManager.createNativeQuery(
+          """
+              update OFFENDER_IND_SCHEDULES
+              set OFFENDER_MOVEMENT_APP_ID = null
+              where EVENT_ID in (${scheduleOut.eventId}, ${scheduleIn.eventId})
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // Sync movement OUT is unscheduled
+      webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+        }
+
+      // Sync movement IN is unscheduled
+      webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+        .apply {
+          assertThat(tapApplicationId).isNull()
+          assertThat(tapScheduleOutId).isNull()
+          assertThat(tapScheduleInId).isNull()
+        }
+
+      // Resync offender is same as for sync
+      webTestClient.getOffenderTapsOk()
+        .apply {
+          assertThat(bookings[0].unscheduledTapMovementOuts[0].sequence).isEqualTo(movementOut.id.sequence)
+          assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+        }
+
+      // Reconciliation counts the movements as unscheduled
+      webTestClient.getOffenderSummaryOk(offender.nomsId)
+        .apply {
+          assertThat(movements.scheduled.outCount).isEqualTo(0)
+          assertThat(movements.scheduled.inCount).isEqualTo(0)
+          assertThat(movements.unscheduled.outCount).isEqualTo(1)
+          assertThat(movements.unscheduled.inCount).isEqualTo(1)
+        }
+    }
+
+    @Nested
+    inner class CorruptScheduleType {
+      @AfterEach
+      fun `clear schedules`() {
+        // We need a special clean up here because we've changed the discriminator on the schedules so they're no longer TAPs
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              delete from OFFENDER_IND_SCHEDULES
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+      }
+
+      @Test
+      fun `scheduled movements point at a schedule that is not a TAP`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          /*
+           * Corrupt the data by making the schedule a non-TAP
+           */
+          entityManager.createNativeQuery(
+            """
+              update OFFENDER_IND_SCHEDULES
+              set EVENT_TYPE = 'TRN'
+              where EVENT_ID in (${scheduleOut.eventId}, ${scheduleIn.eventId})
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // Sync movement OUT is unscheduled
+        webTestClient.getTapMovementOutOk(movementSeq = movementOut.id.sequence)
+          .apply {
+            assertThat(tapApplicationId).isNull()
+            assertThat(tapScheduleOutId).isNull()
+          }
+
+        // Sync movement IN is unscheduled
+        webTestClient.getTapMovementInOk(movementSeq = movementIn.id.sequence)
+          .apply {
+            assertThat(tapApplicationId).isNull()
+            assertThat(tapScheduleOutId).isNull()
+            assertThat(tapScheduleInId).isNull()
+          }
+
+        // Resync offender is same as for sync
+        webTestClient.getOffenderTapsOk()
+          .apply {
+            assertThat(bookings[0].unscheduledTapMovementOuts[0].sequence).isEqualTo(movementOut.id.sequence)
+            assertThat(bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(movementIn.id.sequence)
+          }
+
+        // Reconciliation counts the movements as unscheduled
+        webTestClient.getOffenderSummaryOk(offender.nomsId)
+          .apply {
+            assertThat(movements.scheduled.outCount).isEqualTo(0)
+            assertThat(movements.scheduled.inCount).isEqualTo(0)
+            assertThat(movements.unscheduled.outCount).isEqualTo(1)
+            assertThat(movements.unscheduled.inCount).isEqualTo(1)
+          }
+      }
+    }
+  }
+
+  private fun WebTestClient.getTapMovementOutOk(offenderNo: String = offender.nomsId, bookingId: Long = booking.bookingId, movementSeq: Int = movementOut.id.sequence) = get()
+    .uri("/movements/$offenderNo/taps/movement/out/$bookingId/$movementSeq")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapMovementOut>()
+
+  private fun WebTestClient.getTapMovementInOk(offenderNo: String = offender.nomsId, bookingId: Long = booking.bookingId, movementSeq: Int = movementIn.id.sequence) = get()
+    .uri("/movements/$offenderNo/taps/movement/in/$bookingId/$movementSeq")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapMovementIn>()
+
+  private fun WebTestClient.getOffenderTaps(offenderNo: String = offender.nomsId) = get()
+    .uri("/movements/$offenderNo/taps")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.getOffenderTapsOk(offenderNo: String = offender.nomsId) = getOffenderTaps(offenderNo)
+    .expectStatus().isOk
+    .expectBodyResponse<OffenderTapsResponse>()
+
+  private fun WebTestClient.getOffenderSummaryOk(offenderNo: String) = getOffenderSummary(offenderNo)
+    .expectStatus().isOk
+    .expectBodyResponse<TapSummary>()
+
+  private fun WebTestClient.getOffenderSummary(offenderNo: String) = get()
+    .uri("/movements/$offenderNo/taps/summary")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.createTapMovementOut(
+    request: CreateTapMovementOut = aCreateTapMovementOutRequest(scheduleOut.eventId),
+    offenderNo: String = offender.nomsId,
+  ) = post()
+    .uri("/movements/$offenderNo/taps/movement/out")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun WebTestClient.createTapMovementOutOk(
+    request: CreateTapMovementOut = aCreateTapMovementOutRequest(scheduleOut.eventId),
+  ) = createTapMovementOut(request)
+    .isCreated
+    .expectBodyResponse<CreateTapMovementOutResponse>()
+
+  private fun WebTestClient.createTapMovementOutBadRequest(
+    request: CreateTapMovementOut = aCreateTapMovementOutRequest(scheduleOut.eventId),
+  ) = createTapMovementOut(request)
+    .isBadRequest
+
+  private fun WebTestClient.createTapMovementOutBadRequestUnknown(
+    request: CreateTapMovementOut = aCreateTapMovementOutRequest(scheduleOut.eventId),
+  ) = createTapMovementOutBadRequest(request)
+    .expectBody().jsonPath("userMessage").value<String> {
+      assertThat(it).contains("UNKNOWN").contains("invalid")
+    }
+
+  private fun WebTestClient.createTapMovementIn(
+    request: CreateTapMovementIn = aCreateTapMovementInRequest(scheduleIn.eventId),
+    offenderNo: String = offender.nomsId,
+  ) = post()
+    .uri("/movements/$offenderNo/taps/movement/in")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun WebTestClient.createTapMovementInOk(
+    request: CreateTapMovementIn = aCreateTapMovementInRequest(scheduleIn.eventId),
+  ) = createTapMovementIn(request)
+    .isCreated
+    .expectBodyResponse<CreateTapMovementInResponse>()
+
+  private fun WebTestClient.createTapMovementInBadRequest(
+    request: CreateTapMovementIn = aCreateTapMovementInRequest(scheduleIn.eventId),
+  ) = createTapMovementIn(request)
+    .isBadRequest
+
+  private fun WebTestClient.createTapMovementInBadRequestUnknown(
+    request: CreateTapMovementIn = aCreateTapMovementInRequest(scheduleIn.eventId),
+  ) = createTapMovementInBadRequest(request)
+    .expectBody().jsonPath("userMessage").value<String> {
+      assertThat(it).contains("UNKNOWN").contains("invalid")
+    }
+
+  private fun WebTestClient.getTapScheduleOut() = get()
+    .uri("/movements/${offender.nomsId}/taps/schedule/out/${scheduleOut.eventId}")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapScheduleOut>()
+
+  private fun aCreateTapMovementOutRequest(tapScheduleOutId: Long? = scheduleOut.eventId) = CreateTapMovementOut(
+    tapScheduleOutId = tapScheduleOutId,
+    movementDate = twoDaysAgo.toLocalDate(),
+    movementTime = twoDaysAgo,
+    movementReason = "C5",
+    arrestAgency = "POL",
+    escort = "L",
+    escortText = "SE",
+    fromPrison = "LEI",
+    toAgency = "HAZLWD",
+    commentText = "comment tap movement out",
+    toCity = offenderAddress.city?.code,
+    toAddressId = offenderAddress.addressId,
+  )
+
+  private fun aCreateTapMovementInRequest(tapScheduleInId: Long? = scheduleIn.eventId) = CreateTapMovementIn(
+    tapScheduleInId = tapScheduleInId,
+    movementDate = twoDaysAgo.toLocalDate(),
+    movementTime = twoDaysAgo,
+    movementReason = "C5",
+    arrestAgency = "POL",
+    escort = "L",
+    escortText = "SE",
+    fromAgency = "HAZLWD",
+    toPrison = "LEI",
+    commentText = "comment tap movement in",
+    fromAddressId = offenderAddress.addressId,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapRepositoryIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapRepositoryIntTest.kt
@@ -1,6 +1,6 @@
-package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -12,8 +12,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTest
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.EventType
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementDirection.IN
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementDirection.OUT
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.MovementDirection
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
@@ -86,27 +85,27 @@ class TapRepositoryIntTest(
       }
 
       with(tapApplicationRepository.findByIdOrNull(application.tapApplicationId)!!) {
-        assertThat(tapApplicationId).isGreaterThan(0L)
-        assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
-        assertThat(eventClass).isEqualTo("EXT_MOV")
-        assertThat(eventType).isEqualTo(EventType.TAP)
-        assertThat(eventSubType.code).isEqualTo("C5")
-        assertThat(applicationDate.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(applicationTime.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(fromDate).isEqualTo(LocalDate.now())
-        assertThat(releaseTime.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(toDate).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(returnTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(applicationType.code).isEqualTo("SINGLE")
-        assertThat(applicationStatus.code).isEqualTo("APP-SCH")
-        assertThat(escort?.code).isEqualTo("L")
-        assertThat(transportType?.code).isEqualTo("VAN")
-        assertThat(comment).isEqualTo("Some comment application")
-        assertThat(prison.id).isEqualTo("LEI")
-        assertThat(toAgency?.id).isEqualTo("HAZLWD")
-        assertThat(contactPersonName).isEqualTo("Derek")
-        assertThat(tapType?.code).isEqualTo("RR")
-        assertThat(tapSubType?.code).isEqualTo("RDR")
+        Assertions.assertThat(tapApplicationId).isGreaterThan(0L)
+        Assertions.assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+        Assertions.assertThat(eventClass).isEqualTo("EXT_MOV")
+        Assertions.assertThat(eventType).isEqualTo(EventType.TAP)
+        Assertions.assertThat(eventSubType.code).isEqualTo("C5")
+        Assertions.assertThat(applicationDate.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(applicationTime.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(fromDate).isEqualTo(LocalDate.now())
+        Assertions.assertThat(releaseTime.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(toDate).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(returnTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(applicationType.code).isEqualTo("SINGLE")
+        Assertions.assertThat(applicationStatus.code).isEqualTo("APP-SCH")
+        Assertions.assertThat(escort?.code).isEqualTo("L")
+        Assertions.assertThat(transportType?.code).isEqualTo("VAN")
+        Assertions.assertThat(comment).isEqualTo("Some comment application")
+        Assertions.assertThat(prison.id).isEqualTo("LEI")
+        Assertions.assertThat(toAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(contactPersonName).isEqualTo("Derek")
+        Assertions.assertThat(tapType?.code).isEqualTo("RR")
+        Assertions.assertThat(tapSubType?.code).isEqualTo("RDR")
       }
     }
 
@@ -138,22 +137,22 @@ class TapRepositoryIntTest(
       }
 
       with(tapScheduleOutRepository.findByIdOrNull(scheduleOut.eventId)!!) {
-        assertThat(eventId).isGreaterThan(0L)
-        assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
-        assertThat(tapApplication.tapApplicationId).isEqualTo(scheduleOut.tapApplication.tapApplicationId)
-        assertThat(eventDate).isEqualTo(LocalDate.now())
-        assertThat(startTime?.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(eventSubType.code).isEqualTo("C5")
-        assertThat(eventStatus.code).isEqualTo("SCH")
-        assertThat(fromAgency?.id).isEqualTo("LEI")
-        assertThat(toAgency?.id).isEqualTo("HAZLWD")
-        assertThat(comment).isEqualTo("Some comment")
-        assertThat(escort?.code).isEqualTo("U")
-        assertThat(transportType?.code).isEqualTo("VAN")
-        assertThat(returnDate).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(returnTime?.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(applicationDate.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(applicationTime?.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(eventId).isGreaterThan(0L)
+        Assertions.assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+        Assertions.assertThat(tapApplication.tapApplicationId).isEqualTo(scheduleOut.tapApplication.tapApplicationId)
+        Assertions.assertThat(eventDate).isEqualTo(LocalDate.now())
+        Assertions.assertThat(startTime?.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(eventSubType.code).isEqualTo("C5")
+        Assertions.assertThat(eventStatus.code).isEqualTo("SCH")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("LEI")
+        Assertions.assertThat(toAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(comment).isEqualTo("Some comment")
+        Assertions.assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(transportType?.code).isEqualTo("VAN")
+        Assertions.assertThat(returnDate).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(returnTime?.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(applicationDate.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(applicationTime?.toLocalDate()).isEqualTo(LocalDate.now())
       }
     }
 
@@ -181,17 +180,17 @@ class TapRepositoryIntTest(
       }
 
       with(tapScheduleInRepository.findByIdOrNull(scheduleIn.eventId)!!) {
-        assertThat(eventId).isGreaterThan(0L)
-        assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
-        assertThat(tapScheduleOut.eventId).isEqualTo(scheduleOut.eventId)
-        assertThat(eventDate).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(startTime?.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(eventSubType.code).isEqualTo("R25")
-        assertThat(eventStatus.code).isEqualTo("SCH")
-        assertThat(toAgency?.id).isEqualTo("LEI")
-        assertThat(fromAgency?.id).isEqualTo("HAZLWD")
-        assertThat(comment).isEqualTo("Some comment IN")
-        assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(eventId).isGreaterThan(0L)
+        Assertions.assertThat(offenderBooking.bookingId).isEqualTo(booking.bookingId)
+        Assertions.assertThat(tapScheduleOut.eventId).isEqualTo(scheduleOut.eventId)
+        Assertions.assertThat(eventDate).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(startTime?.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(eventSubType.code).isEqualTo("R25")
+        Assertions.assertThat(eventStatus.code).isEqualTo("SCH")
+        Assertions.assertThat(toAgency?.id).isEqualTo("LEI")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(comment).isEqualTo("Some comment IN")
+        Assertions.assertThat(escort?.code).isEqualTo("U")
       }
     }
 
@@ -222,18 +221,18 @@ class TapRepositoryIntTest(
       }
 
       with(tapApplicationRepository.findByIdOrNull(application1.tapApplicationId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("CORP")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("CORP")
       }
 
       with(tapApplicationRepository.findByIdOrNull(application2.tapApplicationId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("OFF")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("OFF")
       }
 
       with(tapApplicationRepository.findByIdOrNull(application3.tapApplicationId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("AGY")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("AGY")
       }
     }
 
@@ -269,18 +268,18 @@ class TapRepositoryIntTest(
       }
 
       with(tapScheduleOutRepository.findByIdOrNull(scheduleOut.eventId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("CORP")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("CORP")
       }
 
       with(tapScheduleOutRepository.findByIdOrNull(scheduledAbsence2.eventId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("OFF")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("OFF")
       }
 
       with(tapScheduleOutRepository.findByIdOrNull(scheduledAbsence3.eventId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo("AGY")
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo("AGY")
       }
     }
 
@@ -306,8 +305,8 @@ class TapRepositoryIntTest(
       jdbcTemplate.update("update offender_ind_schedules set TO_ADDRESS_OWNER_CLASS='${agencyAddress.agencyLocation.id}'")
 
       with(tapScheduleOutRepository.findByIdOrNull(scheduleOut.eventId)!!) {
-        assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
-        assertThat(toAddressOwnerClass).isEqualTo(agencyAddress.agencyLocation.id)
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(agencyAddress.addressId)
+        Assertions.assertThat(toAddressOwnerClass).isEqualTo(agencyAddress.agencyLocation.id)
       }
     }
 
@@ -340,19 +339,19 @@ class TapRepositoryIntTest(
       }
 
       with(tapMovementOutRepository.findByIdOrNull(movementOut.id)!!) {
-        assertThat(movementDate).isEqualTo(LocalDate.now())
-        assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(movementType?.code).isEqualTo("TAP")
-        assertThat(movementReason.code).isEqualTo("C5")
-        assertThat(movementDirection).isEqualTo(OUT)
-        assertThat(arrestAgency?.code).isEqualTo("POL")
-        assertThat(escort?.code).isEqualTo("U")
-        assertThat(escortText).isEqualTo("SE")
-        assertThat(fromAgency?.id).isEqualTo("BXI")
-        assertThat(toAgency?.id).isEqualTo("HAZLWD")
-        assertThat(commentText).isEqualTo("TAP OUT comment")
-        assertThat(toCity?.id?.code).isEqualTo(SHEFFIELD)
-        assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+        Assertions.assertThat(movementDate).isEqualTo(LocalDate.now())
+        Assertions.assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(movementType?.code).isEqualTo("TAP")
+        Assertions.assertThat(movementReason.code).isEqualTo("C5")
+        Assertions.assertThat(movementDirection).isEqualTo(MovementDirection.OUT)
+        Assertions.assertThat(arrestAgency?.code).isEqualTo("POL")
+        Assertions.assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(escortText).isEqualTo("SE")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("BXI")
+        Assertions.assertThat(toAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(commentText).isEqualTo("TAP OUT comment")
+        Assertions.assertThat(toCity?.id?.code).isEqualTo(SHEFFIELD)
+        Assertions.assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
       }
     }
 
@@ -381,18 +380,18 @@ class TapRepositoryIntTest(
       }
 
       with(tapMovementOutRepository.findByIdOrNull(movementOut.id)!!) {
-        assertThat(movementDate).isEqualTo(LocalDate.now())
-        assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now())
-        assertThat(movementType?.code).isEqualTo("TAP")
-        assertThat(movementReason.code).isEqualTo("C5")
-        assertThat(movementDirection).isEqualTo(OUT)
-        assertThat(arrestAgency?.code).isEqualTo("POL")
-        assertThat(escort?.code).isEqualTo("U")
-        assertThat(escortText).isEqualTo("SE")
-        assertThat(fromAgency?.id).isEqualTo("BXI")
-        assertThat(toAgency?.id).isEqualTo("HAZLWD")
-        assertThat(commentText).isEqualTo("Tap OUT comment")
-        assertThat(toCity?.id?.code).isEqualTo(SHEFFIELD)
+        Assertions.assertThat(movementDate).isEqualTo(LocalDate.now())
+        Assertions.assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now())
+        Assertions.assertThat(movementType?.code).isEqualTo("TAP")
+        Assertions.assertThat(movementReason.code).isEqualTo("C5")
+        Assertions.assertThat(movementDirection).isEqualTo(MovementDirection.OUT)
+        Assertions.assertThat(arrestAgency?.code).isEqualTo("POL")
+        Assertions.assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(escortText).isEqualTo("SE")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("BXI")
+        Assertions.assertThat(toAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(commentText).isEqualTo("Tap OUT comment")
+        Assertions.assertThat(toCity?.id?.code).isEqualTo(SHEFFIELD)
       }
     }
 
@@ -431,22 +430,22 @@ class TapRepositoryIntTest(
       }
 
       with(tapMovementInRepository.findByIdOrNull(movementIn.id)!!) {
-        assertThat(movementDate).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(movementType?.code).isEqualTo("TAP")
-        assertThat(movementReason.code).isEqualTo("C5")
-        assertThat(movementDirection).isEqualTo(IN)
-        assertThat(escort?.code).isEqualTo("U")
-        assertThat(escortText).isEqualTo("SE")
-        assertThat(fromAgency?.id).isEqualTo("HAZLWD")
-        assertThat(toAgency?.id).isEqualTo("BXI")
-        assertThat(commentText).isEqualTo("TAP IN comment")
-        assertThat(fromCity?.id?.code).isEqualTo(SHEFFIELD)
-        assertThat(fromAddress?.addressId).isEqualTo(offenderAddress.addressId)
-        assertThat(tapScheduleIn?.eventId).isEqualTo(scheduleIn.eventId)
-        assertThat(tapScheduleIn?.tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
-        assertThat(tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
-        assertThat(tapScheduleOut?.tapMovementOut?.id).isEqualTo(movementOut.id)
+        Assertions.assertThat(movementDate).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(movementType?.code).isEqualTo("TAP")
+        Assertions.assertThat(movementReason.code).isEqualTo("C5")
+        Assertions.assertThat(movementDirection).isEqualTo(MovementDirection.IN)
+        Assertions.assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(escortText).isEqualTo("SE")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(toAgency?.id).isEqualTo("BXI")
+        Assertions.assertThat(commentText).isEqualTo("TAP IN comment")
+        Assertions.assertThat(fromCity?.id?.code).isEqualTo(SHEFFIELD)
+        Assertions.assertThat(fromAddress?.addressId).isEqualTo(offenderAddress.addressId)
+        Assertions.assertThat(tapScheduleIn?.eventId).isEqualTo(scheduleIn.eventId)
+        Assertions.assertThat(tapScheduleIn?.tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
+        Assertions.assertThat(tapScheduleOut?.eventId).isEqualTo(scheduleOut.eventId)
+        Assertions.assertThat(tapScheduleOut?.tapMovementOut?.id).isEqualTo(movementOut.id)
       }
     }
 
@@ -475,20 +474,20 @@ class TapRepositoryIntTest(
       }
 
       with(tapMovementInRepository.findByIdOrNull(movementIn.id)!!) {
-        assertThat(movementDate).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
-        assertThat(movementType?.code).isEqualTo("TAP")
-        assertThat(movementReason.code).isEqualTo("C5")
-        assertThat(movementDirection).isEqualTo(IN)
-        assertThat(escort?.code).isEqualTo("U")
-        assertThat(escortText).isEqualTo("SE")
-        assertThat(fromAgency?.id).isEqualTo("HAZLWD")
-        assertThat(toAgency?.id).isEqualTo("BXI")
-        assertThat(commentText).isEqualTo("TAP IN comment")
-        assertThat(fromCity?.id?.code).isEqualTo(SHEFFIELD)
-        assertThat(fromAddress?.addressId).isEqualTo(offenderAddress.addressId)
-        assertThat(tapScheduleIn).isNull()
-        assertThat(tapScheduleOut?.eventId).isNull()
+        Assertions.assertThat(movementDate).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(movementTime.toLocalDate()).isEqualTo(LocalDate.now().plusDays(1))
+        Assertions.assertThat(movementType?.code).isEqualTo("TAP")
+        Assertions.assertThat(movementReason.code).isEqualTo("C5")
+        Assertions.assertThat(movementDirection).isEqualTo(MovementDirection.IN)
+        Assertions.assertThat(escort?.code).isEqualTo("U")
+        Assertions.assertThat(escortText).isEqualTo("SE")
+        Assertions.assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+        Assertions.assertThat(toAgency?.id).isEqualTo("BXI")
+        Assertions.assertThat(commentText).isEqualTo("TAP IN comment")
+        Assertions.assertThat(fromCity?.id?.code).isEqualTo(SHEFFIELD)
+        Assertions.assertThat(fromAddress?.addressId).isEqualTo(offenderAddress.addressId)
+        Assertions.assertThat(tapScheduleIn).isNull()
+        Assertions.assertThat(tapScheduleOut?.eventId).isNull()
       }
     }
 
@@ -513,11 +512,15 @@ class TapRepositoryIntTest(
 
       repository.runInTransaction {
         with(offenderBookingRepository.findByIdOrNull(booking.bookingId)!!) {
-          assertThat(externalMovements.find { it.id.sequence == 2 }).isExactlyInstanceOf(OffenderTapMovementOut::class.java)
-          assertThat(externalMovements.find { it.id.sequence == 3 }).isExactlyInstanceOf(OffenderTapMovementIn::class.java)
+          Assertions.assertThat(externalMovements.find { it.id.sequence == 2 })
+            .isExactlyInstanceOf(OffenderTapMovementOut::class.java)
+          Assertions.assertThat(externalMovements.find { it.id.sequence == 3 })
+            .isExactlyInstanceOf(OffenderTapMovementIn::class.java)
           // The TAP missing a direction still comes out as an external movement
-          assertThat(externalMovements.find { it.id.sequence == 4 }).isExactlyInstanceOf(OffenderExternalMovement::class.java)
-          assertThat(externalMovements.find { it.id.sequence == 5 }).isExactlyInstanceOf(OffenderExternalMovement::class.java)
+          Assertions.assertThat(externalMovements.find { it.id.sequence == 4 })
+            .isExactlyInstanceOf(OffenderExternalMovement::class.java)
+          Assertions.assertThat(externalMovements.find { it.id.sequence == 5 })
+            .isExactlyInstanceOf(OffenderExternalMovement::class.java)
         }
       }
     }
@@ -547,7 +550,7 @@ class TapRepositoryIntTest(
 
       repository.runInTransaction {
         with(tapMovementInRepository.findAllByOffenderBooking_Offender_NomsIdAndTapScheduleInIsNull(offender.nomsId)) {
-          assertThat(this).isEmpty()
+          Assertions.assertThat(this).isEmpty()
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapScheduleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapScheduleResourceIntTest.kt
@@ -1,0 +1,1719 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.CorporateAddressDsl.Companion.SHEFFIELD
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderAddress
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CorporateRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderAddressRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapHelpers.Companion.MAX_TAP_COMMENT_LENGTH
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application.UpsertTapApplication
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.application.UpsertTapApplicationResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.TapScheduleIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.TapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.UpsertTapScheduleOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.schedule.UpsertTapScheduleOutResponse
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class TapScheduleResourceIntTest(
+  @Autowired val applicationRepository: OffenderTapApplicationRepository,
+  @Autowired val scheduleOutRepository: OffenderTapScheduleOutRepository,
+  @Autowired val corporateRepository: CorporateRepository,
+  @Autowired val offenderAddressRepository: OffenderAddressRepository,
+  @Autowired val agencyLocationRepository: AgencyLocationRepository,
+  @Autowired val offenderRepository: OffenderRepository,
+) : IntegrationTestBase() {
+  private lateinit var offender: Offender
+  private lateinit var offenderAddress: OffenderAddress
+  private lateinit var corporateAddress: CorporateAddress
+  private lateinit var booking: OffenderBooking
+  private lateinit var application: OffenderTapApplication
+  private lateinit var scheduleOut: OffenderTapScheduleOut
+  private lateinit var scheduleIn: OffenderTapScheduleIn
+  private lateinit var movementOut: OffenderTapMovementOut
+  private lateinit var movementIn: OffenderTapMovementIn
+  private lateinit var agencyLocation: AgencyLocation
+
+  private val offenderNo = "D6347ED"
+  private val today: LocalDateTime = LocalDateTime.now().roundToNearestSecond()
+  private val yesterday: LocalDateTime = today.minusDays(1)
+  private val twoDaysAgo: LocalDateTime = today.minusDays(2)
+
+  @AfterEach
+  fun `tear down`() {
+    offenderRepository.deleteAll()
+    if (this::agencyLocation.isInitialized) {
+      agencyLocationRepository.delete(agencyLocation)
+    }
+    corporateRepository.deleteAll()
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/schedule/out/{eventId}")
+  inner class GetTapScheduleOut {
+
+    @Nested
+    @DisplayName("With offender address")
+    inner class WithOffenderAddress {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(
+                tapType = "RR",
+                tapSubType = "RDR",
+              ) {
+                scheduleOut = tapScheduleOut(
+                  eventDate = twoDaysAgo.toLocalDate(),
+                  startTime = twoDaysAgo,
+                  eventSubType = "C5",
+                  eventStatus = "COMP",
+                  comment = "tap schedule out",
+                  escort = "L",
+                  fromPrison = "LEI",
+                  toAgency = "HAZLWD",
+                  transportType = "VAN",
+                  returnDate = yesterday.toLocalDate(),
+                  returnTime = yesterday,
+                  toAddress = offenderAddress,
+                  contactPersonName = "Jeff",
+                ) {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn(
+                    eventStatus = "SCH",
+                  ) {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should retrieve tap schedule out`() {
+        webTestClient.getTapScheduleOut()
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+            assertThat(eventId).isEqualTo(scheduleOut.eventId)
+            assertThat(eventDate).isEqualTo(twoDaysAgo.toLocalDate())
+            assertThat(startTime).isCloseTo(twoDaysAgo, within(1, ChronoUnit.MINUTES))
+            assertThat(eventSubType).isEqualTo("C5")
+            assertThat(eventStatus).isEqualTo("COMP")
+            assertThat(inboundEventStatus).isEqualTo("SCH")
+            assertThat(comment).isEqualTo("tap schedule out")
+            assertThat(escort).isEqualTo("L")
+            assertThat(fromPrison).isEqualTo("LEI")
+            assertThat(toAgency).isEqualTo("HAZLWD")
+            assertThat(transportType).isEqualTo("VAN")
+            assertThat(returnDate).isEqualTo(yesterday.toLocalDate())
+            assertThat(returnTime).isCloseTo(yesterday, within(1, ChronoUnit.MINUTES))
+            assertThat(toAddressId).isEqualTo(offenderAddress.addressId)
+            assertThat(toAddressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+            assertThat(contactPersonName).isEqualTo("Jeff")
+            assertThat(tapAbsenceType).isEqualTo("RR")
+            assertThat(tapSubType).isEqualTo("RDR")
+          }
+      }
+    }
+
+    @Nested
+    @DisplayName("With corporate address")
+    inner class WithCorporateAddress {
+      private lateinit var corporateAddress: CorporateAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(
+            corporateName = "Boots",
+          ) {
+            corporateAddress = address(
+              type = "BUS",
+              flat = null,
+              premise = "Boots",
+              street = "Scotland Street",
+              locality = "Hunters Bar",
+              postcode = "S1 3GG",
+              city = SHEFFIELD,
+              county = "S.YORKSHIRE",
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  toAddress = corporateAddress,
+                ) {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should retrieve corporate address`() {
+        webTestClient.getTapScheduleOut()
+          .apply {
+            assertThat(toAddressId).isEqualTo(corporateAddress.addressId)
+            assertThat(toAddressOwnerClass).isEqualTo("CORP")
+            assertThat(toAddressDescription).isEqualTo("Boots")
+            assertThat(toFullAddress).isEqualTo("Scotland Street, Hunters Bar, Sheffield, South Yorkshire, England")
+            assertThat(toAddressPostcode).isEqualTo("S1 3GG")
+          }
+      }
+    }
+
+    @Nested
+    @DisplayName("With agency address")
+    inner class WithAgencyAddress {
+      private lateinit var agencyAddress: AgencyLocationAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          agencyLocation = agencyLocation(
+            agencyLocationId = "NGENHO",
+            description = "Northern General Hospital",
+            type = "HOSPITAL",
+          ) {
+            agencyAddress = address(
+              type = "BUS",
+              street = "Herries Road",
+              postcode = "S5 7AU",
+              city = SHEFFIELD,
+              county = "S.YORKSHIRE",
+              country = "ENG",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  toAddress = agencyAddress,
+                ) {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should retrieve agency address`() {
+        webTestClient.getTapScheduleOut()
+          .apply {
+            assertThat(toAddressId).isEqualTo(agencyAddress.addressId)
+            assertThat(toAddressOwnerClass).isEqualTo("AGY")
+            assertThat(toAddressDescription).isEqualTo("Northern General Hospital")
+            assertThat(toFullAddress).isEqualTo("2 Herries Road, Stanningley Road, Sheffield, South Yorkshire, England")
+            assertThat(toAddressPostcode).isEqualTo("S5 7AU")
+          }
+      }
+    }
+
+    @Nested
+    @DisplayName("With updated address")
+    inner class WithUpdatedAddress {
+      private val addressModifyDateTime = LocalDateTime.now().plusHours(1)
+      private val addressModifyUser = "ADDRESS_MODIFY_USER"
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              whenModified = addressModifyDateTime,
+              whoModified = addressModifyUser,
+            )
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  toAddress = offenderAddress,
+                ) {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should retrieve audit details from updated address`() {
+        webTestClient.getTapScheduleOut()
+          .apply {
+            assertThat(audit.modifyDatetime).isEqualTo(addressModifyDateTime)
+            assertThat(audit.modifyUserId).isEqualTo(addressModifyUser)
+          }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut {
+                  movementOut = tapMovementOut()
+                  scheduleIn = tapScheduleIn {
+                    movementIn = tapMovementIn()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should return unauthorised for missing token`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/schedule/out/1")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/schedule/out/1")
+          .headers(setAuthorisation())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/schedule/out/1")
+          .headers(setAuthorisation("ROLE_INVALID"))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return not found if offender not found`() {
+        webTestClient.get()
+          .uri("/movements/UNKNOWN/taps/schedule/out/1")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if tap schedule out not found`() {
+        webTestClient.get()
+          .uri("/movements/$offenderNo/taps/schedule/out/9999")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectStatus().isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("not found")
+          }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps/schedule/in/{eventId}")
+  inner class GetTapScheduleIn {
+
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut {
+                movementOut = tapMovementOut()
+                scheduleIn = tapScheduleIn(
+                  eventDate = yesterday.toLocalDate(),
+                  startTime = yesterday,
+                  eventSubType = "C5",
+                  eventStatus = "SCH",
+                  comment = "tap schedule in",
+                  escort = "L",
+                  fromAgency = "HAZLWD",
+                  toPrison = "LEI",
+                ) {
+                  movementIn = tapMovementIn()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `should return unauthorised for missing token`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/schedule/in/1")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden for missing role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/schedule/in/1")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return forbidden for wrong role`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/schedule/in/1")
+        .headers(setAuthorisation("ROLE_INVALID"))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should return not found if offender not found`() {
+      webTestClient.get()
+        .uri("/movements/UNKNOWN/taps/schedule/in/1")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("UNKNOWN").contains("not found")
+        }
+    }
+
+    @Test
+    fun `should return not found if tap schedule in not found`() {
+      webTestClient.get()
+        .uri("/movements/$offenderNo/taps/schedule/in/9999")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody().jsonPath("userMessage").value<String> {
+          assertThat(it).contains("9999").contains("not found")
+        }
+    }
+
+    @Test
+    fun `should retrieve tap schedule in`() {
+      webTestClient.getTapScheduleIn()
+        .apply {
+          assertThat(bookingId).isEqualTo(booking.bookingId)
+          assertThat(tapApplicationId).isEqualTo(application.tapApplicationId)
+          assertThat(eventId).isEqualTo(scheduleIn.eventId)
+          assertThat(parentEventId).isEqualTo(scheduleOut.eventId)
+          assertThat(eventDate).isEqualTo(yesterday.toLocalDate())
+          assertThat(startTime).isCloseTo(yesterday, within(1, ChronoUnit.MINUTES))
+          assertThat(eventSubType).isEqualTo("C5")
+          assertThat(eventStatus).isEqualTo("SCH")
+          assertThat(comment).isEqualTo("tap schedule in")
+          assertThat(escort).isEqualTo("L")
+          assertThat(fromAgency).isEqualTo("HAZLWD")
+          assertThat(toPrison).isEqualTo("LEI")
+        }
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /movements/{offenderNo}/taps/schedule/out")
+  inner class UpsertTapScheduleOutTest {
+
+    @AfterEach
+    fun tearDown() {
+      repository.deleteOffenders()
+    }
+
+    @Nested
+    inner class CreateScheduleWithOffenderAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk()
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(eventSubType.code).isEqualTo("C5")
+                assertThat(eventStatus.code).isEqualTo("SCH")
+                assertThat(eventDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(startTime).isCloseTo(twoDaysAgo, within(5, ChronoUnit.MINUTES))
+                assertThat(returnDate).isEqualTo(yesterday.toLocalDate())
+                assertThat(returnTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                assertThat(comment).isEqualTo("Some comment tap schedule out")
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+                assertThat(toAgency?.id).isEqualTo("HAZLWD")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(fromAgency?.id).isEqualTo("LEI")
+                assertThat(transportType?.code).isEqualTo("VAN")
+                assertThat(applicationDate).isCloseTo(twoDaysAgo, within(5, ChronoUnit.MINUTES))
+                assertThat(applicationTime).isCloseTo(twoDaysAgo, within(5, ChronoUnit.MINUTES))
+                assertThat(tapScheduleIns).isEmpty()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should truncate comments`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "A9999AD") {
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+
+        webTestClient.upsertTapScheduleOutOk(
+          // comment is 300 long
+          anUpsertTapScheduleOut(application.tapApplicationId, comment = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(comment!!.length).isEqualTo(MAX_TAP_COMMENT_LENGTH)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithOffenderAddressCreatedInNomis {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              premise = "Permanent",
+              street = "16 Main Road",
+              locality = null,
+              city = "28710",
+              postcode = "BD10 9TT",
+              county = null,
+              country = "ENG",
+            )
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with existing address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            toAddress = UpsertTapAddress(
+              name = null,
+              addressText = "Permanent, 16 Main Road, Bradford, England",
+              postalCode = "BD10 9TT",
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithOffenderAddressFromDpsWithTrailingBlanks {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              premise = "RDR, Preston Town Centre , Lancashire",
+              street = null,
+              locality = null,
+              city = null,
+              postcode = null,
+              county = null,
+              country = null,
+            )
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with existing address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            toAddress = UpsertTapAddress(
+              name = null,
+              addressText = "RDR, Preston Town Centre , Lancashire ",
+              postalCode = null,
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithOffenderAddressThatOverflowIntoStreet {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              // Based on a production bug where last character of premise is a comma
+              premise = "Unit 4, Nantcribbau Barns, Private Street From Junction With A490 By Nantcribba Cottages To B4388 By Dol-Y-Maen, Forden, Welshpool,",
+              street = "Powys",
+              locality = null,
+              city = null,
+              postcode = "SY21 8NW",
+              county = null,
+              country = null,
+            )
+            booking = booking {
+              application = tapApplication(
+                toAddress = offenderAddress,
+              )
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with existing address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            toAddress = UpsertTapAddress(
+              name = null,
+              addressText = "Unit 4, Nantcribbau Barns, Private Street From Junction With A490 By Nantcribba Cottages To B4388 By Dol-Y-Maen, Forden, Welshpool, Powys",
+              postalCode = "SY21 8NW",
+            ),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithDuplicateOffenderAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            address(premise = "1 Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+            address(premise = "1 Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = null, addressText = "1 Scotland Street, Sheffield", postalCode = "S1 3GG")),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.premise).isEqualTo("1 Scotland Street, Sheffield")
+                assertThat(toAddress?.postalCode).isEqualTo("S1 3GG")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("OFF")
+              }
+              // Should not create another address
+              with(offenderAddressRepository.findByOffender_RootOffenderId(offender.rootOffenderId!!)) {
+                assertThat(filter { it.premise == "1 Scotland Street, Sheffield" }.size).isEqualTo(2)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWhereOffenderHasEmptyAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            // The existence of this address should not prevent the schedule being created
+            address(
+              flat = null,
+              premise = null,
+              street = null,
+              locality = null,
+              city = null,
+              county = null,
+              country = null,
+              postcode = null,
+            )
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(toAddress = offenderAddress)
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out despite existing empty address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            tapApplicationId = application.tapApplicationId,
+            toAddress = UpsertTapAddress(addressText = "41 High Street, Sheffield"),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithCorporateAddress {
+      private lateinit var corporateAddress: CorporateAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            corporateAddress = address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "Boots", addressText = "Scotland Street, Sheffield", postalCode = "S1 3GG")),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class ShouldFindOffenderAddressWhereCorporateNameSameAsAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address(
+              premise = "Boston",
+              street = null,
+              locality = null,
+            )
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with offender address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "Boston", addressText = "Boston", postalCode = null)),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.premise).isEqualTo("Boston")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("OFF")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class ShouldFindCorporateAddressWhereCorporateNameInAddress {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking()
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with corporate address`() {
+        webTestClient.upsertApplicationOk(
+          request = anUpsertApplicationRequest().copy(
+            toAddresses = listOf(UpsertTapAddress(name = "HSL", addressText = "HSL, Bowness, Cumbria", postalCode = "LA23 3AS")),
+          ),
+        ).also {
+          repository.runInTransaction {
+            application = applicationRepository.findByIdOrNull(it.tapApplicationId)!!
+            corporateAddress = corporateRepository.findAllByCorporateName("HSL").first().addresses.first()
+          }
+        }
+
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "HSL", addressText = "HSL, Bowness, Cumbria", postalCode = "LA23 3AS")),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.premise).isEqualTo("HSL, Bowness, Cumbria")
+                assertThat(toAddress?.postalCode).isEqualTo("LA23 3AS")
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithCorporateAddressCreatedInNomis {
+      private lateinit var corporateAddress: CorporateAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Serving Thyme, HMP Ford") {
+            corporateAddress = address(
+              premise = "Serving Thyme, HMP Ford",
+              street = "Ford Road",
+              locality = null,
+              city = "28389",
+              county = "W.SUSSEX",
+              country = "ENG",
+              postcode = "BN18 0BX",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out with existing address`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "Serving Thyme, HMP Ford", addressText = "Ford Road, Arundel, West Sussex, England", postalCode = "BN18 0BX")),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithCorporateAddressTrailingBlanks {
+      private lateinit var corporateAddress: CorporateAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "HSL") {
+            corporateAddress = address(
+              premise = "Bowness , Cumbria",
+              street = null,
+              locality = null,
+              postcode = "LA23 3AS",
+            )
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should find address despite trailing blanks`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(
+            toAddress = UpsertTapAddress(name = "HSL ", addressText = "Bowness , Cumbria ", postalCode = "LA23 3AS "),
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutWithDuplicatedCorporateAddress {
+      private lateinit var corporateAddress: CorporateAddress
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            corporateAddress = address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+          corporate(corporateName = "Boots") {
+            address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(
+          request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "Boots", addressText = "Scotland Street, Sheffield", postalCode = "S1 3GG")),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(toAddress?.addressId).isEqualTo(corporateAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo("CORP")
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleOutAndIn {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should create tap schedule and its tap schedule in`() {
+        val request = anUpsertTapScheduleOut().copy(
+          eventStatus = "COMP",
+          returnEventStatus = "SCH",
+        )
+
+        webTestClient.upsertTapScheduleOutOk(request)
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(eventStatus.code).isEqualTo("COMP")
+                with(tapScheduleIns.first()) {
+                  assertThat(eventStatus.code).isEqualTo("SCH")
+                  assertThat(eventDate).isEqualTo(yesterday.toLocalDate())
+                  assertThat(startTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                  assertThat(eventSubType.code).isEqualTo("C5")
+                  assertThat(escort?.code).isEqualTo("L")
+                  assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+                  assertThat(toAgency?.id).isEqualTo("LEI")
+                }
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class CreateTapScheduleValidation {
+      @Test
+      fun `should return conflict if adding a schedule to an unapproved application`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(applicationStatus = "PEN")
+            }
+          }
+        }
+
+        webTestClient.upsertTapScheduleOut()
+          .isEqualTo(409)
+      }
+
+      @Test
+      fun `should return conflict if adding a schedule to a single application that already has a schedule`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(applicationType = "SINGLE") {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertTapScheduleOut()
+          .isEqualTo(409)
+      }
+
+      @Test
+      fun `should allow adding a schedule to a repeating application`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication(applicationType = "REPEATING") {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertTapScheduleOutOk()
+          .apply {
+            repository.runInTransaction {
+              with(applicationRepository.findByIdOrNull(application.tapApplicationId)!!) {
+                assertThat(tapScheduleOuts.size).isEqualTo(2)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class UpdateSchedule {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should update tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(anUpsertTapScheduleOut(eventId = scheduleOut.eventId))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(eventSubType.code).isEqualTo("C5")
+                assertThat(eventStatus.code).isEqualTo("SCH")
+                assertThat(eventDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(startTime).isCloseTo(twoDaysAgo, within(5, ChronoUnit.MINUTES))
+                assertThat(returnDate).isEqualTo(yesterday.toLocalDate())
+                assertThat(returnTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                assertThat(comment).isEqualTo("Some comment tap schedule out")
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+                assertThat(toAgency?.id).isEqualTo("HAZLWD")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(fromAgency?.id).isEqualTo("LEI")
+                assertThat(transportType?.code).isEqualTo("VAN")
+                assertThat(applicationDate).isCloseTo(today, within(5, ChronoUnit.MINUTES))
+                assertThat(applicationTime).isCloseTo(today, within(5, ChronoUnit.MINUTES))
+                assertThat(tapScheduleIns).isEmpty()
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should truncate comments`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "A9999AD") {
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.upsertTapScheduleOutOk(
+          // comment is 300 long
+          anUpsertTapScheduleOut(
+            tapApplicationId = application.tapApplicationId,
+            eventId = scheduleOut.eventId,
+            comment = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+          ),
+        )
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(comment!!.length).isEqualTo(MAX_TAP_COMMENT_LENGTH)
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class UpdateTapScheduleOutAndCreateTapScheduleIn {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut()
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should update tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(anUpsertTapScheduleOut(eventId = scheduleOut.eventId, eventStatus = "COMP"))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(eventStatus.code).isEqualTo("COMP")
+                with(tapScheduleIns.first()) {
+                  assertThat(eventStatus.code).isEqualTo("SCH")
+                  assertThat(eventDate).isEqualTo(yesterday.toLocalDate())
+                  assertThat(startTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                  assertThat(eventSubType.code).isEqualTo("C5")
+                  assertThat(escort?.code).isEqualTo("L")
+                  assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+                  assertThat(toAgency?.id).isEqualTo("LEI")
+                }
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class UpdateTapScheduleOutAndIn {
+
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut {
+                  scheduleIn = tapScheduleIn()
+                }
+              }
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should update tap schedule out`() {
+        webTestClient.upsertTapScheduleOutOk(anUpsertTapScheduleOut(eventId = scheduleOut.eventId))
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            repository.runInTransaction {
+              with(scheduleOutRepository.findByEventIdAndOffenderBooking_Offender_NomsId(eventId, offender.nomsId)!!) {
+                assertThat(tapApplication.tapApplicationId).isEqualTo(application.tapApplicationId)
+                assertThat(eventSubType.code).isEqualTo("C5")
+                assertThat(eventStatus.code).isEqualTo("SCH")
+                assertThat(eventDate).isEqualTo(twoDaysAgo.toLocalDate())
+                assertThat(startTime).isCloseTo(twoDaysAgo, within(5, ChronoUnit.MINUTES))
+                assertThat(returnDate).isEqualTo(yesterday.toLocalDate())
+                assertThat(returnTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                assertThat(comment).isEqualTo("Some comment tap schedule out")
+                assertThat(toAddress?.addressId).isEqualTo(offenderAddress.addressId)
+                assertThat(toAddress?.addressOwnerClass).isEqualTo(offenderAddress.addressOwnerClass)
+                assertThat(toAgency?.id).isEqualTo("HAZLWD")
+                assertThat(escort?.code).isEqualTo("L")
+                assertThat(fromAgency?.id).isEqualTo("LEI")
+                assertThat(transportType?.code).isEqualTo("VAN")
+                assertThat(applicationDate).isCloseTo(today, within(5, ChronoUnit.MINUTES))
+                assertThat(applicationTime).isCloseTo(today, within(5, ChronoUnit.MINUTES))
+                with(tapScheduleIns.first()) {
+                  assertThat(eventStatus.code).isEqualTo("SCH")
+                  assertThat(eventDate).isEqualTo(yesterday.toLocalDate())
+                  assertThat(startTime).isCloseTo(yesterday, within(5, ChronoUnit.MINUTES))
+                  assertThat(eventSubType.code).isEqualTo("C5")
+                  assertThat(escort?.code).isEqualTo("L")
+                  assertThat(fromAgency?.id).isEqualTo("HAZLWD")
+                  assertThat(toAgency?.id).isEqualTo("LEI")
+                }
+              }
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should return not found if offender unknown`() {
+        webTestClient.upsertTapScheduleOut(offenderNo = "UNKNOWN")
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("UNKNOWN").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return not found if offender has no bookings`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+          }
+        }
+
+        webTestClient.upsertTapScheduleOut()
+          .isNotFound
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("C1234DE").contains("not found")
+          }
+      }
+
+      @Test
+      fun `should return bad request if tap application does not exist`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = "C1234DE") {
+            offenderAddress = address()
+            booking = booking()
+          }
+        }
+
+        webTestClient.upsertTapScheduleOut(request = anUpsertTapScheduleOut(tapApplicationId = 9999))
+          .isBadRequest
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("does not exist")
+          }
+      }
+
+      @Test
+      fun `should return bad request for invalid event sub type`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(eventSubType = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid event status`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(eventStatus = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid escort`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(escort = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid from prison`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(fromPrison = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to agency`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(toAgency = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid transport type`() {
+        webTestClient.upsertTapScheduleOutBadRequestUnknown(anUpsertTapScheduleOut().copy(transportType = "UNKNOWN"))
+      }
+
+      @Test
+      fun `should return bad request for invalid to address id`() {
+        val invalidAddress = UpsertTapAddress(id = 9999)
+        webTestClient.upsertTapScheduleOutBadRequest(anUpsertTapScheduleOut().copy(toAddress = invalidAddress))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("9999").contains("invalid")
+          }
+      }
+
+      @Test
+      fun `should fail if offender address does not exist`() {
+        webTestClient.upsertTapScheduleOutBadRequest(request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(addressText = "unknown")))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("Address not found")
+          }
+      }
+
+      @Test
+      fun `should fail if corporate entity does not exist`() {
+        webTestClient.upsertTapScheduleOutBadRequest(request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "unknown", addressText = "unknown")))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("Address not found")
+          }
+      }
+
+      @Test
+      fun `should fail if corporate address does not exist`() {
+        nomisDataBuilder.build {
+          corporate(corporateName = "Boots") {
+            address(premise = "Scotland Street, Sheffield", street = null, locality = null, postcode = "S1 3GG")
+          }
+        }
+
+        webTestClient.upsertTapScheduleOutBadRequest(request = anUpsertTapScheduleOut(toAddress = UpsertTapAddress(name = "Boots", addressText = "unknown")))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).contains("Address not found")
+          }
+      }
+
+      @Test
+      fun `should return bad request if address text not passed`() {
+        val invalidAddress = UpsertTapAddress(addressText = null, name = "Business")
+        webTestClient.upsertTapScheduleOutBadRequest(anUpsertTapScheduleOut().copy(toAddress = invalidAddress))
+          .expectBody().jsonPath("userMessage").value<String> {
+            assertThat(it).containsIgnoringCase("address text")
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication()
+            }
+          }
+        }
+      }
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.put()
+          .uri("/movements/$offenderNo/taps/schedule/out")
+          .bodyValue(anUpsertTapScheduleOut(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.put()
+          .uri("/movements/$offenderNo/taps/schedule/out")
+          .headers(setAuthorisation(roles = listOf()))
+          .bodyValue(anUpsertTapScheduleOut(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.put()
+          .uri("/movements/$offenderNo/taps/schedule/out")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .bodyValue(anUpsertTapScheduleOut(application.tapApplicationId))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /movements/{offenderNo}/taps/schedule/out/{eventId}")
+  inner class DeleteTapScheduleOut {
+    @BeforeEach
+    fun setUp() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          offenderAddress = address()
+          booking = booking {
+            application = tapApplication {
+              scheduleOut = tapScheduleOut(
+                eventStatus = "SCH",
+              )
+            }
+          }
+        }
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `should delete schedule`() {
+        webTestClient.deleteTapScheduleOut()
+          .expectStatus().isNoContent
+
+        repository.runInTransaction {
+          assertThat(scheduleOutRepository.findByIdOrNull(scheduleOut.eventId)).isNull()
+        }
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return 204 if unknown application id sent`() {
+        webTestClient.deleteTapScheduleOut(eventId = 9999)
+          .expectStatus().isNoContent
+      }
+
+      @Test
+      fun `should return conflict for unknown offender`() {
+        webTestClient.deleteTapScheduleOut(offenderNo = "UNKNOWN")
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 for wrong offender`() {
+        nomisDataBuilder.build {
+          offender(nomsId = "A7897WW")
+        }
+
+        webTestClient.deleteTapScheduleOut(offenderNo = "A7897WW")
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 if scheduled has a movement`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  eventStatus = "SCH",
+                ) {
+                  tapMovementOut()
+                }
+              }
+            }
+          }
+        }
+
+        webTestClient.deleteTapScheduleOut()
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 if status is completed`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  eventStatus = "COMP",
+                )
+              }
+            }
+          }
+        }
+
+        webTestClient.deleteTapScheduleOut()
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should return 409 if there is an inbound schedule`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            offenderAddress = address()
+            booking = booking {
+              application = tapApplication {
+                scheduleOut = tapScheduleOut(
+                  eventStatus = "SCH",
+                ) {
+                  tapScheduleIn()
+                }
+              }
+            }
+          }
+        }
+
+        webTestClient.deleteTapScheduleOut()
+          .expectStatus().isEqualTo(409)
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorized for missing token`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/schedule/out/${scheduleOut.eventId}")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/schedule/out/${scheduleOut.eventId}")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.delete()
+          .uri("/movements/$offenderNo/taps/schedule/out/${scheduleOut.eventId}")
+          .headers(setAuthorisation(roles = listOf("ROLE_INVALID")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+  }
+
+  private fun WebTestClient.getTapScheduleIn() = get()
+    .uri("/movements/${offender.nomsId}/taps/schedule/in/${scheduleIn.eventId}")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapScheduleIn>()
+
+  private fun WebTestClient.getTapScheduleOut() = get()
+    .uri("/movements/${offender.nomsId}/taps/schedule/out/${scheduleOut.eventId}")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+    .expectStatus().isOk
+    .expectBodyResponse<TapScheduleOut>()
+
+  private fun WebTestClient.deleteTapScheduleOut(offenderNo: String = offender.nomsId, eventId: Long = scheduleOut.eventId): WebTestClient.ResponseSpec = delete()
+    .uri("/movements/$offenderNo/taps/schedule/out/$eventId")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.upsertTapScheduleOutOk(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+  ) = upsertTapScheduleOut(request)
+    .isOk
+    .expectBodyResponse<UpsertTapScheduleOutResponse>()
+
+  private fun WebTestClient.upsertTapScheduleOutBadRequest(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+  ) = upsertTapScheduleOut(request)
+    .isBadRequest
+
+  private fun WebTestClient.upsertTapScheduleOutBadRequestUnknown(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+  ) = upsertTapScheduleOutBadRequest(request)
+    .expectBody().jsonPath("userMessage").value<String> {
+      assertThat(it).contains("UNKNOWN").contains("invalid")
+    }
+
+  private fun WebTestClient.upsertApplicationOk(request: UpsertTapApplication = anUpsertApplicationRequest()) = upsertApplication(request)
+    .isOk
+    .expectBodyResponse<UpsertTapApplicationResponse>()
+
+  private fun WebTestClient.upsertApplication(
+    request: UpsertTapApplication = anUpsertApplicationRequest(),
+    offenderNo: String = offender.nomsId,
+  ) = put()
+    .uri("/movements/$offenderNo/taps/application")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun WebTestClient.upsertTapScheduleOut(
+    request: UpsertTapScheduleOut = anUpsertTapScheduleOut(application.tapApplicationId),
+    offenderNo: String = offender.nomsId,
+  ) = put()
+    .uri("/movements/$offenderNo/taps/schedule/out")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .bodyValue(request)
+    .exchange()
+    .expectStatus()
+
+  private fun anUpsertTapScheduleOut(
+    tapApplicationId: Long? = null,
+    eventId: Long? = null,
+    returnEventStatus: String? = null,
+    eventStatus: String = "SCH",
+    toAddress: UpsertTapAddress = UpsertTapAddress(id = offenderAddress.addressId),
+    comment: String = "Some comment tap schedule out",
+  ) = UpsertTapScheduleOut(
+    eventId = eventId,
+    tapApplicationId = tapApplicationId ?: application.tapApplicationId,
+    eventDate = twoDaysAgo.toLocalDate(),
+    startTime = twoDaysAgo,
+    eventSubType = "C5",
+    eventStatus = eventStatus,
+    comment = comment,
+    escort = "L",
+    fromPrison = "LEI",
+    toAgency = "HAZLWD",
+    transportType = "VAN",
+    returnDate = yesterday.toLocalDate(),
+    returnTime = yesterday,
+    toAddress = toAddress,
+    applicationDate = twoDaysAgo,
+    applicationTime = twoDaysAgo,
+    returnEventStatus = returnEventStatus,
+  )
+  private fun anUpsertApplicationRequest(
+    id: Long? = null,
+    toAddresses: List<UpsertTapAddress> = listOf(UpsertTapAddress(addressText = "some street")),
+  ) = UpsertTapApplication(
+    tapApplicationId = id,
+    eventSubType = "C5",
+    applicationDate = twoDaysAgo.toLocalDate(),
+    fromDate = twoDaysAgo.toLocalDate(),
+    releaseTime = twoDaysAgo,
+    toDate = yesterday.toLocalDate(),
+    returnTime = yesterday,
+    applicationType = "SINGLE",
+    applicationStatus = "APP-SCH",
+    escortCode = "L",
+    transportType = "VAN",
+    comment = "Some comment application",
+    prisonId = "LEI",
+    contactPersonName = "Derek",
+    tapType = "RR",
+    tapSubType = "RDR",
+    toAddresses = toAddresses,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapTestHelpers.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapTestHelpers.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+internal fun LocalDateTime.roundToNearestSecond(): LocalDateTime {
+  val secondsOnly = this.truncatedTo(ChronoUnit.SECONDS)
+  val nanosOnly = this.nano
+  val nanosRounded = if (nanosOnly >= 500_000_000) 1 else 0
+  return secondsOnly.plusSeconds(nanosRounded.toLong())
+}


### PR DESCRIPTION
Created a new API for TAPs. This is a **copy** of the old API with everything renamed to the new naming convention (URLs, model, class name).

The old API is still there for now. The plan is to switch clients to the new API before removing the old API.