### PR TITLE
SDIT-3846 Fix bug where a charges is removed that was previously link…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -572,37 +572,37 @@ class CourtSentencingService(
     courtEventChargesToUpdate: List<CourtEventChargeRequest>,
     courtEvent: CourtEvent,
   ) {
-    val originalList = courtEvent.courtEventCharges
-    val newChargeList = mutableListOf<CourtEventCharge>()
-    courtEventChargesToUpdate.map { cecRequest ->
-      val resultCode = cecRequest.resultCode1?.let { lookupOffenceResultCode(it) }
-      courtEvent.courtEventCharges.firstOrNull { it.id.offenderCharge.id == cecRequest.offenderChargeId }
-        ?.let { existingCourtEventCharge ->
-          existingCourtEventCharge.resultCode1 = resultCode
-          existingCourtEventCharge.resultCode1Indicator = resultCode?.dispositionCode
-          newChargeList.add(existingCourtEventCharge)
-        } ?: let {
-        getOffenderCharge(cecRequest.offenderChargeId).let { offenderCharge ->
-          log.info("Adding charge ${offenderCharge.id} to appearance ${courtEvent.id} with result code ${resultCode?.code}\n  appearance outcome: ${courtEvent.outcomeReasonCode?.code}\n offenderCharge result code: ${offenderCharge.resultCode1?.code}")
-          newChargeList.add(
-            CourtEventCharge(
-              CourtEventChargeId(
-                courtEvent = courtEvent,
-                offenderCharge = offenderCharge,
-              ),
-              offenceDate = offenderCharge.offenceDate,
-              offenceEndDate = offenderCharge.offenceEndDate,
-              mostSeriousFlag = offenderCharge.mostSeriousFlag,
-              resultCode1 = resultCode,
-              resultCode1Indicator = resultCode?.dispositionCode,
+    val chargesToRemove = courtEvent.courtEventCharges.filter { charge ->
+      charge.id.offenderCharge.id !in courtEventChargesToUpdate.map { it.offenderChargeId }
+    }
+    // the linked transaction remains but no longer points at the court event charge, just the court event and offender charge
+    chargesToRemove.forEach { it.linkedCaseTransaction?.courtEventCharge = null }
+    courtEvent.courtEventCharges.removeAll(chargesToRemove)
+
+    courtEventChargesToUpdate.forEach { chargeRequest ->
+      val resultCode = chargeRequest.resultCode1?.let { lookupOffenceResultCode(it) }
+      val existingCourtEventCharge = courtEvent.courtEventCharges.firstOrNull { it.id.offenderCharge.id == chargeRequest.offenderChargeId }
+      if (existingCourtEventCharge != null) {
+        existingCourtEventCharge.resultCode1 = resultCode
+        existingCourtEventCharge.resultCode1Indicator = resultCode?.dispositionCode
+      } else {
+        val offenderCharge = getOffenderCharge(chargeRequest.offenderChargeId)
+        log.info("Adding charge ${offenderCharge.id} to appearance ${courtEvent.id} with result code ${resultCode?.code}\n  appearance outcome: ${courtEvent.outcomeReasonCode?.code}\n offenderCharge result code: ${offenderCharge.resultCode1?.code}")
+        courtEvent.courtEventCharges.add(
+          CourtEventCharge(
+            CourtEventChargeId(
+              courtEvent = courtEvent,
+              offenderCharge = offenderCharge,
             ),
-          )
-        }
+            offenceDate = offenderCharge.offenceDate,
+            offenceEndDate = offenderCharge.offenceEndDate,
+            mostSeriousFlag = offenderCharge.mostSeriousFlag,
+            resultCode1 = resultCode,
+            resultCode1Indicator = resultCode?.dispositionCode,
+          ),
+        )
       }
     }
-    log.info("Court event charges for appearance ${courtEvent.id}\noriginalList: $originalList\nnewList: $newChargeList")
-    courtEvent.courtEventCharges.clear()
-    courtEvent.courtEventCharges.addAll(newChargeList)
   }
 
   fun updateCourtAppearance(
@@ -725,21 +725,24 @@ class CourtSentencingService(
     offenderNo: String,
     eventId: Long,
   ): List<OffenderCharge> = courtCase.getOffenderChargesNotAssociatedWithCourtAppearances().also { orphanedOffenderCharges ->
-    orphanedOffenderCharges.forEach {
-      courtCase.offenderCharges.remove(it)
-      log.debug("Offender charge deleted: ${it.id}")
-      telemetryClient.trackEvent(
-        "offender-charge-deleted",
-        mapOf(
-          "courtCaseId" to courtCase.id.toString(),
-          "bookingId" to courtCase.offenderBooking.bookingId.toString(),
-          "offenderNo" to offenderNo,
-          "offenderChargeId" to it.id.toString(),
-          "courtEventId" to eventId.toString(),
-        ),
-        null,
-      )
-    }
+    orphanedOffenderCharges
+      // exclude where a linked case source still points to this charge
+      .filter { offenderChargeToRemove -> courtCase.sourceCombinedCases.none { sourceCase -> sourceCase.courtEvents.flatMap { it.courtEventCharges }.any { offenderChargeToRemove.id == it.id.offenderCharge.id } } }
+      .forEach {
+        courtCase.offenderCharges.remove(it)
+        log.debug("Offender charge deleted: ${it.id}")
+        telemetryClient.trackEvent(
+          "offender-charge-deleted",
+          mapOf(
+            "courtCaseId" to courtCase.id.toString(),
+            "bookingId" to courtCase.offenderBooking.bookingId.toString(),
+            "offenderNo" to offenderNo,
+            "offenderChargeId" to it.id.toString(),
+            "courtEventId" to eventId.toString(),
+          ),
+          null,
+        )
+      }
   }
 
   fun deleteCourtCase(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/LinkCaseTxn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/LinkCaseTxn.kt
@@ -37,14 +37,14 @@ data class LinkCaseTxn(
   @Column(name = "EVENT_ID")
   var courtEventId: Long,
 
-  @OneToOne(fetch = FetchType.LAZY, optional = false)
+  @OneToOne(fetch = FetchType.LAZY, optional = true)
   @JoinColumns(
     value = [
       JoinColumn(name = "OFFENDER_CHARGE_ID", referencedColumnName = "OFFENDER_CHARGE_ID", nullable = true, insertable = false, updatable = false),
       JoinColumn(name = "EVENT_ID", referencedColumnName = "EVENT_ID", nullable = true, insertable = false, updatable = false),
     ],
   )
-  var courtEventCharge: CourtEventCharge,
+  var courtEventCharge: CourtEventCharge?,
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "CASE_ID", nullable = false, insertable = false, updatable = false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -108,6 +108,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
 
   @AfterEach
   internal fun tearDown() {
+    repository.deleteAllOffenderLinkedTransactions()
     repository.deleteOffenders()
   }
 
@@ -5269,15 +5270,20 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
   inner class UpdateCourtAppearance {
     private val offenderNo: String = "A1234AB"
     private lateinit var courtCase: CourtCase
+    private lateinit var sourceLinkedCourtCase: CourtCase
+    private lateinit var targetLinkedCourtCase: CourtCase
     private lateinit var courtCaseBeingUpdatedWithChargeUpdate: CourtCase
     private lateinit var courtEvent: CourtEvent
     private lateinit var courtEvent2: CourtEvent
+    private lateinit var targetCaseEvent: CourtEvent
     private var latestBookingId: Long = 0
     private lateinit var offenderCharge1: OffenderCharge
     private lateinit var offenderCharge2: OffenderCharge
     private lateinit var offenderCharge3: OffenderCharge
     private lateinit var offenderCharge4: OffenderCharge
     private lateinit var offenderChargeAdjourned: OffenderCharge
+    private lateinit var offenderChargeInLinkedCase: OffenderCharge
+    private lateinit var linkedOffenderCharge: OffenderCharge
     private lateinit var order: CourtOrder
     private lateinit var courtEventAdjourned: CourtEvent
 
@@ -5348,6 +5354,38 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                 }
               }
             }
+
+            sourceLinkedCourtCase =
+              courtCase(
+                reportingStaff = staff,
+                caseSequence = 3,
+                caseStatus = "I",
+                statusUpdateReason = "LINKED",
+                caseInfoNumber = "LINKED-SOURCE",
+              ) {
+                linkedOffenderCharge = offenderCharge(offenceCode = "RT88074", resultCode1 = "4001")
+                courtEvent {
+                  courtEventCharge(
+                    offenderCharge = linkedOffenderCharge,
+                    plea = "NG",
+                  )
+                }
+              }
+
+            targetLinkedCourtCase = courtCase(
+              reportingStaff = staff,
+              caseSequence = 2,
+              caseInfoNumber = "LINKED-TARGET",
+            ) {
+              offenderChargeInLinkedCase = offenderCharge(offenceCode = "RR84700")
+              targetCaseEvent = courtEvent {
+                courtEventCharge(
+                  offenderCharge = offenderChargeInLinkedCase,
+                  plea = "NG",
+                )
+              }
+            }
+            linkCases(sourceCourtCase = sourceLinkedCourtCase, targetCourtCase = targetLinkedCourtCase, targetCourtEvent = targetCaseEvent)
           }
         }
       }
@@ -5739,10 +5777,49 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           isNull(),
         )
       }
