### PR TITLE
SDIT-3826 Add additional breach hearings when recall updated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
@@ -2917,6 +2917,16 @@ data class ConvertToRecallResponse(
   val clonedCourtCases: BookingCourtCaseCloneResponse?,
 )
 
+@Schema(description = "Recall update response")
+data class UpdateRecallResponse(
+  @Schema(description = "the breach court appearance ids created")
+  val createdCourtEventIds: List<Long>,
+  @Schema(description = "the breach court appearance ids updated")
+  val updatedCourtEventIds: List<Long>,
+  @Schema(description = "the breach court appearance ids deleted")
+  val deletedCourtEventIds: List<Long>,
+)
+
 @Schema(description = "Recall convert response")
 data class SentenceIdAndAdjustmentIds(
   val sentenceId: SentenceId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -1349,49 +1349,20 @@ class CourtSentencingService(
     // it would make sense to not make any assumptions
     val bookingIds = convertToRecallRequest.sentences.map { it.sentenceId.offenderBookingId }.toSet()
 
-    val sentencesUpdated = convertToRecallRequest.sentences.updateSentences()
-    sentencingAdjustmentService.convertAdjustmentsToRecallEquivalents(sentencesUpdated)
-    val adjustmentsUpdated = sentencingAdjustmentService.activateAllAdjustment(sentencesUpdated)
+    val sentencesInRecall = convertToRecallRequest.sentences.updateSentences()
+    sentencingAdjustmentService.convertAdjustmentsToRecallEquivalents(sentencesInRecall)
+    val adjustmentsUpdated = sentencingAdjustmentService.activateAllAdjustment(sentencesInRecall)
     convertToRecallRequest.returnToCustody.createOrUpdateBooking(bookingIds)
 
     // Create a new CourtEvent for each unique CourtCase associated with each OffenderSentence
-    val uniqueCourtCases = sentencesUpdated.mapNotNull { it.courtCase }.toSet()
+    val uniqueCourtCases = sentencesInRecall.mapNotNull { it.courtCase }.toSet()
     // Create a new CourtEvent for each unique CourtCase
     val courtEvents = uniqueCourtCases.map { courtCase ->
-      // Find all sentences associated with this court case that are being recalled
-      val sentencesForCase = sentencesUpdated.filter {
-        it.courtCase == courtCase
-      }
-
-      // Find the court from the last appearance
-      val court = courtCase.courtEvents.maxByOrNull(CourtEvent::eventDate)!!.court
-
-      // Create the court event
-      val courtEvent = CourtEvent(
-        offenderBooking = courtCase.offenderBooking,
+      createRecallBreachCourtAppearance(
         courtCase = courtCase,
-        eventDate = convertToRecallRequest.recallRevocationDate,
-        startTime = LocalDateTime.of(convertToRecallRequest.recallRevocationDate, LocalTime.MIDNIGHT),
-        courtEventType = lookupMovementReasonType(RECALL_BREACH_HEARING),
-        eventStatus = determineEventStatus(
-          convertToRecallRequest.recallRevocationDate,
-          courtCase.offenderBooking,
-        ),
-        court = court,
-        outcomeReasonCode = lookupOffenceResultCode(RECALL_TO_PRISON),
-        directionCode = lookupDirectionType(DirectionType.OUT),
+        recallRevocationDate = convertToRecallRequest.recallRevocationDate,
+        sentencesInRecall = sentencesInRecall,
       )
-
-      // Create CourtEventCharge for each offenderSentenceCharge in the OffenderSentence
-      val offenderChargeIds =
-        sentencesForCase.flatMap { sentence -> sentence.offenderSentenceCharges.map { it.offenderCharge.id } }.toSet()
-      // Associate charges with the court event
-      associateChargesWithAppearanceUsingCourtEventOutcome(
-        courtEventChargesToUpdate = offenderChargeIds.toList(),
-        courtEvent = courtEvent,
-      )
-
-      courtEventRepository.saveAndFlush(courtEvent)
     }
 
     bookingIds.forEach { bookingId ->
@@ -1427,10 +1398,12 @@ class CourtSentencingService(
     )
   }
 
-  fun updateRecallSentences(offenderNo: String, request: UpdateRecallRequest) {
+  fun updateRecallSentences(offenderNo: String, request: UpdateRecallRequest): UpdateRecallResponse {
     val removedBreachCourtEventIds = mutableListOf<Long>()
+    val updatedBreachCourtEventIds = mutableListOf<Long>()
     val bookingIds = request.sentences.map { it.sentenceId.offenderBookingId }.toSet()
-    val courtCasesStillInRecall = request.sentences.updateSentences().mapNotNull { it.courtCase }.toSet()
+    val sentencesInRecall = request.sentences.updateSentences()
+    val courtCasesInRecall = sentencesInRecall.mapNotNull { it.courtCase }.toSet()
     request.sentencesRemoved.updateSentences()
     request.returnToCustody.createOrUpdateBooking(bookingIds)
     bookingIds.forEach { bookingId ->
@@ -1439,17 +1412,30 @@ class CourtSentencingService(
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
     }
-    request.beachCourtEventIds.forEach {
-      courtEventRepository.findByIdOrNull(it)?.also { courtEvent ->
-        if (courtEvent.courtCase in courtCasesStillInRecall) {
+    val casesUpdated = request.beachCourtEventIds.mapNotNull {
+      courtEventRepository.findByIdOrNull(it)?.let { courtEvent ->
+        if (courtEvent.courtCase in courtCasesInRecall) {
           courtEvent.eventDate = request.recallRevocationDate
           courtEvent.startTime = LocalDateTime.of(request.recallRevocationDate, LocalTime.MIDNIGHT)
+          updatedBreachCourtEventIds.add(it)
+          courtEvent.courtCase
         } else {
           courtEventRepository.delete(courtEvent)
           removedBreachCourtEventIds.add(it)
+          null
         }
       }
     }
+
+    val newCasesAddedToRecall = courtCasesInRecall - casesUpdated.toSet()
+    val createdBreachCourtEventIds = newCasesAddedToRecall.map { courtCase ->
+      createRecallBreachCourtAppearance(
+        courtCase = courtCase,
+        recallRevocationDate = request.recallRevocationDate,
+        sentencesInRecall = sentencesInRecall,
+      )
+    }.map { it.id }
+
     telemetryClient.trackEvent(
       "recall-sentences-updated",
       mapOf(
@@ -1459,8 +1445,15 @@ class CourtSentencingService(
         "offenderNo" to offenderNo,
         "breachCourtEventIds" to request.beachCourtEventIds.joinToString { it.toString() },
         "removedBreachCourtEventIds" to removedBreachCourtEventIds.joinToString { it.toString() },
+        "createdBreachCourtEventIds" to createdBreachCourtEventIds.joinToString { it.toString() },
       ),
       null,
+    )
+
+    return UpdateRecallResponse(
+      createdCourtEventIds = createdBreachCourtEventIds,
+      updatedCourtEventIds = updatedBreachCourtEventIds,
+      deletedCourtEventIds = removedBreachCourtEventIds,
     )
   }
 
@@ -1514,6 +1507,43 @@ class CourtSentencingService(
       ),
       null,
     )
+  }
+
+  private fun createRecallBreachCourtAppearance(courtCase: CourtCase, recallRevocationDate: LocalDate, sentencesInRecall: List<OffenderSentence>): CourtEvent {
+    // Find all sentences associated with this court case that are being recalled
+    val sentencesForCase = sentencesInRecall.filter {
+      it.courtCase == courtCase
+    }
+
+    // Find the court from the last appearance
+    val court = courtCase.courtEvents.maxByOrNull(CourtEvent::eventDate)!!.court
+
+    // Create the court event
+    val courtEvent = CourtEvent(
+      offenderBooking = courtCase.offenderBooking,
+      courtCase = courtCase,
+      eventDate = recallRevocationDate,
+      startTime = LocalDateTime.of(recallRevocationDate, LocalTime.MIDNIGHT),
+      courtEventType = lookupMovementReasonType(RECALL_BREACH_HEARING),
+      eventStatus = determineEventStatus(
+        recallRevocationDate,
+        courtCase.offenderBooking,
+      ),
+      court = court,
+      outcomeReasonCode = lookupOffenceResultCode(RECALL_TO_PRISON),
+      directionCode = lookupDirectionType(DirectionType.OUT),
+    )
+
+    // Create CourtEventCharge for each offenderSentenceCharge in the OffenderSentence
+    val offenderChargeIds =
+      sentencesForCase.flatMap { sentence -> sentence.offenderSentenceCharges.map { it.offenderCharge.id } }.toSet()
+    // Associate charges with the court event
+    associateChargesWithAppearanceUsingCourtEventOutcome(
+      courtEventChargesToUpdate = offenderChargeIds.toList(),
+      courtEvent = courtEvent,
+    )
+
+    return courtEventRepository.saveAndFlush(courtEvent)
   }
 
   private fun ReturnToCustodyRequest?.createOrUpdateBooking(bookingIds: Set<Long>) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -10433,9 +10433,12 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
       private lateinit var sentence2: OffenderSentence
       private lateinit var sentence3: OffenderSentence
       private lateinit var sentenceRemovedFromRecall: OffenderSentence
+      private lateinit var sentenceToBeAddedToRecall: OffenderSentence
       private lateinit var request: UpdateRecallRequest
       private lateinit var breachCourtEvent: CourtEvent
       private lateinit var breachCourtEventFromRemovedCase: CourtEvent
+      private lateinit var caseToBeAddedToRecall: CourtCase
+      val recallRevocationDate: LocalDate = LocalDate.parse("2023-06-06")
 
       @Nested
       inner class FirstFixedTermRecall {
@@ -10519,6 +10522,23 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                       term(days = 35, sentenceTermType = "IMP")
                     }
                   }
+                  caseToBeAddedToRecall = courtCase(reportingStaff = staff, caseSequence = 3) {
+                    val offenderCharge = offenderCharge(offenceCode = "RT88074")
+                    courtEvent {
+                      courtEventCharge(offenderCharge = offenderCharge)
+                      courtOrder = courtOrder(courtDate = LocalDate.of(2023, 1, 1))
+                    }
+                    sentenceToBeAddedToRecall = sentence(
+                      category = "2020",
+                      calculationType = "ADIMP",
+                      statusUpdateStaff = staff,
+                      courtOrder = courtOrder,
+                      status = "A",
+                    ) {
+                      offenderSentenceCharge(offenderCharge = offenderCharge)
+                      term(days = 35, sentenceTermType = "IMP")
+                    }
+                  }
 
                   fixedTermRecall(staff = staff)
                 }
@@ -10527,7 +10547,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           request = UpdateRecallRequest(
             returnToCustody = null,
             beachCourtEventIds = listOf(breachCourtEvent.id, breachCourtEventFromRemovedCase.id),
-            recallRevocationDate = LocalDate.parse("2023-06-06"),
+            recallRevocationDate = recallRevocationDate,
             sentences = listOf(
               RecallRelatedSentenceDetails(
                 SentenceId(offenderBookingId = booking.bookingId, sentenceSequence = sentence1.id.sequence),
@@ -10541,6 +10561,12 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                 sentenceCalcType = "LR",
                 // no sure this will ever happen, but lets test it just in case
                 active = false,
+              ),
+              RecallRelatedSentenceDetails(
+                SentenceId(offenderBookingId = booking.bookingId, sentenceSequence = sentenceToBeAddedToRecall.id.sequence),
+                sentenceCategory = "2020",
+                sentenceCalcType = "LR",
+                active = true,
               ),
             ),
             sentencesRemoved = listOf(
@@ -10587,6 +10613,31 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
               assertThat(calculationType.isRecallSentence()).isTrue
               assertThat(calculationType.description).isEqualTo("Licence Recall")
               assertThat(status).isEqualTo("I")
+            }
+          }
+        }
+
+        @Test
+        fun `will update newly added sentence to recall`() {
+          nomisDataBuilder.runInTransaction {
+            with(offenderSentenceRepository.findById(sentenceToBeAddedToRecall.id).orElseThrow()) {
+              assertThat(calculationType.isRecallSentence()).isFalse
+              assertThat(calculationType.description).isEqualTo("Sentencing Code Standard Determinate Sentence")
+            }
+          }
+
+          webTestClient.put()
+            .uri("/prisoners/${prisoner.nomsId}/sentences/recall")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(request))
+            .exchange()
+            .expectStatus().isOk
+
+          nomisDataBuilder.runInTransaction {
+            with(offenderSentenceRepository.findById(sentenceToBeAddedToRecall.id).orElseThrow()) {
+              assertThat(calculationType.isRecallSentence()).isTrue
+              assertThat(calculationType.description).isEqualTo("Licence Recall")
             }
           }
         }
@@ -10666,6 +10717,35 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         }
 
         @Test
+        fun `will create breach court appearance for each new court case added`() {
+          nomisDataBuilder.runInTransaction {
+            with(courtCaseRepository.findById(caseToBeAddedToRecall.id).orElseThrow()) {
+              assertThat(this.courtEvents).hasSize(1)
+            }
+          }
+
+          webTestClient.put()
+            .uri("/prisoners/${prisoner.nomsId}/sentences/recall")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(request))
+            .exchange()
+            .expectStatus().isOk
+
+          nomisDataBuilder.runInTransaction {
+            with(courtCaseRepository.findById(caseToBeAddedToRecall.id).orElseThrow()) {
+              assertThat(this.courtEvents).hasSize(2)
+              with(this.courtEvents.first { it.eventDate == recallRevocationDate }) {
+                assertThat(eventDate).isEqualTo(recallRevocationDate)
+                assertThat(courtEventType.code).isEqualTo("BREACH")
+                assertThat(outcomeReasonCode?.code).isEqualTo("1501")
+                assertThat(courtEventCharges).hasSize(1)
+              }
+            }
+          }
+        }
+
+        @Test
         fun `will remove custody data when absent`() {
           assertThat(offenderFixedTermRecallRepository.findById(booking.bookingId)).isPresent
 
@@ -10738,14 +10818,30 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             eq("recall-sentences-updated"),
             check {
               assertThat(it["bookingId"]).isEqualTo(booking.bookingId.toString())
-              assertThat(it["sentenceSequences"]).isEqualTo("${sentence1.id.sequence}, ${sentence2.id.sequence}")
+              assertThat(it["sentenceSequences"]).isEqualTo("${sentence1.id.sequence}, ${sentence2.id.sequence}, ${sentenceToBeAddedToRecall.id.sequence}")
               assertThat(it["offenderNo"]).isEqualTo(prisoner.nomsId)
               assertThat(it["breachCourtEventIds"]).isEqualTo("${breachCourtEvent.id}, ${breachCourtEventFromRemovedCase.id}")
               assertThat(it["removedBreachCourtEventIds"]).isEqualTo("${breachCourtEventFromRemovedCase.id}")
               assertThat(it["removedSentenceSequences"]).isEqualTo("${sentenceRemovedFromRecall.id.sequence}")
+              assertThat(it["createdBreachCourtEventIds"]).isNotEmpty
             },
             isNull(),
           )
+        }
+
+        @Test
+        fun `will return information about the breach court appearances`() {
+          val response: UpdateRecallResponse = webTestClient.put()
+            .uri("/prisoners/${prisoner.nomsId}/sentences/recall")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(request))
+            .exchange()
+            .expectStatus().isOk.expectBodyResponse()
+
+          assertThat(response.updatedCourtEventIds).isEqualTo(listOf(breachCourtEvent.id))
+          assertThat(response.deletedCourtEventIds).isEqualTo(listOf(breachCourtEventFromRemovedCase.id))
+          assertThat(response.createdCourtEventIds).hasSize(1)
         }
       }
     }


### PR DESCRIPTION
When a recall is updated new sentences (and therefore cases) can be added to a recall and removed from a recall. We already deal with cases being removed but not new ones added.

For each cases added to a recall a breach court appearance/hearing is added.

The IDs of the court hearings are returned back to sync service to all mapping to be updated.