### PR TITLE
SDIT-3731 court movements performance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
@@ -10,15 +10,12 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.JoinColumnOrFormula
 import org.hibernate.annotations.JoinColumnsOrFormulas
 import org.hibernate.annotations.JoinFormula
-import org.hibernate.annotations.NotFound
-import org.hibernate.annotations.NotFoundAction
 import org.hibernate.type.YesNoConverter
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.helper.EntityOpen
 import java.time.LocalDate
@@ -128,16 +125,6 @@ class CourtEvent(
   // Only ever 1 order of type "AUTO" for an event
   @OneToMany(mappedBy = "courtEvent", cascade = [CascadeType.ALL], orphanRemoval = true)
   val courtOrders: MutableList<CourtOrder> = mutableListOf(),
-
-  @OneToOne(mappedBy = "courtScheduleOut", cascade = [CascadeType.ALL])
-  @JoinColumn(name = "EVENT_ID")
-  @NotFound(action = NotFoundAction.IGNORE)
-  var courtMovementOut: OffenderCourtMovementOut? = null,
-
-  @OneToOne(mappedBy = "courtScheduleOut", cascade = [CascadeType.ALL])
-  @JoinColumn(name = "EVENT_ID")
-  @NotFound(action = NotFoundAction.IGNORE)
-  var courtMovementIn: OffenderCourtMovementIn? = null,
 
   /* COLUMNS NOT MAPPED
     END_TIME - not used

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
@@ -10,12 +10,15 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.JoinColumnOrFormula
 import org.hibernate.annotations.JoinColumnsOrFormulas
 import org.hibernate.annotations.JoinFormula
+import org.hibernate.annotations.NotFound
+import org.hibernate.annotations.NotFoundAction
 import org.hibernate.type.YesNoConverter
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.helper.EntityOpen
 import java.time.LocalDate
@@ -125,6 +128,16 @@ class CourtEvent(
   // Only ever 1 order of type "AUTO" for an event
   @OneToMany(mappedBy = "courtEvent", cascade = [CascadeType.ALL], orphanRemoval = true)
   val courtOrders: MutableList<CourtOrder> = mutableListOf(),
+
+  @OneToOne(mappedBy = "courtScheduleOut", cascade = [CascadeType.ALL])
+  @JoinColumn(name = "EVENT_ID")
+  @NotFound(action = NotFoundAction.IGNORE)
+  var courtMovementOut: OffenderCourtMovementOut? = null,
+
+  @OneToOne(mappedBy = "courtScheduleOut", cascade = [CascadeType.ALL])
+  @JoinColumn(name = "EVENT_ID")
+  @NotFound(action = NotFoundAction.IGNORE)
+  var courtMovementIn: OffenderCourtMovementIn? = null,
 
   /* COLUMNS NOT MAPPED
     END_TIME - not used

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderBooking.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderBooking.kt
@@ -139,6 +139,9 @@ data class OffenderBooking(
   @OneToMany(mappedBy = "offenderBooking", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
   val courtCases: MutableList<CourtCase> = mutableListOf(),
 
+  @OneToMany(mappedBy = "offenderBooking", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+  val courtEvents: MutableList<CourtEvent> = mutableListOf(),
+
   @OneToMany(mappedBy = "id.offenderBooking", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
   val alerts: MutableList<OffenderAlert> = mutableListOf(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCourtMovementIn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCourtMovementIn.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType.LAZY
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToOne
 import org.hibernate.annotations.NotFound
 import org.hibernate.annotations.NotFoundAction
 import java.time.LocalDate
@@ -21,10 +21,9 @@ class OffenderCourtMovementIn(
   active: Boolean = false,
   commentText: String? = null,
 
-  @OneToOne()
-  @JoinColumn(name = "PARENT_EVENT_ID")
+  @Column(name = "PARENT_EVENT_ID")
   @NotFound(action = NotFoundAction.IGNORE)
-  var courtScheduleOut: CourtEvent? = null,
+  var courtScheduleOutId: Long? = null,
 ) : OffenderExternalMovement(
   id = id,
   movementDate = movementDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCourtMovementOut.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderCourtMovementOut.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa
 
-import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType.LAZY
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToOne
 import org.hibernate.annotations.NotFound
 import org.hibernate.annotations.NotFoundAction
 import java.time.LocalDate
@@ -22,10 +21,9 @@ class OffenderCourtMovementOut(
   active: Boolean = false,
   commentText: String? = null,
 
-  @OneToOne(cascade = [CascadeType.ALL])
-  @JoinColumn(name = "EVENT_ID")
+  @Column(name = "EVENT_ID")
   @NotFound(action = NotFoundAction.IGNORE)
-  var courtScheduleOut: CourtEvent? = null,
+  var courtScheduleOutId: Long? = null,
 ) : OffenderExternalMovement(
   id = id,
   movementDate = movementDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
@@ -8,5 +8,5 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
 
 @Repository
 interface CourtEventRepository : JpaRepository<CourtEvent, Long> {
-  fun findAllByOffenderBooking_BookingId(bookingId: Long): List<CourtEvent>
+  fun findAllByOffenderBooking_Offender_NomsIdAndDirectionCode_CodeIs(offenderNo: String, directionCode: String): List<CourtEvent>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderCourtMovementInRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderCourtMovementInRepository.kt
@@ -9,5 +9,5 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovemen
 
 @Repository
 interface OffenderCourtMovementInRepository : JpaRepository<OffenderCourtMovementIn, OffenderExternalMovementId> {
-  fun findAllByOffenderBooking_BookingId(bookingId: Long): List<OffenderCourtMovementIn>
+  fun findAllByOffenderBooking_Offender_NomsId(offenderNo: String): List<OffenderCourtMovementIn>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderCourtMovementOutRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderCourtMovementOutRepository.kt
@@ -9,5 +9,5 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovemen
 
 @Repository
 interface OffenderCourtMovementOutRepository : JpaRepository<OffenderCourtMovementOut, OffenderExternalMovementId> {
-  fun findAllByOffenderBooking_BookingId(bookingId: Long): List<OffenderCourtMovementOut>
+  fun findAllByOffenderBooking_Offender_NomsId(offenderNo: String): List<OffenderCourtMovementOut>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderExternalMovementRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderExternalMovementRepository.kt
@@ -3,8 +3,10 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovement
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovementId
+import java.time.LocalDateTime
 
 @Repository
 interface OffenderExternalMovementRepository : CrudRepository<OffenderExternalMovement, OffenderExternalMovementId> {
@@ -97,4 +99,12 @@ interface OffenderExternalMovementRepository : CrudRepository<OffenderExternalMo
 
   @Suppress("ktlint:standard:function-naming")
   fun findAllById_OffenderBooking_BookingId(bookingId: Long): List<OffenderExternalMovement>
+
+  fun findPrisonAt(time: LocalDateTime, bookingId: Long): AgencyLocation? {
+    val admissions = findAllById_OffenderBooking_BookingId(bookingId)
+      .filter { it.movementReason.id.type == "ADM" }
+    val admission = admissions.filter { it.movementTime < time }.maxByOrNull { it.movementTime }
+      ?: admissions.minByOrNull { it.movementTime }
+    return admission?.toAgency
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementModel.kt
@@ -52,9 +52,6 @@ data class CourtMovementIn(
   @Schema(description = "Movement sequence")
   val sequence: Int,
 
-  @Schema(description = "Schedule out ID")
-  val eventId: Long?,
-
   @Schema(description = "Court schedule out event ID. Empty for unscheduled movements.")
   val courtScheduleOutId: Long?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementService.kt
@@ -72,7 +72,6 @@ class CourtMovementService(
   private fun OffenderCourtMovementIn.toResponse() = CourtMovementIn(
     bookingId = id.offenderBooking.bookingId,
     sequence = id.sequence,
-    eventId = courtScheduleOut?.id,
     courtScheduleOutId = courtScheduleOut?.id,
     movementDate = movementDate,
     movementTime = movementTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/movement/CourtMovementService.kt
@@ -57,8 +57,8 @@ class CourtMovementService(
   private fun OffenderCourtMovementOut.toResponse() = CourtMovementOut(
     bookingId = id.offenderBooking.bookingId,
     sequence = id.sequence,
-    eventId = courtScheduleOut?.id,
-    courtScheduleOutId = courtScheduleOut?.id,
+    eventId = courtScheduleOutId,
+    courtScheduleOutId = courtScheduleOutId,
     movementDate = movementDate,
     movementTime = movementTime,
     movementReason = movementReason.id.reasonCode,
@@ -72,7 +72,7 @@ class CourtMovementService(
   private fun OffenderCourtMovementIn.toResponse() = CourtMovementIn(
     bookingId = id.offenderBooking.bookingId,
     sequence = id.sequence,
-    courtScheduleOutId = courtScheduleOut?.id,
+    courtScheduleOutId = courtScheduleOutId,
     movementDate = movementDate,
     movementTime = movementTime,
     movementReason = movementReason.id.reasonCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsModel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsModel.kt
@@ -37,10 +37,10 @@ data class BookingCourtScheduleOut(
   val eventId: Long,
 
   @Schema(description = "Court movement out")
-  val courtMovementOut: BookingCourtMovementOut,
+  val courtMovementOut: BookingCourtMovementOut? = null,
 
   @Schema(description = "Court movement in")
-  val courtMovementIn: BookingCourtMovementIn,
+  val courtMovementIn: BookingCourtMovementIn? = null,
 
   @Schema(description = "Event date")
   val eventDate: LocalDate,
@@ -66,9 +66,6 @@ data class BookingCourtScheduleOut(
   @Schema(description = "Court case ID")
   val courtCaseId: Long? = null,
 
-  @Schema(description = "Audit user's active caseload ID (modified user else create user)")
-  val userActiveCaseloadId: String?,
-
   @Schema(description = "Audit data associated with the records")
   val audit: NomisAudit,
 )
@@ -77,12 +74,6 @@ data class BookingCourtMovementOut(
 
   @Schema(description = "Movement sequence")
   val sequence: Int,
-
-  @Schema(description = "Schedule out ID")
-  val eventId: Long?,
-
-  @Schema(description = "Court schedule out event ID. Empty for unscheduled movements.")
-  val courtScheduleOutId: Long?,
 
   @Schema(description = "Movement date")
   val movementDate: LocalDate,
@@ -102,9 +93,6 @@ data class BookingCourtMovementOut(
   @Schema(description = "Comment text")
   val commentText: String?,
 
-  @Schema(description = "Audit user's active caseload ID (modified user else create user)")
-  val userActiveCaseloadId: String?,
-
   @Schema(description = "Audit data associated with the records")
   val audit: NomisAudit,
 )
@@ -113,12 +101,6 @@ data class BookingCourtMovementIn(
 
   @Schema(description = "Movement sequence")
   val sequence: Int,
-
-  @Schema(description = "Schedule out ID")
-  val eventId: Long?,
-
-  @Schema(description = "Court schedule out event ID. Empty for unscheduled movements.")
-  val courtScheduleOutId: Long?,
 
   @Schema(description = "Movement date")
   val movementDate: LocalDate,
@@ -137,9 +119,6 @@ data class BookingCourtMovementIn(
 
   @Schema(description = "Comment text")
   val commentText: String?,
-
-  @Schema(description = "Audit user's active caseload ID (modified user else create user)")
-  val userActiveCaseloadId: String?,
 
   @Schema(description = "Audit data associated with the records")
   val audit: NomisAudit,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
@@ -32,15 +32,16 @@ class OffenderCourtMovementsService(
     val allMovementsIn = courtMovementInRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
     val allSchedulesOut = courtEventRepository.findAllByOffenderBooking_Offender_NomsIdAndDirectionCode_CodeIs(offenderNo, "OUT")
 
-    val unscheduledMovementsOut = allMovementsOut.toSet() - allSchedulesOut.mapNotNull { it.courtMovementOut }.toSet()
-    val unscheduledMovementsIn = allMovementsIn.toSet() - allSchedulesOut.mapNotNull { it.courtMovementIn }.toSet()
+    // When finding unscheduled movements we also have to cross reference with the schedules we loaded - just in case any are linked to a schedule without a direction (bad old NOMIS data that we are ignoring)
+    val unscheduledMovementsOut = allMovementsOut.filter { it.courtScheduleOutId == null || it.courtScheduleOutId !in(allSchedulesOut.map { it.id }) }
+    val unscheduledMovementsIn = allMovementsIn.filter { it.courtScheduleOutId == null || it.courtScheduleOutId !in(allSchedulesOut.map { it.id }) }
 
-    data class Booking(val id: Long, val active: Boolean, val latest: Boolean, val prison: String)
+    data class Booking(val id: Long, val active: Boolean, val latest: Boolean)
 
     val bookings = (
-      allSchedulesOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) } +
-        allMovementsOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) } +
-        allMovementsIn.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) }
+      allSchedulesOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) } +
+        allMovementsOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) } +
+        allMovementsIn.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1) }
       ).toSet()
 
     return OffenderCourtMovementsResponse(
@@ -51,7 +52,12 @@ class OffenderCourtMovementsService(
           latestBooking = bk.latest,
           courtSchedules = allSchedulesOut
             .filter { it.offenderBooking.bookingId == bk.id }
-            .map { it.toResponse(it.courtMovementOut, it.courtMovementIn) },
+            .map { schedule ->
+              schedule.toResponse(
+                moveOut = allMovementsOut.find { it.courtScheduleOutId == schedule.id },
+                moveIn = allMovementsIn.find { it.courtScheduleOutId == schedule.id },
+              )
+            },
           unscheduledCourtMovementOuts = unscheduledMovementsOut
             .filter { it.offenderBooking.bookingId == bk.id }
             .map { it.toResponse() },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
@@ -1,10 +1,103 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.court.offender
 
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCourtMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCourtMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtEventRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderCourtMovementInRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderCourtMovementOutRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderExternalMovementRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 
 @Service
-class OffenderCourtMovementsService {
+@Transactional
+class OffenderCourtMovementsService(
+  private val courtEventRepository: CourtEventRepository,
+  private val courtMovementOutRepository: OffenderCourtMovementOutRepository,
+  private val courtMovementInRepository: OffenderCourtMovementInRepository,
+  private val externalMovementRepository: OffenderExternalMovementRepository,
+  private val offenderRepository: OffenderRepository,
+) {
 
-  // TODO implement this service
-  fun getOffenderCourtMovements(offenderNo: String): OffenderCourtMovementsResponse? = null
+  fun getOffenderCourtMovements(offenderNo: String): OffenderCourtMovementsResponse {
+    if (!offenderRepository.existsByNomsId(offenderNo)) {
+      throw NotFoundException("Offender with nomsId=$offenderNo not found")
+    }
+
+    val allMovementsOut = courtMovementOutRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
+    val allMovementsIn = courtMovementInRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
+    val allSchedulesOut = courtEventRepository.findAllByOffenderBooking_Offender_NomsIdAndDirectionCode_CodeIs(offenderNo, "OUT")
+
+    val unscheduledMovementsOut = allMovementsOut.toSet() - allSchedulesOut.mapNotNull { it.courtMovementOut }.toSet()
+    val unscheduledMovementsIn = allMovementsIn.toSet() - allSchedulesOut.mapNotNull { it.courtMovementIn }.toSet()
+
+    data class Booking(val id: Long, val active: Boolean, val latest: Boolean, val prison: String)
+
+    val bookings = (
+      allSchedulesOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) } +
+        allMovementsOut.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) } +
+        allMovementsIn.map { Booking(it.offenderBooking.bookingId, it.offenderBooking.active, it.offenderBooking.bookingSequence == 1, it.offenderBooking.location.id) }
+      ).toSet()
+
+    return OffenderCourtMovementsResponse(
+      bookings.map { bk ->
+        BookingCourtMovements(
+          bookingId = bk.id,
+          activeBooking = bk.active,
+          latestBooking = bk.latest,
+          courtSchedules = allSchedulesOut
+            .filter { it.offenderBooking.bookingId == bk.id }
+            .map { it.toResponse(it.courtMovementOut, it.courtMovementIn) },
+          unscheduledCourtMovementOuts = unscheduledMovementsOut
+            .filter { it.offenderBooking.bookingId == bk.id }
+            .map { it.toResponse() },
+          unscheduledCourtMovementIns = unscheduledMovementsIn
+            .filterNot { it.createUsername == "SYS" && it.auditModuleName == "MERGE" }
+            .filter { it.offenderBooking.bookingId == bk.id }
+            .map { it.toResponse() },
+        )
+      },
+    )
+  }
+
+  private fun OffenderCourtMovementOut.toResponse() = BookingCourtMovementOut(
+    sequence = id.sequence,
+    movementDate = movementDate,
+    movementTime = movementTime,
+    movementReason = movementReason.id.reasonCode,
+    fromPrison = fromAgency!!.id,
+    toCourt = toAgency?.id,
+    commentText = commentText,
+    audit = toAudit(),
+  )
+
+  private fun OffenderCourtMovementIn.toResponse() = BookingCourtMovementIn(
+    sequence = id.sequence,
+    movementDate = movementDate,
+    movementTime = movementTime,
+    movementReason = movementReason.id.reasonCode,
+    fromCourt = fromAgency?.id,
+    toPrison = toAgency!!.id,
+    commentText = commentText,
+    audit = toAudit(),
+  )
+
+  private fun CourtEvent.toResponse(moveOut: OffenderCourtMovementOut?, moveIn: OffenderCourtMovementIn?) = BookingCourtScheduleOut(
+    eventId = id,
+    courtMovementOut = moveOut?.toResponse(),
+    courtMovementIn = moveIn?.toResponse(),
+    eventDate = eventDate,
+    startTime = startTime,
+    eventType = courtEventType.code,
+    eventStatus = eventStatus.code,
+    comment = commentText,
+    prison = externalMovementRepository.findPrisonAt(createDatetime, offenderBooking.bookingId)?.id ?: offenderBooking.location.id,
+    court = court.id,
+    courtCaseId = courtCase?.id,
+    audit = toAudit(),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
@@ -5,14 +5,12 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.DirectionType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtEventRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderExternalMovementRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.court.findActiveCaseloadId
-import java.time.LocalDateTime
 
 @Transactional(readOnly = true)
 @Service
@@ -31,14 +29,6 @@ class CourtScheduleService(
       ?: throw NotFoundException("Court event OUT with id=$eventId not found for prisoner with nomsId=$offenderNo")
   }
 
-  private fun findPrisonAt(time: LocalDateTime, bookingId: Long): AgencyLocation? {
-    val admissions = externalMovementRepository.findAllById_OffenderBooking_BookingId(bookingId)
-      .filter { it.movementReason.id.type == "ADM" }
-    val admission = admissions.filter { it.movementTime < time }.maxByOrNull { it.movementTime }
-      ?: admissions.minByOrNull { it.movementTime }
-    return admission?.toAgency
-  }
-
   private fun CourtEvent.toResponse() = CourtScheduleOut(
     bookingId = offenderBooking.bookingId,
     eventId = id,
@@ -47,7 +37,7 @@ class CourtScheduleService(
     eventType = courtEventType.code,
     eventStatus = eventStatus.code,
     comment = commentText,
-    prison = findPrisonAt(createDatetime, offenderBooking.bookingId)?.id ?: offenderBooking.location.id,
+    prison = externalMovementRepository.findPrisonAt(createDatetime, offenderBooking.bookingId)?.id ?: offenderBooking.location.id,
     court = court.id,
     courtCaseId = courtCase?.id,
     userActiveCaseloadId = findActiveCaseloadId(modifyStaffUserAccount, createStaffUserAccount),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderExternalMovement.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/OffenderExternalMovement.kt
@@ -249,7 +249,7 @@ class OffenderExternalMovementBuilder(
     toCourt = repository.lookupAgency(toCourt),
     active = true,
     commentText = comment,
-    courtScheduleOut = courtScheduleOut,
+    courtScheduleOutId = courtScheduleOut?.id,
   ).also {
     offenderBooking.inOutStatus = "OUT"
     offenderBooking.location = repository.lookupAgency("OUT")
@@ -275,7 +275,7 @@ class OffenderExternalMovementBuilder(
     toPrison = repository.lookupAgency(toPrison),
     active = true,
     commentText = comment,
-    courtScheduleOut = courtScheduleOut,
+    courtScheduleOutId = courtScheduleOut?.id,
   ).also {
     offenderBooking.inOutStatus = "IN"
     offenderBooking.location = it.toAgency!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtMovementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtMovementResourceIntTest.kt
@@ -262,7 +262,6 @@ class CourtMovementResourceIntTest(
         webTestClient.getCourtMovementInOk().apply {
           assertThat(bookingId).isEqualTo(booking.bookingId)
           assertThat(sequence).isEqualTo(movementIn.id.sequence)
-          assertThat(eventId).isEqualTo(scheduleOut.id)
           assertThat(courtScheduleOutId).isEqualTo(scheduleOut.id)
           assertThat(movementDate).isEqualTo(movementIn.movementDate)
           assertThat(movementTime).isCloseTo(movementIn.movementTime, within(Duration.ofSeconds(1)))
@@ -290,7 +289,6 @@ class CourtMovementResourceIntTest(
         webTestClient.getCourtMovementInOk().apply {
           assertThat(bookingId).isEqualTo(booking.bookingId)
           assertThat(sequence).isEqualTo(movementIn.id.sequence)
-          assertThat(eventId).isNull()
           assertThat(courtScheduleOutId).isNull()
           assertThat(userActiveCaseloadId).isEqualTo("CADM_I")
         }
@@ -314,7 +312,6 @@ class CourtMovementResourceIntTest(
         webTestClient.getCourtMovementInOk().apply {
           assertThat(bookingId).isEqualTo(booking.bookingId)
           assertThat(sequence).isEqualTo(movementIn.id.sequence)
-          assertThat(eventId).isEqualTo(scheduleOut.id)
           assertThat(courtScheduleOutId).isEqualTo(scheduleOut.id)
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtMovementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtMovementResourceIntTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.court
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -33,6 +34,11 @@ class CourtMovementResourceIntTest(
   private lateinit var movementIn: OffenderCourtMovementIn
   private lateinit var scheduleOut: CourtEvent
   private lateinit var staff: Staff
+
+  @AfterEach
+  fun tearDown() {
+    repository.deleteOffenders()
+  }
 
   @Nested
   @DisplayName("GET /movements/{offenderNo}/court/movement/out/{bookingId}/{movementSeq}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
@@ -43,12 +43,6 @@ class OffenderCourtMovementsResourceIntTest(
 
   @AfterEach
   fun tearDown() {
-    if (::scheduleOut.isInitialized) {
-      repository.delete(scheduleOut)
-    }
-    if (::scheduleIn.isInitialized) {
-      repository.delete(scheduleIn)
-    }
     repository.deleteOffenders()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
@@ -1,40 +1,546 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.court
 
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.integration.expectBodyResponse
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtCase
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.DirectionType.Companion.IN
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.DirectionType.Companion.OUT
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCourtMovementIn
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCourtMovementOut
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Staff
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.court.offender.OffenderCourtMovementsResponse
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit.SECONDS
 
-class OffenderCourtMovementsResourceIntTest : IntegrationTestBase() {
+class OffenderCourtMovementsResourceIntTest(
+  @Autowired private val entityManager: EntityManager,
+) : IntegrationTestBase() {
+
+  private val offenderNo = "C7463CC"
+  private lateinit var offender: Offender
+  private lateinit var booking: OffenderBooking
+  private lateinit var scheduleOut: CourtEvent
+  private lateinit var movementOut: OffenderCourtMovementOut
+  private lateinit var movementIn: OffenderCourtMovementIn
+  private lateinit var staff: Staff
+  private lateinit var courtCase: CourtCase
+  private lateinit var mergeBooking: OffenderBooking
+  private lateinit var mergeMovementIn: OffenderCourtMovementIn
+  private lateinit var scheduleIn: CourtEvent
+
+  @AfterEach
+  fun tearDown() {
+    if (::scheduleOut.isInitialized) {
+      repository.delete(scheduleOut)
+    }
+    if (::scheduleIn.isInitialized) {
+      repository.delete(scheduleIn)
+    }
+    repository.deleteOffenders()
+  }
 
   @Nested
   @DisplayName("GET /movements/{offenderNo}/court")
-  inner class Security {
+  inner class GetOffenderCourtMovements {
 
-    @Test
-    fun `should return unauthorised for missing token`() {
-      webTestClient.get()
-        .uri("/movements/A1234BC/court")
-        .exchange()
-        .expectStatus().isUnauthorized
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `should get court schedule`() {
+        nomisDataBuilder.build {
+          staff = staff {
+            account()
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              courtCase = courtCase(reportingStaff = staff) {
+                scheduleOut = courtEvent()
+              }
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            assertThat(bookings).hasSize(1)
+            assertThat(bookings[0].bookingId).isEqualTo(booking.bookingId)
+            assertThat(bookings[0].courtSchedules).hasSize(1)
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(eventId).isEqualTo(scheduleOut.id)
+              assertThat(eventDate).isEqualTo(scheduleOut.eventDate)
+              assertThat(startTime).isEqualTo(scheduleOut.startTime)
+              assertThat(eventType).isEqualTo(scheduleOut.courtEventType.code)
+              assertThat(eventStatus).isEqualTo(scheduleOut.eventStatus.code)
+              assertThat(comment).isEqualTo(scheduleOut.commentText)
+              assertThat(prison).isEqualTo(booking.location.id)
+              assertThat(court).isEqualTo(scheduleOut.court.id)
+              assertThat(courtCaseId).isEqualTo(courtCase.id)
+              assertThat(audit.createUsername).isEqualTo("SA")
+              assertThat(audit.createDatetime).isCloseTo(LocalDateTime.now(), within(10, SECONDS))
+            }
+          }
+      }
+
+      @Test
+      fun `should get court case without court schedule`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent()
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            assertThat(bookings[0].courtSchedules).hasSize(1)
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(eventId).isEqualTo(scheduleOut.id)
+              assertThat(courtCaseId).isNull()
+            }
+          }
+      }
+
+      @Test
+      fun `should get prison from offender's prison at time of schedule creation`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking(agencyLocationId = "MDI", bookingBeginDate = LocalDateTime.now().minusDays(1)) {
+              // The court schedule was created while in MDI
+              scheduleOut = courtEvent(whenCreated = LocalDateTime.now().minusHours(6))
+              prisonTransfer(from = "MDI", to = "BXI", date = LocalDateTime.now().minusHours(1))
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(prison).isEqualTo("MDI")
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement OUT`() {
+        nomisDataBuilder.build {
+          staff = staff {
+            account()
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              courtCase = courtCase(reportingStaff = staff) {
+                scheduleOut = courtEvent {
+                  movementOut = courtMovementOut()
+                }
+              }
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0].courtMovementOut!!) {
+              assertThat(sequence).isEqualTo(movementOut.id.sequence)
+              assertThat(movementDate).isEqualTo(movementOut.movementDate)
+              assertThat(movementTime).isCloseTo(movementOut.movementTime, within(Duration.ofSeconds(1)))
+              assertThat(movementReason).isEqualTo(movementOut.movementReason.id.reasonCode)
+              assertThat(fromPrison).isEqualTo("BXI")
+              assertThat(toCourt).isEqualTo(movementOut.toAgency!!.id)
+              assertThat(commentText).isEqualTo(movementOut.commentText)
+              assertThat(audit.createUsername).isEqualTo("SA")
+              assertThat(audit.createDatetime).isCloseTo(movementOut.createDatetime, within(10, SECONDS))
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement OUT without court case`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+              }
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0].courtMovementOut!!) {
+              assertThat(sequence).isEqualTo(movementOut.id.sequence)
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement OUT without schedule`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              movementOut = courtMovementOut()
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].unscheduledCourtMovementOuts[0]) {
+              assertThat(sequence).isEqualTo(movementOut.id.sequence)
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement IN`() {
+        nomisDataBuilder.build {
+          staff = staff {
+            account()
+          }
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              courtCase = courtCase(reportingStaff = staff) {
+                scheduleOut = courtEvent {
+                  movementOut = courtMovementOut()
+                  movementIn = courtMovementIn()
+                }
+              }
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0].courtMovementIn!!) {
+              assertThat(sequence).isEqualTo(movementIn.id.sequence)
+              assertThat(movementDate).isEqualTo(movementIn.movementDate)
+              assertThat(movementTime).isCloseTo(movementIn.movementTime, within(Duration.ofSeconds(1)))
+              assertThat(movementReason).isEqualTo(movementIn.movementReason.id.reasonCode)
+              assertThat(toPrison).isEqualTo(movementIn.toAgency!!.id)
+              assertThat(fromCourt).isEqualTo(movementIn.fromAgency!!.id)
+              assertThat(commentText).isEqualTo(movementIn.commentText)
+              assertThat(audit.createUsername).isEqualTo("SA")
+              assertThat(audit.createDatetime).isCloseTo(movementIn.createDatetime, within(10, SECONDS))
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement IN without court case`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+                movementIn = courtMovementIn()
+              }
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0].courtMovementIn!!) {
+              assertThat(sequence).isEqualTo(movementIn.id.sequence)
+            }
+          }
+      }
+
+      @Test
+      fun `should get court movement IN without schedule`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              movementOut = courtMovementOut()
+              movementIn = courtMovementIn()
+            }
+          }
+        }
+
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].unscheduledCourtMovementIns[0]) {
+              assertThat(sequence).isEqualTo(movementIn.id.sequence)
+            }
+          }
+      }
     }
 
-    @Test
-    fun `should return forbidden for missing role`() {
-      webTestClient.get()
-        .uri("/movements/A1234BC/court")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus().isForbidden
+    @Nested
+    inner class Validation {
+      @Test
+      fun `should return not found if offender unknown`() {
+        webTestClient.getOffenderCourtMovements(offenderNo = "UNKNOWN")
+          .expectStatus().isNotFound
+      }
     }
 
-    @Test
-    fun `should return forbidden for wrong role`() {
-      webTestClient.get()
-        .uri("/movements/A1234BC/court")
-        .headers(setAuthorisation("ROLE_INVALID"))
-        .exchange()
-        .expectStatus().isForbidden
+    @Nested
+    inner class BadData {
+
+      @Test
+      fun `should not return any movements IN created during merges`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+                movementIn = courtMovementIn()
+              }
+            }
+            mergeBooking = booking {
+              scheduleOut = courtEvent()
+              mergeMovementIn = courtMovementIn()
+            }
+          }
+        }
+
+        // Set the audit columns on the movement IN created by a merge to indicate a merge was responsible
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set CREATE_USER_ID = 'SYS', AUDIT_MODULE_NAME = 'MERGE'
+              where OFFENDER_BOOK_ID = ${mergeBooking.bookingId} and MOVEMENT_SEQ = ${mergeMovementIn.id.sequence}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // The movement IN created by a merge should not be returned
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings.first { it.bookingId == mergeBooking.bookingId }) {
+              assertThat(unscheduledCourtMovementIns).isEmpty()
+            }
+          }
+      }
+
+      @Test
+      fun `should ignore orphaned schedule IN`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent(directionCode = OUT)
+              scheduleIn = courtEvent(directionCode = IN)
+              movementOut = courtMovementOut()
+              movementIn = courtMovementIn()
+            }
+          }
+        }
+
+        // Link the schedule IN to the schedule OUT, but then delete the schedule OUT
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS
+              set PARENT_EVENT_ID = ${scheduleOut.id}
+              where EVENT_ID = ${scheduleIn.id}
+            """.trimIndent(),
+          ).executeUpdate()
+          entityManager.createNativeQuery(
+            """
+              delete from COURT_EVENTS
+              where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // The orphaned schedule IN doesn't break anything
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0]) {
+              assertThat(courtSchedules).isEmpty()
+              assertThat(unscheduledCourtMovementOuts).hasSize(1)
+              assertThat(unscheduledCourtMovementIns).hasSize(1)
+            }
+          }
+      }
+
+      @Test
+      fun `should treat orphaned movements as unscheduled`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+                movementIn = courtMovementIn()
+              }
+            }
+          }
+        }
+
+        // Remove the schedule OUT attached to the movements
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              delete from COURT_EVENTS
+              where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // The movements are returned as unscheduled
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0]) {
+              assertThat(unscheduledCourtMovementOuts).hasSize(1)
+              assertThat(unscheduledCourtMovementIns).hasSize(1)
+            }
+          }
+      }
+
+      @Test
+      fun `should not return any schedules with null direction code`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+              }
+            }
+          }
+        }
+
+        // Set the schedule direction code to null
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS
+              set DIRECTION_CODE = null
+              where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // The court schedule without direction code should not be returned
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0]) {
+              assertThat(courtSchedules).isEmpty()
+              assertThat(unscheduledCourtMovementOuts).hasSize(1)
+            }
+          }
+      }
+
+      @Test
+      fun `should return incorrect data where prison or court transposed`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent(agencyId = "LEI") {
+                movementOut = courtMovementOut(fromPrison = "LEEDYC", toCourt = "LEI")
+                movementIn = courtMovementIn(fromCourt = "LEI", toPrison = "LEEDYC")
+              }
+            }
+          }
+        }
+
+        // The court schedule without direction code should not be returned
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(this.court).isEqualTo("LEI")
+              assertThat(courtMovementOut?.fromPrison).isEqualTo("LEEDYC")
+              assertThat(courtMovementOut?.toCourt).isEqualTo("LEI")
+              assertThat(courtMovementIn?.fromCourt).isEqualTo("LEI")
+              assertThat(courtMovementIn?.toPrison).isEqualTo("LEEDYC")
+            }
+          }
+      }
+
+      @Test
+      fun `should return null court if it is missing`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEvent {
+                movementOut = courtMovementOut()
+                movementIn = courtMovementIn()
+              }
+            }
+          }
+        }
+
+        // Set the movement courts to null
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set TO_AGY_LOC_ID = null
+              where OFFENDER_BOOK_ID = ${movementOut.id.offenderBooking.bookingId} and MOVEMENT_SEQ = ${movementOut.id.sequence}
+            """.trimIndent(),
+          ).executeUpdate()
+          entityManager.createNativeQuery(
+            """
+              update OFFENDER_EXTERNAL_MOVEMENTS
+              set FROM_AGY_LOC_ID = null
+              where OFFENDER_BOOK_ID = ${movementIn.id.offenderBooking.bookingId} and MOVEMENT_SEQ = ${movementIn.id.sequence}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        // The null courts are returned
+        webTestClient.getOffenderCourtMovementsOk(offenderNo)
+          .apply {
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(courtMovementOut?.toCourt).isNull()
+              assertThat(courtMovementIn?.fromCourt).isNull()
+            }
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `should return unauthorised for missing token`() {
+        webTestClient.get()
+          .uri("/movements/A1234BC/court")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `should return forbidden for missing role`() {
+        webTestClient.get()
+          .uri("/movements/A1234BC/court")
+          .headers(setAuthorisation())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `should return forbidden for wrong role`() {
+        webTestClient.get()
+          .uri("/movements/A1234BC/court")
+          .headers(setAuthorisation("ROLE_INVALID"))
+          .exchange()
+          .expectStatus().isForbidden
+      }
     }
   }
+
+  private fun WebTestClient.getOffenderCourtMovements(offenderNo: String = offender.nomsId) = get()
+    .uri("/movements/$offenderNo/court")
+    .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+    .exchange()
+
+  private fun WebTestClient.getOffenderCourtMovementsOk(offenderNo: String = offender.nomsId) = getOffenderCourtMovements(offenderNo)
+    .expectStatus().isOk
+    .expectBodyResponse<OffenderCourtMovementsResponse>()
 }


### PR DESCRIPTION
Reverts the previous revert to remove get offender court movements endpoint due to performance issues.

Then rework the JPA to prevent said performance issues. This mainly involved taking out the @OneToOne link between CourtEvent and OffenderCourtMovementOut/In because it appears that the SQL generated caused the performance issues we saw in production. We don't really need CourtEvent to know about related movements anyway, it was mainly done for completeness (plus that approach seemed to work fine for TAPs).

In fact if you look at the [2nd commit](https://github.com/ministryofjustice/hmpps-nomis-prisoner-api/pull/1764/changes/722fd77506751fb6a096cae635406277d6c730c3) you can see the JPA fixes.