### PR TITLE
SDIT-3809 Remove orphaned breached hearings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -1428,9 +1428,9 @@ class CourtSentencingService(
   }
 
   fun updateRecallSentences(offenderNo: String, request: UpdateRecallRequest) {
+    val removedBreachCourtEventIds = mutableListOf<Long>()
     val bookingIds = request.sentences.map { it.sentenceId.offenderBookingId }.toSet()
-
-    request.sentences.updateSentences()
+    val courtCasesStillInRecall = request.sentences.updateSentences().mapNotNull { it.courtCase }.toSet()
     request.sentencesRemoved.updateSentences()
     request.returnToCustody.createOrUpdateBooking(bookingIds)
     bookingIds.forEach { bookingId ->
@@ -1441,8 +1441,13 @@ class CourtSentencingService(
     }
     request.beachCourtEventIds.forEach {
       courtEventRepository.findByIdOrNull(it)?.also { courtEvent ->
-        courtEvent.eventDate = request.recallRevocationDate
-        courtEvent.startTime = LocalDateTime.of(request.recallRevocationDate, LocalTime.MIDNIGHT)
+        if (courtEvent.courtCase in courtCasesStillInRecall) {
+          courtEvent.eventDate = request.recallRevocationDate
+          courtEvent.startTime = LocalDateTime.of(request.recallRevocationDate, LocalTime.MIDNIGHT)
+        } else {
+          courtEventRepository.delete(courtEvent)
+          removedBreachCourtEventIds.add(it)
+        }
       }
     }
     telemetryClient.trackEvent(
@@ -1452,7 +1457,8 @@ class CourtSentencingService(
         "sentenceSequences" to request.sentences.map { it.sentenceId.sentenceSequence }.joinToString { it.toString() },
         "removedSentenceSequences" to request.sentencesRemoved.map { it.sentenceId.sentenceSequence }.joinToString { it.toString() },
         "offenderNo" to offenderNo,
-        "beachCourtEventIds" to request.beachCourtEventIds.joinToString { it.toString() },
+        "breachCourtEventIds" to request.beachCourtEventIds.joinToString { it.toString() },
+        "removedBreachCourtEventIds" to removedBreachCourtEventIds.joinToString { it.toString() },
       ),
       null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -10432,8 +10432,10 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
       private lateinit var sentence1: OffenderSentence
       private lateinit var sentence2: OffenderSentence
       private lateinit var sentence3: OffenderSentence
+      private lateinit var sentenceRemovedFromRecall: OffenderSentence
       private lateinit var request: UpdateRecallRequest
       private lateinit var breachCourtEvent: CourtEvent
+      private lateinit var breachCourtEventFromRemovedCase: CourtEvent
 
       @Nested
       inner class FirstFixedTermRecall {
@@ -10492,13 +10494,39 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                       courtOrder(courtDate = LocalDate.parse("2023-01-01"))
                     }
                   }
+                  courtCase(reportingStaff = staff, caseSequence = 2) {
+                    val offenderCharge = offenderCharge(offenceCode = "RT88074")
+                    courtEvent {
+                      courtEventCharge(offenderCharge = offenderCharge)
+                      courtOrder = courtOrder(courtDate = LocalDate.of(2023, 1, 1))
+                    }
+                    breachCourtEventFromRemovedCase = courtEvent(
+                      courtEventType = RECALL_BREACH_HEARING,
+                      outcomeReasonCode = RECALL_TO_PRISON,
+                      eventDateTime = LocalDate.parse("2023-01-01").atStartOfDay(),
+                    ) {
+                      courtEventCharge(offenderCharge = offenderCharge, resultCode1 = RECALL_TO_PRISON)
+                      courtOrder(courtDate = LocalDate.parse("2023-01-01"))
+                    }
+                    sentenceRemovedFromRecall = sentence(
+                      category = "2020",
+                      calculationType = "FTR_ORA",
+                      statusUpdateStaff = staff,
+                      courtOrder = courtOrder,
+                      status = "A",
+                    ) {
+                      offenderSentenceCharge(offenderCharge = offenderCharge)
+                      term(days = 35, sentenceTermType = "IMP")
+                    }
+                  }
+
                   fixedTermRecall(staff = staff)
                 }
               }
           }
           request = UpdateRecallRequest(
             returnToCustody = null,
-            beachCourtEventIds = listOf(breachCourtEvent.id),
+            beachCourtEventIds = listOf(breachCourtEvent.id, breachCourtEventFromRemovedCase.id),
             recallRevocationDate = LocalDate.parse("2023-06-06"),
             sentences = listOf(
               RecallRelatedSentenceDetails(
@@ -10514,7 +10542,14 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                 // no sure this will ever happen, but lets test it just in case
                 active = false,
               ),
-
+            ),
+            sentencesRemoved = listOf(
+              RecallRelatedSentenceDetails(
+                SentenceId(offenderBookingId = booking.bookingId, sentenceSequence = sentenceRemovedFromRecall.id.sequence),
+                sentenceCategory = "2020",
+                sentenceCalcType = "ADIMP",
+                active = false,
+              ),
             ),
           )
         }
@@ -10616,6 +10651,21 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         }
 
         @Test
+        fun `will delete the breach court appearance no longer associated with recall`() {
+          assertThat(courtEventRepository.findByIdOrNull(breachCourtEventFromRemovedCase.id)).isNotNull
+
+          webTestClient.put()
+            .uri("/prisoners/${prisoner.nomsId}/sentences/recall")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(request))
+            .exchange()
+            .expectStatus().isOk
+
+          assertThat(courtEventRepository.findByIdOrNull(breachCourtEventFromRemovedCase.id)).isNull()
+        }
+
+        @Test
         fun `will remove custody data when absent`() {
           assertThat(offenderFixedTermRecallRepository.findById(booking.bookingId)).isPresent
 
@@ -10690,6 +10740,9 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
               assertThat(it["bookingId"]).isEqualTo(booking.bookingId.toString())
               assertThat(it["sentenceSequences"]).isEqualTo("${sentence1.id.sequence}, ${sentence2.id.sequence}")
               assertThat(it["offenderNo"]).isEqualTo(prisoner.nomsId)
+              assertThat(it["breachCourtEventIds"]).isEqualTo("${breachCourtEvent.id}, ${breachCourtEventFromRemovedCase.id}")
+              assertThat(it["removedBreachCourtEventIds"]).isEqualTo("${breachCourtEventFromRemovedCase.id}")
+              assertThat(it["removedSentenceSequences"]).isEqualTo("${sentenceRemovedFromRecall.id.sequence}")
             },
             isNull(),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/integration/IntegrationTestBase.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.NomisDataBuilder
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders.Repository
@@ -24,7 +24,7 @@ abstract class IntegrationTestBase {
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
 
-  @MockitoSpyBean
+  @MockitoBean
   protected lateinit var telemetryClient: TelemetryClient
 
   @Autowired


### PR DESCRIPTION
When a recall is amended a case that was originally in a recall can be removed. When that happens any breach court appearances added also need deleting.