### PR TITLE
SDIT-3865 Changed orphaned offender charges detection

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -724,7 +724,7 @@ class CourtSentencingService(
     courtCase: CourtCase,
     offenderNo: String,
     eventId: Long,
-  ): List<OffenderCharge> = courtCase.getOffenderChargesNotAssociatedWithCaseOrLinkedCasesCourtAppearances().also { orphanedOffenderCharges ->
+  ): List<OffenderCharge> = courtCase.getOffenderChargesNotAssociatedWithThisCaseOrAnyOtherCases().also { orphanedOffenderCharges ->
     orphanedOffenderCharges
       .forEach {
         courtCase.offenderCharges.remove(it)
@@ -2096,6 +2096,19 @@ class CourtSentencingService(
       },
     )
   }
+
+  private fun CourtCase.getOffenderChargesNotAssociatedWithThisCaseOrAnyOtherCases(): List<OffenderCharge> {
+    val referencedOffenderCharges =
+      this.courtEvents.flatMap { courtEvent -> courtEvent.courtEventCharges.map { it.id.offenderCharge } }.toSet()
+    return this.offenderCharges
+      .filterNot { oc -> referencedOffenderCharges.contains(oc) }
+      .filterNot { oc ->
+        courtEventChargeRepository.existsByIdOffenderChargeIdAndIdCourtEventCourtCaseNot(
+          offenderChargeId = oc.id,
+          courtCase = this,
+        )
+      }
+  }
 }
 
 private fun OffenderChargeRequest.toExistingOffenderChargeRequest(chargeId: Long): ExistingOffenderChargeRequest = ExistingOffenderChargeRequest(
@@ -2105,14 +2118,6 @@ private fun OffenderChargeRequest.toExistingOffenderChargeRequest(chargeId: Long
   resultCode1 = this.resultCode1,
   offenderChargeId = chargeId,
 )
-
-private fun CourtCase.getOffenderChargesNotAssociatedWithCaseOrLinkedCasesCourtAppearances(): List<OffenderCharge> {
-  val referencedOffenderCharges =
-    this.courtEvents.flatMap { courtEvent -> courtEvent.courtEventCharges.map { it.id.offenderCharge } }.toSet()
-  return this.offenderCharges.filterNot { oc -> referencedOffenderCharges.contains(oc) }
-    // exclude where a linked case source still points to this charge
-    .filter { offenderChargeToRemove -> sourceCombinedCases.none { sourceCase -> sourceCase.courtEvents.flatMap { it.courtEventCharges }.any { offenderChargeToRemove.id == it.id.offenderCharge.id } } }
-}
 
 private fun CourtCase.toCourtCaseResponse(): CourtCaseResponse = CourtCaseResponse(
   id = this.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
@@ -2,10 +2,13 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtCase
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEventCharge
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEventChargeId
 
 @Repository
 interface CourtEventChargeRepository : JpaRepository<CourtEventCharge, CourtEventChargeId> {
   fun findFirstByIdOffenderChargeIdOrderByLastModifiedDateTimeDesc(offenderChargeId: Long): CourtEventCharge?
+
+  fun existsByIdOffenderChargeIdAndIdCourtEventCourtCaseNot(offenderChargeId: Long, courtCase: CourtCase): Boolean
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -5779,7 +5779,55 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
-      fun `can remove charge that was source from linked case`() {
+      fun `can remove charge that was sourced from linked case`() {
+        with(
+          webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-appearances/${targetCaseEvent.id}")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBodyResponse<CourtEventResponse>(),
+        ) {
+          assertThat(this.courtEventCharges).hasSize(2)
+        }
+
+        val courtAppearanceUpdateResponse: UpdateCourtAppearanceResponse = webTestClient.put()
+          .uri("/prisoners/$offenderNo/sentencing/court-cases/${targetLinkedCourtCase.id}/court-appearances/${targetCaseEvent.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+            createCourtAppearanceRequest(
+              outcomeReasonCode = "1004",
+              courtEventCharges = mutableListOf(
+                CourtEventChargeRequest(offenderChargeInLinkedCase.id, resultCode1 = "1004"),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk.expectBodyResponse()
+
+        // no offender charges deleted since they will still be linked by other cases
+        assertThat(courtAppearanceUpdateResponse.deletedOffenderChargesIds).isEmpty()
+
+        with(
+          webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-appearances/${targetCaseEvent.id}")
+            .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+            .exchange()
+            .expectStatus().isOk
+            .expectBodyResponse<CourtEventResponse>(),
+        ) {
+          assertThat(this.courtEventCharges).hasSize(1)
+        }
+      }
+
+      @Test
+      fun `can remove charge that was sourced from linked case that is no longer linked`() {
+        // unlink case - but charge is still on both cases
+        nomisDataBuilder.runInTransaction {
+          courtCaseRepository.findByIdOrNull(sourceLinkedCourtCase.id)!!.run {
+            targetCombinedCase = null
+          }
+        }
+
         with(
           webTestClient.get().uri("/prisoners/$offenderNo/sentencing/court-appearances/${targetCaseEvent.id}")
             .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))


### PR DESCRIPTION
Fix bug where a charges is removed that was previously linked from a combined case that itself was previously later unlinked but the charge is still referenced by both cases