### PR TITLE
SDIT-3755 Hack to all timeslots to be updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTime
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTimeId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.WeekDay
+import java.time.LocalDate
 import java.time.LocalTime
 
 @Repository
@@ -54,6 +56,20 @@ interface AgencyVisitTimeRepository : JpaRepository<AgencyVisitTime, AgencyVisit
   fun findAllIds(
     pageable: Pageable,
   ): Page<VisitTimeSlotIdProjection>
+
+  @Modifying
+  @Query(
+    """
+      update AgencyVisitTime avt
+      set avt.effectiveDate = :effectiveDate, avt.expiryDate = :expiryDate
+      where avt.agencyVisitTimesId = :agencyVisitTimesId
+    """,
+  )
+  fun updateActivationDates(
+    agencyVisitTimesId: AgencyVisitTimeId,
+    effectiveDate: LocalDate,
+    expiryDate: LocalDate?,
+  )
 }
 
 interface VisitTimeSlotIdProjection {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationService.kt
@@ -87,11 +87,19 @@ class VisitsConfigurationService(
   fun updateVisitTimeSlot(prisonId: String, dayOfWeek: WeekDay, timeSlotSequence: Int, request: UpdateVisitTimeSlotRequest) {
     val timeSlot = agencyVisitTimeRepository.findByIdOrNull(AgencyVisitTimeId(lookupAgency(prisonId), dayOfWeek, timeSlotSequence)) ?: throw NotFoundException("Visit time slot $prisonId, $dayOfWeek, $timeSlotSequence does not exist")
 
-    with(timeSlot) {
-      startTime = request.startTime
-      endTime = request.endTime
-      effectiveDate = request.effectiveDate
-      expiryDate = request.expiryDate
+    // if times have not changed then just update the effective and expiry dates
+    // this is a temporary hack to prevent the date element of start and endTime being set to
+    // 1970-01-01 while the NOMIS unique index is investigated
+    if (timeSlot.startTime == request.startTime && timeSlot.endTime == request.endTime) {
+      agencyVisitTimeRepository.updateActivationDates(timeSlot.agencyVisitTimesId, request.effectiveDate, request.expiryDate)
+    } else {
+      with(timeSlot) {
+        startTime = request.startTime
+        endTime = request.endTime
+        effectiveDate = request.effectiveDate
+        expiryDate = request.expiryDate
+        agencyVisitTimeRepository.saveAndFlush(this)
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationIntTest.kt
@@ -605,6 +605,34 @@ class VisitsConfigurationIntTest : IntegrationTestBase() {
         assertThat(visitTimeSlot.expiryDate).isEqualTo(LocalDate.parse("2032-09-01"))
         assertThat(visitTimeSlot.visitSlots).hasSize(1)
       }
+
+      @Test
+      fun `can update just effective and expiry dates slot`() {
+        webTestClient.put().uri("/visits/configuration/time-slots/prison-id/BXI/day-of-week/MON/time-slot-sequence/1")
+          .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .bodyValue(
+            UpdateVisitTimeSlotRequest(
+              startTime = LocalTime.parse("10:00"),
+              endTime = LocalTime.parse("11:00"),
+              effectiveDate = LocalDate.parse("2022-09-01"),
+              expiryDate = LocalDate.parse("2032-09-01"),
+            ),
+          )
+          .exchange()
+          .expectStatus().isNoContent
+
+        val visitTimeSlot: VisitTimeSlotResponse = webTestClient.get().uri("/visits/configuration/time-slots/prison-id/BXI/day-of-week/MON/time-slot-sequence/1")
+          .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(visitTimeSlot.prisonId).isEqualTo("BXI")
+        assertThat(visitTimeSlot.startTime).isEqualTo(LocalTime.parse("10:00"))
+        assertThat(visitTimeSlot.endTime).isEqualTo(LocalTime.parse("11:00"))
+        assertThat(visitTimeSlot.effectiveDate).isEqualTo(LocalDate.parse("2022-09-01"))
+        assertThat(visitTimeSlot.expiryDate).isEqualTo(LocalDate.parse("2032-09-01"))
+        assertThat(visitTimeSlot.visitSlots).hasSize(1)
+      }
     }
   }
 


### PR DESCRIPTION
This hack will only update the activation dates when a time slot is updated when the  start and end times have not changed. This is a hack to get around the NOMIS trigger that hopefully will be removed and catch the common scenario of a prison just end dating a time slot

Else the value in the START_TIME can be set to 1/1/1970 which can then clash with VSIP time slots.

A bigger chnage is required to cover all case - biut this is enough to clear DLQ.