### PR TITLE
SDIT-3676 Fallback to system user for return to custody data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.courtsentencing
 
 import com.microsoft.applicationinsights.TelemetryClient
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -109,6 +110,7 @@ class CourtSentencingService(
   private val sentencingAdjustmentService: SentencingAdjustmentService,
   private val linkCaseTxnRepository: LinkCaseTxnRepository,
   private val auditRepository: AuditRepository,
+  @Value("\${spring.datasource.username}") val datasourceUsername: String,
 ) {
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -1485,7 +1487,7 @@ class CourtSentencingService(
 
   private fun ReturnToCustodyRequest?.createOrUpdateBooking(bookingIds: Set<Long>) {
     if (this != null) {
-      val enteredByStaff = findStaffByUsername(this.enteredByStaffUsername)
+      val enteredByStaff = findStaffByUsername(this.enteredByStaffUsername, fallBackUsername = datasourceUsername.uppercase())
       bookingIds.forEach { bookingId ->
         with(findOffenderBooking(bookingId)) {
           if (fixedTermRecall == null) {
@@ -1630,6 +1632,8 @@ class CourtSentencingService(
 
   private fun findStaffByUsername(username: String): Staff = staffUserAccountRepository.findByUsername(username)?.staff
     ?: throw BadDataException("Username $username not found")
+
+  private fun findStaffByUsername(username: String, fallBackUsername: String): Staff = runCatching { findStaffByUsername(username) }.getOrElse { findStaffByUsername(fallBackUsername) }
 
   fun cloneCourtCasesToLatestBookingFor(offenderNo: String, caseId: Long): BookingCourtCaseCloneResponse {
     val case = courtCaseRepository.findByIdOrNull(caseId) ?: throw NotFoundException("Court case $caseId not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -11192,6 +11192,26 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         }
 
         @Test
+        fun `will update custody data when username is not found`() {
+          assertThat(offenderFixedTermRecallRepository.findByIdOrNull(booking.bookingId)!!.staff.id).isEqualTo(
+            staff.id,
+          )
+
+          webTestClient.put()
+            .uri("/prisoners/${prisoner.nomsId}/sentences/recall/restore-previous")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(request.copy(returnToCustody = request.returnToCustody!!.copy(enteredByStaffUsername = "someclientcredndentials"))))
+            .exchange()
+            .expectStatus().isOk
+
+          // will be system staff ID
+          assertThat(offenderFixedTermRecallRepository.findByIdOrNull(booking.bookingId)!!.staff.id).isEqualTo(
+            -1,
+          )
+        }
+
+        @Test
         fun `will remove breach court appearance data`() {
           assertThat(courtEventRepository.findById(breachCourtEvent.id)).isPresent
           assertThat(courtEventRepository.findById(previousBreachCourtEvent.id)).isPresent


### PR DESCRIPTION
When DPS deletes a recall that reverted to previous recall migrated by NOMIS we have lost the enteredBy username. So fallback to system staff rather than throw exception