### PR TITLE
SDIT-3646 Custom event logs incorrect sequence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -795,7 +795,7 @@ class AdjudicationService(
             "hearing-result-award-created",
             mapOf(
               "adjudicationNumber" to party.adjudicationNumber.toString(),
-              "sanctionSequence" to sanctionSeq.toString(),
+              "sanctionSequence" to it.id.sanctionSequence.toString(),
               "bookingId" to offenderBookId.toString(),
               "resultSequence" to hearingResult.id.resultSequence.toString(),
               "hearingId" to hearingResult.id.oicHearingId.toString(),


### PR DESCRIPTION
For a batch of punishments it incorrectly logged only the first sanction sequence