### PR TITLE
SDIT-3755 Hack to allow timeslots to be created and updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyVisitTime.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyVisitTime.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Persistable
 import java.io.Serializable
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Entity
@@ -31,6 +32,13 @@ data class AgencyVisitTime(
 
   @Column(name = "END_TIME", nullable = false)
   var endTime: LocalTime,
+
+  // used to be able to set date element of what is only used by the NOMIS as the time
+  @Column(name = "START_TIME", nullable = false, updatable = false, insertable = false)
+  var startDateTime: LocalDateTime = startTime.atDate(LocalDate.now()),
+
+  @Column(name = "END_TIME", nullable = false, updatable = false, insertable = false)
+  var endDateTime: LocalDateTime = endTime.atDate(LocalDate.now()),
 
   @Column(nullable = false)
   var effectiveDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyVisitTimeRepository.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTime
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTimeId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.WeekDay
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Repository
@@ -61,12 +62,35 @@ interface AgencyVisitTimeRepository : JpaRepository<AgencyVisitTime, AgencyVisit
   @Query(
     """
       update AgencyVisitTime avt
-      set avt.effectiveDate = :effectiveDate, avt.expiryDate = :expiryDate
+      set 
+        avt.effectiveDate = :effectiveDate, 
+        avt.expiryDate = :expiryDate,
+        avt.startDateTime = :startDateTime, 
+        avt.endDateTime = :endDateTime
       where avt.agencyVisitTimesId = :agencyVisitTimesId
     """,
   )
-  fun updateActivationDates(
+  fun updateDates(
     agencyVisitTimesId: AgencyVisitTimeId,
+    startDateTime: LocalDateTime,
+    endDateTime: LocalDateTime,
+    effectiveDate: LocalDate,
+    expiryDate: LocalDate?,
+  )
+
+  @Modifying
+  @Query(
+    """
+      insert into AgencyVisitTime
+            (agencyVisitTimesId, effectiveDate, expiryDate, startDateTime, endDateTime) 
+        values 
+            (:agencyVisitTimesId, :effectiveDate, :expiryDate, :startDateTime, :endDateTime)
+    """,
+  )
+  fun createDates(
+    agencyVisitTimesId: AgencyVisitTimeId,
+    startDateTime: LocalDateTime,
+    endDateTime: LocalDateTime,
     effectiveDate: LocalDate,
     expiryDate: LocalDate?,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocati
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitDayRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitSlotRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitTimeRepository
+import java.time.LocalDate
 
 @Service
 @Transactional
@@ -64,43 +65,37 @@ class VisitsConfigurationService(
   fun createVisitTimeSlot(prisonId: String, dayOfWeek: WeekDay, request: CreateVisitTimeSlotRequest): VisitTimeSlotResponse {
     val location = lookupAgency(prisonId)
     val nextSequence = agencyVisitTimeRepository.getNextTimeSlotSequence(prisonId, dayOfWeek.name)
-
-    return agencyVisitTimeRepository.saveAndFlush(
-      AgencyVisitTime(
-        agencyVisitTimesId = AgencyVisitTimeId(
-          location = location,
-          weekDay = dayOfWeek,
-          timeSlotSequence = nextSequence,
-        ),
-        startTime = request.startTime,
-        endTime = request.endTime,
-        effectiveDate = request.effectiveDate,
-        expiryDate = request.expiryDate,
-      ),
-    ).let {
-      agencyVisitTimeRepository.findByIdOrNull(it.agencyVisitTimesId)
-        ?: throw BadDataException("Visit time slot $prisonId, $dayOfWeek, ${it.agencyVisitTimesId.timeSlotSequence} could not be reloaded")
-    }.toVisitTimeSlotResponse()
+    val agencyVisitTimesId = AgencyVisitTimeId(
+      location = location,
+      weekDay = dayOfWeek,
+      timeSlotSequence = nextSequence,
+    )
+    // To prevent clashes with deactivated start and end times - use today as date portion
+    // rather than default of 1/1/1970 while the NOMIS constraint exists
+    agencyVisitTimeRepository.createDates(
+      agencyVisitTimesId = agencyVisitTimesId,
+      startDateTime = request.startTime.atDate(LocalDate.now()),
+      endDateTime = request.endTime.atDate(LocalDate.now()),
+      effectiveDate = request.effectiveDate,
+      expiryDate = request.expiryDate,
+    )
+    return agencyVisitTimeRepository.findByIdOrNull(agencyVisitTimesId)?.toVisitTimeSlotResponse()
+      ?: throw BadDataException("Visit time slot $prisonId, $dayOfWeek, ${agencyVisitTimesId.timeSlotSequence} could not be reloaded")
   }
 
   @Audit(auditModule = "DPS_SYNCHRONISATION_OFFICIAL_VISITS")
   fun updateVisitTimeSlot(prisonId: String, dayOfWeek: WeekDay, timeSlotSequence: Int, request: UpdateVisitTimeSlotRequest) {
     val timeSlot = agencyVisitTimeRepository.findByIdOrNull(AgencyVisitTimeId(lookupAgency(prisonId), dayOfWeek, timeSlotSequence)) ?: throw NotFoundException("Visit time slot $prisonId, $dayOfWeek, $timeSlotSequence does not exist")
 
-    // if times have not changed then just update the effective and expiry dates
-    // this is a temporary hack to prevent the date element of start and endTime being set to
-    // 1970-01-01 while the NOMIS unique index is investigated
-    if (timeSlot.startTime == request.startTime && timeSlot.endTime == request.endTime) {
-      agencyVisitTimeRepository.updateActivationDates(timeSlot.agencyVisitTimesId, request.effectiveDate, request.expiryDate)
-    } else {
-      with(timeSlot) {
-        startTime = request.startTime
-        endTime = request.endTime
-        effectiveDate = request.effectiveDate
-        expiryDate = request.expiryDate
-        agencyVisitTimeRepository.saveAndFlush(this)
-      }
-    }
+    // To prevent clashes with deactivated start and end times - use the date portion
+    // from original slot details rather than default of 1/1/1970 while the NOMIS constraint exists
+    agencyVisitTimeRepository.updateDates(
+      agencyVisitTimesId = timeSlot.agencyVisitTimesId,
+      startDateTime = request.startTime.atDate(timeSlot.startDateTime.toLocalDate()),
+      endDateTime = request.endTime.atDate(timeSlot.endDateTime.toLocalDate()),
+      effectiveDate = request.effectiveDate,
+      expiryDate = request.expiryDate,
+    )
   }
 
   @Audit(auditModule = "DPS_SYNCHRONISATION_OFFICIAL_VISITS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyVisitDay.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyVisitDay.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.WeekDay
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitDayRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @DslMarker
@@ -21,6 +22,16 @@ interface AgencyVisitDayDsl {
     timeSlotSequence: Int,
     startTime: LocalTime = LocalTime.now(),
     endTime: LocalTime = LocalTime.now().plusHours(1),
+    effectiveDate: LocalDate = LocalDate.now(),
+    expiryDate: LocalDate? = null,
+    dsl: AgencyVisitTimeDsl.() -> Unit = {},
+  ): AgencyVisitTime
+
+  @AgencyVisitTimeDslMarker
+  fun visitTimeSlot(
+    timeSlotSequence: Int,
+    startDateTime: LocalDateTime = LocalDateTime.now(),
+    endDateTime: LocalDateTime = LocalDateTime.now().plusHours(1),
     effectiveDate: LocalDate = LocalDate.now(),
     expiryDate: LocalDate? = null,
     dsl: AgencyVisitTimeDsl.() -> Unit = {},
@@ -40,7 +51,7 @@ class AgencyVisitDayBuilderRepository(
   private val agencyVisitDayRepository: AgencyVisitDayRepository,
   private val agencyLocationRepository: AgencyLocationRepository,
 ) {
-  fun save(agencyVisitDay: AgencyVisitDay): AgencyVisitDay = agencyVisitDayRepository.save(agencyVisitDay)
+  fun save(agencyVisitDay: AgencyVisitDay): AgencyVisitDay = agencyVisitDayRepository.saveAndFlush(agencyVisitDay)
   fun lookupAgency(id: String): AgencyLocation = agencyLocationRepository.findById(id).orElseThrow()
 }
 
@@ -75,6 +86,24 @@ class AgencyVisitDayBuilder(
       timeSlotSequence = timeSlotSequence,
       startTime = startTime,
       endTime = endTime,
+      effectiveDate = effectiveDate,
+      expiryDate = expiryDate,
+    )
+      .also { builder.apply(dsl) }
+  }
+  override fun visitTimeSlot(
+    timeSlotSequence: Int,
+    startDateTime: LocalDateTime,
+    endDateTime: LocalDateTime,
+    effectiveDate: LocalDate,
+    expiryDate: LocalDate?,
+    dsl: AgencyVisitTimeDsl.() -> Unit,
+  ): AgencyVisitTime = agencyVisitTimeBuilderFactory.builder().let { builder ->
+    builder.build(
+      weekDay = agencyVisitDay,
+      timeSlotSequence = timeSlotSequence,
+      startDateTime = startDateTime,
+      endDateTime = endDateTime,
       effectiveDate = effectiveDate,
       expiryDate = expiryDate,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyVisitTime.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyVisitTime.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyInternalLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitDay
@@ -8,6 +9,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTime
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTimeId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitTimeRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @DslMarker
@@ -37,6 +39,19 @@ class AgencyVisitTimeBuilderRepository(
   private val agencyVisitTimeRepository: AgencyVisitTimeRepository,
 ) {
   fun save(agencyVisitTime: AgencyVisitTime): AgencyVisitTime = agencyVisitTimeRepository.save(agencyVisitTime)
+  fun create(
+    agencyVisitTimesId: AgencyVisitTimeId,
+    startDateTime: LocalDateTime,
+    endDateTime: LocalDateTime,
+    effectiveDate: LocalDate,
+    expiryDate: LocalDate?,
+  ): AgencyVisitTime = agencyVisitTimeRepository.createDates(
+    agencyVisitTimesId = agencyVisitTimesId,
+    startDateTime = startDateTime,
+    endDateTime = endDateTime,
+    effectiveDate = effectiveDate,
+    expiryDate = expiryDate,
+  ).let { agencyVisitTimeRepository.findByIdOrNull(id = agencyVisitTimesId)!! }
 }
 
 class AgencyVisitTimeBuilder(
@@ -64,6 +79,26 @@ class AgencyVisitTimeBuilder(
     expiryDate = expiryDate,
   )
     .let { repository.save(it) }
+    .also { agencyVisitTime = it }
+
+  fun build(
+    weekDay: AgencyVisitDay,
+    timeSlotSequence: Int,
+    startDateTime: LocalDateTime,
+    endDateTime: LocalDateTime,
+    effectiveDate: LocalDate,
+    expiryDate: LocalDate?,
+  ): AgencyVisitTime = repository.create(
+    agencyVisitTimesId = AgencyVisitTimeId(
+      location = weekDay.agencyVisitDayId.location,
+      weekDay = weekDay.agencyVisitDayId.weekDay,
+      timeSlotSequence = timeSlotSequence,
+    ),
+    startDateTime = startDateTime,
+    endDateTime = endDateTime,
+    effectiveDate = effectiveDate,
+    expiryDate = expiryDate,
+  )
     .also { agencyVisitTime = it }
 
   override fun visitSlot(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitsConfigurationIntTest.kt
@@ -11,15 +11,21 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyInternalLocation
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyVisitTimeId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.WeekDay
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyInternalLocationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitDayRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitSlotRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyVisitTimeRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class VisitsConfigurationIntTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var agencyLocationRepository: AgencyLocationRepository
+
   @Autowired
   private lateinit var agencyInternalLocationRepository: AgencyInternalLocationRepository
 
@@ -131,6 +137,40 @@ class VisitsConfigurationIntTest : IntegrationTestBase() {
           .expectStatus().isCreated
           .expectBody()
           .jsonPath("$.timeSlotSequence").isEqualTo(2)
+      }
+
+      @Test
+      fun `will create time slot start and end times with date part set to today`() {
+        nomisDataBuilder.build {
+          agencyVisitDay(prisonerId = "BXI", weekDay = WeekDay.MON)
+        }
+        webTestClient.post().uri("/visits/configuration/time-slots/prison-id/BXI/day-of-week/MON")
+          .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .bodyValue(
+            CreateVisitTimeSlotRequest(
+              startTime = LocalTime.parse("10:00"),
+              endTime = LocalTime.parse("11:00"),
+              effectiveDate = LocalDate.parse("2022-09-01"),
+              expiryDate = null,
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated
+
+        with(
+          agencyVisitTimeRepository.findByIdOrNull(
+            AgencyVisitTimeId(
+              location = agencyLocationRepository.findByIdOrNull("BXI")!!,
+              weekDay = WeekDay.MON,
+              timeSlotSequence = 1,
+            ),
+          )!!,
+        ) {
+          assertThat(startTime).isEqualTo(LocalTime.parse("10:00"))
+          assertThat(startDateTime.toLocalDate()).isToday
+          assertThat(endTime).isEqualTo(LocalTime.parse("11:00"))
+          assertThat(endDateTime.toLocalDate()).isToday
+        }
       }
     }
   }
@@ -469,8 +509,8 @@ class VisitsConfigurationIntTest : IntegrationTestBase() {
         agencyVisitDay(prisonerId = "BXI", weekDay = WeekDay.MON) {
           visitTimeSlot(
             timeSlotSequence = 1,
-            startTime = LocalTime.parse("10:00"),
-            endTime = LocalTime.parse("11:00"),
+            startDateTime = LocalDateTime.parse("2020-07-19T10:00"),
+            endDateTime = LocalDateTime.parse("2020-07-19T11:00"),
             effectiveDate = LocalDate.parse("2023-01-01"),
             expiryDate = LocalDate.parse("2033-01-31"),
           ) {
@@ -607,13 +647,26 @@ class VisitsConfigurationIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `can update just effective and expiry dates slot`() {
+      fun `will leave date portion of start and end times alone`() {
+        val id = AgencyVisitTimeId(
+          location = agencyLocationRepository.findByIdOrNull("BXI")!!,
+          weekDay = WeekDay.MON,
+          timeSlotSequence = 1,
+        )
+
+        with(agencyVisitTimeRepository.findByIdOrNull(id)!!) {
+          assertThat(startTime).isEqualTo(LocalTime.parse("10:00"))
+          assertThat(startDateTime.toLocalDate()).isEqualTo(LocalDate.parse("2020-07-19"))
+          assertThat(endTime).isEqualTo(LocalTime.parse("11:00"))
+          assertThat(endDateTime.toLocalDate()).isEqualTo(LocalDate.parse("2020-07-19"))
+        }
+
         webTestClient.put().uri("/visits/configuration/time-slots/prison-id/BXI/day-of-week/MON/time-slot-sequence/1")
           .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
           .bodyValue(
             UpdateVisitTimeSlotRequest(
-              startTime = LocalTime.parse("10:00"),
-              endTime = LocalTime.parse("11:00"),
+              startTime = LocalTime.parse("10:10"),
+              endTime = LocalTime.parse("11:10"),
               effectiveDate = LocalDate.parse("2022-09-01"),
               expiryDate = LocalDate.parse("2032-09-01"),
             ),
@@ -621,14 +674,21 @@ class VisitsConfigurationIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isNoContent
 
+        with(agencyVisitTimeRepository.findByIdOrNull(id)!!) {
+          assertThat(startTime).isEqualTo(LocalTime.parse("10:10"))
+          assertThat(startDateTime.toLocalDate()).isEqualTo(LocalDate.parse("2020-07-19"))
+          assertThat(endTime).isEqualTo(LocalTime.parse("11:10"))
+          assertThat(endDateTime.toLocalDate()).isEqualTo(LocalDate.parse("2020-07-19"))
+        }
+
         val visitTimeSlot: VisitTimeSlotResponse = webTestClient.get().uri("/visits/configuration/time-slots/prison-id/BXI/day-of-week/MON/time-slot-sequence/1")
           .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
           .exchange()
           .expectBodyResponse()
 
         assertThat(visitTimeSlot.prisonId).isEqualTo("BXI")
-        assertThat(visitTimeSlot.startTime).isEqualTo(LocalTime.parse("10:00"))
-        assertThat(visitTimeSlot.endTime).isEqualTo(LocalTime.parse("11:00"))
+        assertThat(visitTimeSlot.startTime).isEqualTo(LocalTime.parse("10:10"))
+        assertThat(visitTimeSlot.endTime).isEqualTo(LocalTime.parse("11:10"))
         assertThat(visitTimeSlot.effectiveDate).isEqualTo(LocalDate.parse("2022-09-01"))
         assertThat(visitTimeSlot.expiryDate).isEqualTo(LocalDate.parse("2032-09-01"))
         assertThat(visitTimeSlot.visitSlots).hasSize(1)


### PR DESCRIPTION
Due to a NOMIS constraint, we have to jump through hoops to try to prevent active and inactive time slots sharing the same start and end time. Though we (and NOMIS) are only interested in the time portion, the DB constraint prevents two or more rows sharing the same DateTime for start and end time for a given day in a prison.

Therefore, new rows created deafult to todays date and any updates retain that original date. This is more consistent to how NOMIS sets the date portion.

NB VSIP (social visits) sync is left unchanged since that sync only sets the time portion with the date portion defaulting to the epoch start date.