### PR TITLE
SDIT-3986 Allow create court movement out with provided eventId

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtEvent.kt
@@ -5,12 +5,10 @@ import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.JoinColumnOrFormula
@@ -25,14 +23,9 @@ import java.time.LocalDateTime
 @Table(name = "COURT_EVENTS")
 @EntityOpen
 class CourtEvent(
-  @SequenceGenerator(
-    name = "EVENT_ID",
-    sequenceName = "EVENT_ID",
-    allocationSize = 1,
-  )
-  @GeneratedValue(generator = "EVENT_ID")
   @Id
   @Column(name = "EVENT_ID")
+  @SequenceOrUseId(name = "EVENT_ID")
   val id: Long = 0,
 
   @Column(name = "PARENT_EVENT_ID")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleResource.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.ErrorResponse
@@ -121,7 +122,10 @@ class CourtScheduleResource(
     offenderNo: String,
     @RequestBody @Valid
     request: UpsertCourtScheduleOut,
-  ): UpsertCourtScheduleOutResponse = service.upsertCourtScheduleOut(offenderNo, request)
+    @Schema(description = "Recreate the court schedule out with the same event ID. This either creates a new court schedule out or overwrites the existing one if it exists.")
+    @RequestParam
+    recreate: Boolean = false,
+  ): UpsertCourtScheduleOutResponse = service.upsertCourtScheduleOut(offenderNo, request, recreate)
 
   @DeleteMapping("/out/{eventId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.audit.Audit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
@@ -45,7 +46,13 @@ class CourtScheduleService(
 
   @Transactional
   @Audit(auditModule = "DPS_COURT_SCHEDULER_SYNCHRONISATION")
-  fun upsertCourtScheduleOut(offenderNo: String, request: UpsertCourtScheduleOut): UpsertCourtScheduleOutResponse {
+  fun upsertCourtScheduleOut(
+    offenderNo: String,
+    request: UpsertCourtScheduleOut,
+    recreate: Boolean,
+  ): UpsertCourtScheduleOutResponse {
+    if (recreate && request.eventId == null) throw BadDataException("Cannot recreate a court schedule out without an eventId")
+
     val offenderBooking = movementHelpers.offenderBookingOrThrow(offenderNo)
     val courtEventType = movementHelpers.movementReasonOrThrow(request.eventType)
     val eventStatus = movementHelpers.eventStatusOrThrow(request.eventStatus)
@@ -54,6 +61,7 @@ class CourtScheduleService(
     val court = movementHelpers.agencyLocationOrThrow(request.court)
 
     val scheduleOut = request.eventId
+      ?.takeIf { !recreate }
       ?.let { courtEventRepository.findById(it).get() }
       ?. apply {
         this.setEventDateAndTime(request.startTime)
@@ -63,6 +71,7 @@ class CourtScheduleService(
         this.court = court
       }
       ?: CourtEvent(
+        id = if (recreate) request.eventId!! else 0,
         offenderBooking = offenderBooking,
         eventDate = request.startTime.toLocalDate(),
         startTime = request.startTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtScheduleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtScheduleResourceIntTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtCase
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Offender
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderCourtMovementOut
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Staff
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtEventRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.MovementHelpers.Companion.MAX_COURT_SCHEDULER_COMMENT_LENGTH
@@ -37,6 +38,7 @@ class CourtScheduleResourceIntTest(
   private lateinit var offender: Offender
   private lateinit var booking: OffenderBooking
   private lateinit var scheduleOut: CourtEvent
+  private lateinit var movementOut: OffenderCourtMovementOut
   private lateinit var scheduleIn: CourtEvent
   private lateinit var staff: Staff
   private lateinit var courtCase: CourtCase
@@ -318,6 +320,57 @@ class CourtScheduleResourceIntTest(
     }
 
     @Nested
+    inner class Recreate {
+      @BeforeEach
+      fun setUp() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEventOut {
+                movementOut = courtMovementOut()
+              }
+              scheduleIn = courtEventOut(eventDateTime = LocalDateTime.now().minusHours(1))
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          entityManager.createNativeQuery(
+            """
+              delete from COURT_EVENTS where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+      }
+
+      @Test
+      fun `should create court schedule out with the same event ID as deleted`() {
+        webTestClient.upsertCourtScheduleOutOk(request = aRequest(eventId = scheduleOut.id), recreate = true)
+          .apply {
+            assertThat(bookingId).isEqualTo(booking.bookingId)
+            assertThat(eventId).isEqualTo(scheduleOut.id)
+            repository.runInTransaction {
+              with(courtEventRepository.findByIdOrNull(eventId)!!) {
+                assertThat(directionCode?.code).isEqualTo("OUT")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should handle further requests to recreate with the same event ID (maintains idempotency)`() {
+        webTestClient.upsertCourtScheduleOutOk(request = aRequest(eventId = scheduleOut.id), recreate = true)
+        webTestClient.upsertCourtScheduleOutOk(request = aRequest(eventId = scheduleOut.id), recreate = true)
+      }
+
+      @Test
+      fun `should error if we try to recreate without an event ID`() {
+        webTestClient.upsertCourtScheduleOut(request = aRequest(eventId = null), recreate = true)
+          .isBadRequest
+      }
+    }
+
+    @Nested
     inner class Update {
       @BeforeEach
       fun setUp() {
@@ -530,15 +583,21 @@ class CourtScheduleResourceIntTest(
 
     private fun WebTestClient.upsertCourtScheduleOutOk(
       request: UpsertCourtScheduleOut = aRequest(),
-    ) = upsertCourtScheduleOut(request)
+      recreate: Boolean = false,
+    ) = upsertCourtScheduleOut(request, recreate = recreate)
       .isOk
       .expectBodyResponse<UpsertCourtScheduleOutResponse>()
 
     private fun WebTestClient.upsertCourtScheduleOut(
       request: UpsertCourtScheduleOut = aRequest(),
       offenderNo: String = offender.nomsId,
+      recreate: Boolean = false,
     ) = put()
-      .uri("/movements/$offenderNo/court/schedule/out")
+      .uri {
+        it.path("/movements/$offenderNo/court/schedule/out")
+          .queryParam("recreate", recreate)
+          .build()
+      }
       .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
       .bodyValue(request)
       .exchange()


### PR DESCRIPTION
When upserting a court movement out, take the id from the request if we specify query parameter "recreate=true". This is to support a scenario where we need to recreate a NOMIS court event that was previously deleted.