+
+      @Test
+      fun `can remove charge that was source from linked case`() {
+        with(
+          webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-appearances/${targetCaseEvent.id}")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBodyResponse<CourtEventResponse>(),
+        ) {
+          assertThat(this.courtEventCharges).hasSize(2)
+        }
+
+        webTestClient.put()
+          .uri("/prisoners/$offenderNo/sentencing/court-cases/${targetLinkedCourtCase.id}/court-appearances/${targetCaseEvent.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+            createCourtAppearanceRequest(
+              outcomeReasonCode = "1004",
+              courtEventCharges = mutableListOf(
+                CourtEventChargeRequest(offenderChargeInLinkedCase.id, resultCode1 = "1004"),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        with(
+          webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-appearances/${targetCaseEvent.id}")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBodyResponse<CourtEventResponse>(),
+        ) {
+          assertThat(this.courtEventCharges).hasSize(1)
+        }
+      }
     }
 
     @AfterEach
     internal fun deletePrisoner() {
+      repository.deleteAllOffenderLinkedTransactions()
       repository.delete(prisonerAtMoorland)
       repository.deleteOffenderChargeByBooking(latestBookingId)
     }


### PR DESCRIPTION
…ed from a combined case

Two issued fixed:
1. if court_event_charge is deleted from a case and that case no longer points to that charge we correctly also delete the offender_charge. However, for a linked case there may be court_event_charge pointing at that offender_charge for the combined cases making deletion impossible. This checks if any linked case is also referencing the offender_charge before deciding to delete the offender_charge
2. LinkCaseTxn was modelled incorrectly; it assumed it would always point at CourtEventCharge. This was incorrect. You can delete the court_event_charge record, but the LINK_CASE_TXNS record still remains in NOMIS. So the fix is to make the reference nullable and to set it to null when the associated courtEventCharge is being removed.