### PR TITLE
SDIT-3754 Time-slots can differ by end time

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
@@ -26,8 +26,9 @@ interface AgencyVisitTimeRepository : JpaRepository<AgencyVisitTime, AgencyVisit
   )
   fun findByAgencyVisitTimesIdLocationIdNotExpiredIsEffective(locationId: String): List<AgencyVisitTime>
 
-  fun findByStartTimeAndAgencyVisitTimesIdWeekDayAndAgencyVisitTimesIdLocation(
+  fun findByStartTimeAndEndTimeAndExpiryDateIsNotNullAndAgencyVisitTimesIdWeekDayAndAgencyVisitTimesIdLocation(
     startTime: LocalTime,
+    endTime: LocalTime,
     weekDay: WeekDay,
     location: AgencyLocation,
   ): AgencyVisitTime?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitService.kt
@@ -496,8 +496,9 @@ class VisitService(
     endDateTime: LocalDateTime,
   ): AgencyVisitTime {
     val weekDay = getOrCreateVisitDay(startDateTime = startDateTime, location = location)
-    return visitTimeRepository.findByStartTimeAndAgencyVisitTimesIdWeekDayAndAgencyVisitTimesIdLocation(
+    return visitTimeRepository.findByStartTimeAndEndTimeAndExpiryDateIsNotNullAndAgencyVisitTimesIdWeekDayAndAgencyVisitTimesIdLocation(
       startTime = startDateTime.toLocalTime(),
+      endTime = endDateTime.toLocalTime(),
       weekDay = weekDay.agencyVisitDayId.weekDay,
       location = location,
     ) ?: createVisitTime(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitResourceIntTest.kt
@@ -703,7 +703,7 @@ class VisitResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      internal fun `a different end time does not cause a new time of day to be created`() {
+      internal fun `a different end time causes a new time of day to be created`() {
         assertThat(repository.getAllAgencyVisitTimes(PRISON_ID)).isEmpty()
 
         repository.runInTransaction {
@@ -727,8 +727,19 @@ class VisitResourceIntTest : IntegrationTestBase() {
               openClosedStatus = "OPEN",
             ),
           )
-          assertThat(repository.getAllAgencyVisitTimes(PRISON_ID)).hasSize(1)
+          assertThat(repository.getAllAgencyVisitTimes(PRISON_ID)).hasSize(2)
             .anyMatch { it.agencyVisitTimesId == visitThatEndAtDifferentTime.agencyVisitSlot!!.agencyVisitTime.agencyVisitTimesId }
+
+          val visitThatEndAtDifferentTimeButSameDayOfWeek = repository.getVisit(
+            createVisit(
+              startDateTime = "2021-11-11T14:00",
+              endTime = "14:30",
+              room = "Main visit room",
+              openClosedStatus = "OPEN",
+            ),
+          )
+          assertThat(repository.getAllAgencyVisitTimes(PRISON_ID)).hasSize(2)
+            .anyMatch { it.agencyVisitTimesId == visitThatEndAtDifferentTimeButSameDayOfWeek.agencyVisitSlot!!.agencyVisitTime.agencyVisitTimesId }
         }
       }
 


### PR DESCRIPTION
When looking up a time slot use end time as well as start time. Prisons can have multiple slots at the same time but for different lengths.
Also ignore expired slots to avoid clashes. There should only ever be one active time slot for a time range on a particular day in a particular prison