### PR TITLE
Sdit 3977 agency location mapping

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
@@ -174,6 +174,8 @@ data class PrisonResponse(
   val active: Boolean,
   @Schema(description = "Date no longer active", example = "2020-01-01")
   val deactivationDate: LocalDate?,
+  @Schema(description = "Indicates if data is allowed to be updated", example = "true")
+  val updateAllowed: Boolean,
 )
 
 data class AgencyResponse(
@@ -189,6 +191,8 @@ data class AgencyResponse(
   val active: Boolean,
   @Schema(description = "Date no longer active", example = "2020-01-01")
   val deactivationDate: LocalDate?,
+  @Schema(description = "Indicates if data is allowed to be updated", example = "true")
+  val updateAllowed: Boolean,
 )
 
 data class AgencyLocationResponse(
@@ -202,4 +206,6 @@ data class AgencyLocationResponse(
   val active: Boolean,
   @Schema(description = "Date no longer active", example = "2020-01-01")
   val deactivationDate: LocalDate?,
+  @Schema(description = "Indicates if data is allowed to be updated", example = "true")
+  val updateAllowed: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
@@ -197,6 +197,9 @@ data class AgencyResponse(
   val updateAllowed: Boolean,
   @Schema(description = "Name of contact at agency", example = "John Smith")
   val contactName: String?,
+  // maybe move this to court sub entity in future
+  @Schema(description = "Court type")
+  val courtType: CodeDescription?,
 )
 
 data class AgencyLocationResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResource.kt
@@ -176,6 +176,8 @@ data class PrisonResponse(
   val deactivationDate: LocalDate?,
   @Schema(description = "Indicates if data is allowed to be updated", example = "true")
   val updateAllowed: Boolean,
+  @Schema(description = "Name of contact at agency", example = "John Smith")
+  val contactName: String?,
 )
 
 data class AgencyResponse(
@@ -193,6 +195,8 @@ data class AgencyResponse(
   val deactivationDate: LocalDate?,
   @Schema(description = "Indicates if data is allowed to be updated", example = "true")
   val updateAllowed: Boolean,
+  @Schema(description = "Name of contact at agency", example = "John Smith")
+  val contactName: String?,
 )
 
 data class AgencyLocationResponse(
@@ -208,4 +212,6 @@ data class AgencyLocationResponse(
   val deactivationDate: LocalDate?,
   @Schema(description = "Indicates if data is allowed to be updated", example = "true")
   val updateAllowed: Boolean,
+  @Schema(description = "Name of contact at agency", example = "John Smith")
+  val contactName: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
@@ -34,6 +34,7 @@ fun Prison.toPrisonResponse() = PrisonResponse(
   district = this.district?.toCodeDescription(),
   active = this.active,
   deactivationDate = this.deactivationDate,
+  updateAllowed = this.updateAllowed,
 )
 
 fun Agency.toAgencyResponse() = AgencyResponse(
@@ -43,6 +44,7 @@ fun Agency.toAgencyResponse() = AgencyResponse(
   active = this.active,
   deactivationDate = this.deactivationDate,
   type = this.type.toCodeDescription(),
+  updateAllowed = this.updateAllowed,
 )
 
 fun AgencyLocation.toAgencyLocationResponse() = AgencyLocationResponse(
@@ -51,4 +53,5 @@ fun AgencyLocation.toAgencyLocationResponse() = AgencyLocationResponse(
   active = this.active,
   deactivationDate = this.deactivationDate,
   type = this.type.toCodeDescription(),
+  updateAllowed = this.updateAllowed,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
@@ -35,6 +35,7 @@ fun Prison.toPrisonResponse() = PrisonResponse(
   active = this.active,
   deactivationDate = this.deactivationDate,
   updateAllowed = this.updateAllowed,
+  contactName = this.contactName,
 )
 
 fun Agency.toAgencyResponse() = AgencyResponse(
@@ -45,6 +46,7 @@ fun Agency.toAgencyResponse() = AgencyResponse(
   deactivationDate = this.deactivationDate,
   type = this.type.toCodeDescription(),
   updateAllowed = this.updateAllowed,
+  contactName = this.contactName,
 )
 
 fun AgencyLocation.toAgencyLocationResponse() = AgencyLocationResponse(
@@ -54,4 +56,5 @@ fun AgencyLocation.toAgencyLocationResponse() = AgencyLocationResponse(
   deactivationDate = this.deactivationDate,
   type = this.type.toCodeDescription(),
   updateAllowed = this.updateAllowed,
+  contactName = this.contactName,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyService.kt
@@ -47,6 +47,7 @@ fun Agency.toAgencyResponse() = AgencyResponse(
   type = this.type.toCodeDescription(),
   updateAllowed = this.updateAllowed,
   contactName = this.contactName,
+  courtType = this.courtType?.toCodeDescription(),
 )
 
 fun AgencyLocation.toAgencyLocationResponse() = AgencyLocationResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
@@ -43,7 +43,7 @@ class AgencyLocation(
   val id: String,
 
   @Column(name = "DESCRIPTION")
-  val description: String,
+  var description: String,
 
   @ManyToOne(fetch = LAZY)
   @JoinColumnsOrFormulas(
@@ -66,10 +66,10 @@ class AgencyLocation(
 
   @Column(name = "ACTIVE_FLAG")
   @Convert(converter = YesNoConverter::class)
-  val active: Boolean = false,
+  var active: Boolean = false,
 
   @Column(name = "DEACTIVATION_DATE")
-  val deactivationDate: LocalDate? = null,
+  var deactivationDate: LocalDate? = null,
 
   @OneToMany(mappedBy = "agencyLocation", cascade = [CascadeType.ALL], fetch = LAZY)
   @SQLRestriction("OWNER_CLASS = '${AgencyLocationAddress.ADDR_TYPE}'")
@@ -77,11 +77,33 @@ class AgencyLocation(
 
   @Column(name = "UPDATED_ALLOWED_FLAG")
   @Convert(converter = YesNoConverter::class)
-  val updateAllowed: Boolean = true,
+  var updateAllowed: Boolean = true,
 
-  // ABBREVIATION = all null
+  // ABBREVIATION: all null
   @Column(name = "CONTACT_NAME")
-  val contactName: String? = null,
+  var contactName: String? = null,
+
+  // PRINT_QUEUE: all null
+
+  // `OUT` also has a court type, but maybe move to a Court entity later
+  @ManyToOne(fetch = LAZY)
+  @JoinColumnsOrFormulas(
+    value = [
+      JoinColumnOrFormula(
+        formula = JoinFormula(
+          value = "'" + CourtType.JURISDICTION + "'",
+          referencedColumnName = "domain",
+        ),
+      ), JoinColumnOrFormula(
+        column = JoinColumn(
+          name = "JURISDICTION_CODE",
+          referencedColumnName = "code",
+          nullable = true,
+        ),
+      ),
+    ],
+  )
+  var courtType: CourtType? = null,
 ) {
 
   override fun equals(other: Any?): Boolean {
@@ -109,6 +131,7 @@ class Prison(
   deactivationDate: LocalDate?,
   updateAllowed: Boolean,
   contactName: String?,
+  courtType: CourtType?,
 
   // FD (for OUT and TRN) not in reference data, so ignore if not found
   @NotFound(action = NotFoundAction.IGNORE)
@@ -140,6 +163,7 @@ class Prison(
   deactivationDate = deactivationDate,
   updateAllowed = updateAllowed,
   contactName = contactName,
+  courtType = courtType,
 )
 
 @Entity
@@ -151,6 +175,7 @@ class Agency(
   deactivationDate: LocalDate?,
   updateAllowed: Boolean,
   contactName: String?,
+  courtType: CourtType?,
 
   @ManyToOne(fetch = LAZY)
   @JoinColumnsOrFormulas(
@@ -180,4 +205,5 @@ class Agency(
   deactivationDate = deactivationDate,
   updateAllowed = updateAllowed,
   contactName = contactName,
+  courtType = courtType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
@@ -75,6 +75,10 @@ class AgencyLocation(
   @SQLRestriction("OWNER_CLASS = '${AgencyLocationAddress.ADDR_TYPE}'")
   val addresses: MutableList<AgencyLocationAddress> = mutableListOf(),
 
+  @Column(name = "UPDATED_ALLOWED_FLAG")
+  @Convert(converter = YesNoConverter::class)
+  val updateAllowed: Boolean = true,
+
 ) {
 
   override fun equals(other: Any?): Boolean {
@@ -100,6 +104,7 @@ class Prison(
   type: AgencyLocationType,
   active: Boolean,
   deactivationDate: LocalDate?,
+  updateAllowed: Boolean,
 
   // FD (for OUT and TRN) not in reference data, so ignore if not found
   @NotFound(action = NotFoundAction.IGNORE)
@@ -129,6 +134,7 @@ class Prison(
   type = type,
   active = active,
   deactivationDate = deactivationDate,
+  updateAllowed = updateAllowed,
 )
 
 @Entity
@@ -138,6 +144,7 @@ class Agency(
   type: AgencyLocationType,
   active: Boolean,
   deactivationDate: LocalDate?,
+  updateAllowed: Boolean,
 
   @ManyToOne(fetch = LAZY)
   @JoinColumnsOrFormulas(
@@ -165,4 +172,5 @@ class Agency(
   type = type,
   active = active,
   deactivationDate = deactivationDate,
+  updateAllowed = updateAllowed,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/AgencyLocation.kt
@@ -79,6 +79,9 @@ class AgencyLocation(
   @Convert(converter = YesNoConverter::class)
   val updateAllowed: Boolean = true,
 
+  // ABBREVIATION = all null
+  @Column(name = "CONTACT_NAME")
+  val contactName: String? = null,
 ) {
 
   override fun equals(other: Any?): Boolean {
@@ -105,6 +108,7 @@ class Prison(
   active: Boolean,
   deactivationDate: LocalDate?,
   updateAllowed: Boolean,
+  contactName: String?,
 
   // FD (for OUT and TRN) not in reference data, so ignore if not found
   @NotFound(action = NotFoundAction.IGNORE)
@@ -135,6 +139,7 @@ class Prison(
   active = active,
   deactivationDate = deactivationDate,
   updateAllowed = updateAllowed,
+  contactName = contactName,
 )
 
 @Entity
@@ -145,6 +150,7 @@ class Agency(
   active: Boolean,
   deactivationDate: LocalDate?,
   updateAllowed: Boolean,
+  contactName: String?,
 
   @ManyToOne(fetch = LAZY)
   @JoinColumnsOrFormulas(
@@ -173,4 +179,5 @@ class Agency(
   active = active,
   deactivationDate = deactivationDate,
   updateAllowed = updateAllowed,
+  contactName = contactName,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/CourtType.kt
@@ -5,10 +5,10 @@ import jakarta.persistence.Entity
 
 @Entity
 @DiscriminatorValue(CourtType.JURISDICTION)
-class CourtType : ReferenceCode {
-  constructor(code: String, description: String) : super(JURISDICTION, code, description)
+class CourtType(code: String, description: String) : ReferenceCode(JURISDICTION, code, description) {
 
   companion object {
     const val JURISDICTION = "JURISDICTION"
+    fun pk(code: String): Pk = Pk(JURISDICTION, code)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
@@ -37,9 +37,25 @@ class AgencyResourceIntTest : IntegrationTestBase() {
     @BeforeEach
     fun setUp() {
       nomisDataBuilder.build {
-        legacyGenericAgency = agencyLocation(agencyLocationId = "XXI", description = "HMP XXI", type = "INST")
-        prison = prison(agencyLocationId = "AAI", description = "HMP AAI", districtCode = "LONDON")
-        approvedPremise = agency(agencyLocationId = "THA029", description = "Approved Premises", districtCode = "40", active = false, type = "APPR", deactivationDate = LocalDate.parse("2022-01-01"))
+        legacyGenericAgency = agencyLocation(
+          agencyLocationId = "XXI",
+          description = "HMP XXI",
+          type = "INST",
+        )
+        prison = prison(
+          agencyLocationId = "AAI",
+          description = "HMP AAI",
+          districtCode = "LONDON",
+        )
+        approvedPremise = agency(
+          agencyLocationId = "THA029",
+          description = "Approved Premises",
+          districtCode = "40",
+          active = false,
+          type = "APPR",
+          deactivationDate = LocalDate.parse("2022-01-01"),
+          updateAllowed = false,
+        )
       }
     }
 
@@ -102,6 +118,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(prison.district?.description).isEqualTo("London")
         assertThat(prison.active).isTrue
         assertThat(prison.deactivationDate).isNull()
+        assertThat(prison.updateAllowed).isTrue
       }
 
       @Test
@@ -115,6 +132,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.description).isEqualTo("HMP AAI")
         assertThat(agency.active).isTrue
         assertThat(agency.deactivationDate).isNull()
+        assertThat(agency.updateAllowed).isTrue
       }
 
       @Test
@@ -129,6 +147,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.type.description).isEqualTo("Approved Premises")
         assertThat(agency.active).isFalse
         assertThat(agency.deactivationDate).isEqualTo(LocalDate.parse("2022-01-01"))
+        assertThat(agency.updateAllowed).isFalse
       }
 
       @Test
@@ -144,6 +163,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.type.description).isEqualTo("Approved Premises")
         assertThat(agency.active).isFalse
         assertThat(agency.deactivationDate).isEqualTo(LocalDate.parse("2022-01-01"))
+        assertThat(agency.updateAllowed).isFalse
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
@@ -32,6 +32,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
   inner class GetPrison {
     lateinit var legacyGenericAgency: AgencyLocation
     lateinit var approvedPremise: Agency
+    lateinit var court: Agency
     lateinit var prison: Prison
 
     @BeforeEach
@@ -57,6 +58,12 @@ class AgencyResourceIntTest : IntegrationTestBase() {
           updateAllowed = false,
           contactName = "Gerald Simpson",
         )
+        court = agency(
+          agencyLocationId = "SHEFCC",
+          description = "Sheffield Crown Court",
+          type = "CRT",
+          courtTypeCode = "CC",
+        )
       }
     }
 
@@ -64,6 +71,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
     fun tearDown() {
       agencyLocationRepository.deleteById(legacyGenericAgency.id)
       agencyRepository.delete(approvedPremise)
+      agencyRepository.delete(court)
       prisonRepository.delete(prison)
     }
 
@@ -169,6 +177,18 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.deactivationDate).isEqualTo(LocalDate.parse("2022-01-01"))
         assertThat(agency.updateAllowed).isFalse
         assertThat(agency.contactName).isEqualTo("Gerald Simpson")
+      }
+
+      @Test
+      fun `will return details for a court`() {
+        val agency: AgencyResponse = webTestClient.get().uri("/agency/SHEFCC")
+          .headers(setAuthorisation(roles = listOf("NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .exchange()
+          .expectBodyResponse()
+
+        assertThat(agency.agencyId).isEqualTo("SHEFCC")
+        assertThat(agency.description).isEqualTo("Sheffield Crown Court")
+        assertThat(agency.courtType?.description).isEqualTo("Crown Court")
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/agency/AgencyResourceIntTest.kt
@@ -55,6 +55,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
           type = "APPR",
           deactivationDate = LocalDate.parse("2022-01-01"),
           updateAllowed = false,
+          contactName = "Gerald Simpson",
         )
       }
     }
@@ -119,6 +120,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(prison.active).isTrue
         assertThat(prison.deactivationDate).isNull()
         assertThat(prison.updateAllowed).isTrue
+        assertThat(prison.contactName).isNull()
       }
 
       @Test
@@ -133,6 +135,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.active).isTrue
         assertThat(agency.deactivationDate).isNull()
         assertThat(agency.updateAllowed).isTrue
+        assertThat(agency.contactName).isNull()
       }
 
       @Test
@@ -148,6 +151,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.active).isFalse
         assertThat(agency.deactivationDate).isEqualTo(LocalDate.parse("2022-01-01"))
         assertThat(agency.updateAllowed).isFalse
+        assertThat(agency.contactName).isEqualTo("Gerald Simpson")
       }
 
       @Test
@@ -164,6 +168,7 @@ class AgencyResourceIntTest : IntegrationTestBase() {
         assertThat(agency.active).isFalse
         assertThat(agency.deactivationDate).isEqualTo(LocalDate.parse("2022-01-01"))
         assertThat(agency.updateAllowed).isFalse
+        assertThat(agency.contactName).isEqualTo("Gerald Simpson")
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
@@ -85,6 +85,7 @@ class AgencyLocationBuilder(
     active: Boolean,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
   ): AgencyLocation = AgencyLocation(
     id = id,
     description = description,
@@ -92,6 +93,7 @@ class AgencyLocationBuilder(
     active = active,
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
+    contactName = contactName,
   )
     .let { repository.save(it) }
     .also { agencyLocation = it }
@@ -104,6 +106,7 @@ class AgencyLocationBuilder(
     districtCode: String?,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
   ): Agency = Agency(
     id = id,
     description = description,
@@ -112,6 +115,7 @@ class AgencyLocationBuilder(
     district = repository.areaOf(districtCode),
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
+    contactName = contactName,
   )
     .let { repository.saveAgency(it) }
     .also { agencyLocation = it }
@@ -124,6 +128,7 @@ class AgencyLocationBuilder(
     districtCode: String?,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
   ): Prison = Prison(
     id = id,
     description = description,
@@ -132,6 +137,7 @@ class AgencyLocationBuilder(
     district = repository.geographicOf(districtCode),
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
+    contactName = contactName,
   )
     .let { repository.savePrison(it) }
     .also { agencyLocation = it }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
@@ -84,12 +84,14 @@ class AgencyLocationBuilder(
     type: String,
     active: Boolean,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
   ): AgencyLocation = AgencyLocation(
     id = id,
     description = description,
     type = repository.agencyTypeOf(type),
     active = active,
     deactivationDate = deactivationDate,
+    updateAllowed = updateAllowed,
   )
     .let { repository.save(it) }
     .also { agencyLocation = it }
@@ -101,6 +103,7 @@ class AgencyLocationBuilder(
     active: Boolean,
     districtCode: String?,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
   ): Agency = Agency(
     id = id,
     description = description,
@@ -108,6 +111,7 @@ class AgencyLocationBuilder(
     active = active,
     district = repository.areaOf(districtCode),
     deactivationDate = deactivationDate,
+    updateAllowed = updateAllowed,
   )
     .let { repository.saveAgency(it) }
     .also { agencyLocation = it }
@@ -119,6 +123,7 @@ class AgencyLocationBuilder(
     active: Boolean,
     districtCode: String?,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
   ): Prison = Prison(
     id = id,
     description = description,
@@ -126,6 +131,7 @@ class AgencyLocationBuilder(
     active = active,
     district = repository.geographicOf(districtCode),
     deactivationDate = deactivationDate,
+    updateAllowed = updateAllowed,
   )
     .let { repository.savePrison(it) }
     .also { agencyLocation = it }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/AgencyLocation.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AreaType
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.GeographicType
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Prison
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocationRepository
@@ -55,6 +56,7 @@ class AgencyLocationBuilderRepository(
   private val agencyTypeRepository: ReferenceCodeRepository<AgencyLocationType>,
   private val areaTypeRepository: ReferenceCodeRepository<AreaType>,
   private val geographicTypeRepository: ReferenceCodeRepository<GeographicType>,
+  private val courtTypeRepository: ReferenceCodeRepository<CourtType>,
 ) {
   fun save(agencyLocation: AgencyLocation): AgencyLocation = agencyLocationRepository.saveAndFlush(agencyLocation)
   fun saveAgency(agency: Agency): Agency = agencyRepository.saveAndFlush(agency)
@@ -62,6 +64,7 @@ class AgencyLocationBuilderRepository(
   fun agencyTypeOf(code: String): AgencyLocationType = agencyTypeRepository.findByIdOrNull(AgencyLocationType.pk(code))!!
   fun areaOf(code: String?): AreaType? = code?.let { areaTypeRepository.findByIdOrNull(AreaType.pk(code)) }
   fun geographicOf(code: String?): GeographicType? = code?.let { geographicTypeRepository.findByIdOrNull(GeographicType.pk(code)) }
+  fun courtTypeOf(code: String?): CourtType? = code?.let { courtTypeRepository.findByIdOrNull(CourtType.pk(code)) }
 }
 
 @Component
@@ -86,6 +89,7 @@ class AgencyLocationBuilder(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
   ): AgencyLocation = AgencyLocation(
     id = id,
     description = description,
@@ -94,6 +98,7 @@ class AgencyLocationBuilder(
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
     contactName = contactName,
+    courtType = repository.courtTypeOf(courtTypeCode),
   )
     .let { repository.save(it) }
     .also { agencyLocation = it }
@@ -107,6 +112,7 @@ class AgencyLocationBuilder(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
   ): Agency = Agency(
     id = id,
     description = description,
@@ -116,6 +122,7 @@ class AgencyLocationBuilder(
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
     contactName = contactName,
+    courtType = repository.courtTypeOf(courtTypeCode),
   )
     .let { repository.saveAgency(it) }
     .also { agencyLocation = it }
@@ -129,6 +136,7 @@ class AgencyLocationBuilder(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
   ): Prison = Prison(
     id = id,
     description = description,
@@ -138,6 +146,7 @@ class AgencyLocationBuilder(
     deactivationDate = deactivationDate,
     updateAllowed = updateAllowed,
     contactName = contactName,
+    courtType = repository.courtTypeOf(courtTypeCode),
   )
     .let { repository.savePrison(it) }
     .also { agencyLocation = it }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
@@ -493,6 +493,7 @@ class NomisData(
     active: Boolean,
     districtCode: String?,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
     dsl: AgencyLocationDsl.() -> Unit,
   ): AgencyLocation = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.build(
@@ -501,6 +502,7 @@ class NomisData(
       type = type,
       active = active,
       deactivationDate = deactivationDate,
+      updateAllowed = updateAllowed,
     )
       .also { builder.apply(dsl) }
   }
@@ -511,6 +513,7 @@ class NomisData(
     active: Boolean,
     districtCode: String?,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Agency = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildAgency(
@@ -520,6 +523,7 @@ class NomisData(
       active = active,
       districtCode = districtCode,
       deactivationDate = deactivationDate,
+      updateAllowed = updateAllowed,
     )
       .also { builder.apply(dsl) }
   }
@@ -529,6 +533,7 @@ class NomisData(
     active: Boolean,
     districtCode: String?,
     deactivationDate: LocalDate?,
+    updateAllowed: Boolean,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Prison = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildPrison(
@@ -538,6 +543,7 @@ class NomisData(
       active = active,
       districtCode = districtCode,
       deactivationDate = deactivationDate,
+      updateAllowed = updateAllowed,
     )
       .also { builder.apply(dsl) }
   }
@@ -592,7 +598,6 @@ class NomisData(
 
 @NomisDataDslMarker
 interface NomisDataDsl {
-  @OffenderDslMarker
   fun offender(
     nomsId: String = "A5194DY",
     titleCode: String? = null,
@@ -612,7 +617,6 @@ interface NomisDataDsl {
     dsl: OffenderDsl.() -> Unit = {},
   ): Offender
 
-  @ProgramServiceDslMarker
   fun programService(
     programCode: String = "INTTEST",
     programId: Long = 0,
@@ -621,10 +625,8 @@ interface NomisDataDsl {
     dsl: ProgramServiceDsl.() -> Unit = {},
   ): ProgramService
 
-  @StaffDslMarker
   fun staff(firstName: String = "AAYAN", lastName: String = "AHMAD", dsl: StaffDsl.() -> Unit = {}): Staff
 
-  @AdjudicationIncidentDslMarker
   fun adjudicationIncident(
     whenCreated: LocalDateTime = LocalDateTime.now(),
     incidentDetails: String = "Big fight",
@@ -638,7 +640,6 @@ interface NomisDataDsl {
     dsl: AdjudicationIncidentDsl.() -> Unit = {},
   ): AdjudicationIncident
 
-  @NonAssociationDslMarker
   fun nonAssociation(
     offender1: Offender,
     offender2: Offender,
@@ -647,7 +648,6 @@ interface NomisDataDsl {
     dsl: NonAssociationDsl.() -> Unit = {},
   ): OffenderNonAssociation
 
-  @QuestionnaireDslMarker
   fun questionnaire(
     code: String,
     description: String = "This is a questionnaire",
@@ -656,7 +656,6 @@ interface NomisDataDsl {
     dsl: QuestionnaireDsl.() -> Unit = {},
   ): Questionnaire
 
-  @IncidentDslMarker
   fun incident(
     id: Long,
     title: String = "An incident occurred",
@@ -671,7 +670,6 @@ interface NomisDataDsl {
     dsl: IncidentDsl.() -> Unit = {},
   ): Incident
 
-  @RoleDslMarker
   fun role(
     code: String,
     name: String,
@@ -680,14 +678,12 @@ interface NomisDataDsl {
     dsl: RoleDsl.() -> Unit = {},
   ): Role
 
-  @ExternalServiceDslMarker
   fun externalService(
     serviceName: String,
     description: String = serviceName,
     dsl: ExternalServiceDsl.() -> Unit = {},
   ): ExternalService
 
-  @SplashScreenDslMarker
   fun splashScreen(
     moduleName: String,
     warningText: String? = null,
@@ -696,7 +692,6 @@ interface NomisDataDsl {
     dsl: SplashScreenDsl.() -> Unit = {},
   ): SplashScreen
 
-  @AgencyInternalLocationDslMarker
   fun agencyInternalLocation(
     locationCode: String,
     locationType: String,
@@ -714,14 +709,12 @@ interface NomisDataDsl {
     dsl: AgencyInternalLocationDsl.() -> Unit = {},
   ): AgencyInternalLocation
 
-  @IWPTemplateDslMarker
   fun template(
     name: String = "template1",
     description: String?,
     dsl: IWPTemplateDsl.() -> Unit = {},
   ): IWPTemplate
 
-  @MergeTransactionDslMarker
   fun mergeTransaction(
     requestDate: LocalDateTime = LocalDateTime.now(),
     requestStatusCode: String = "COMPLETED",
@@ -741,7 +734,6 @@ interface NomisDataDsl {
     dsl: MergeTransactionDsl.() -> Unit = {},
   ): MergeTransaction
 
-  @PersonDslMarker
   fun person(
     firstName: String = "AAYAN",
     lastName: String = "AHMAD",
@@ -760,7 +752,6 @@ interface NomisDataDsl {
     dsl: PersonDsl.() -> Unit = {},
   ): Person
 
-  @CorporateDslMarker
   fun corporate(
     corporateName: String,
     caseloadId: String? = null,
@@ -775,7 +766,6 @@ interface NomisDataDsl {
     dsl: CorporateDsl.() -> Unit = {},
   ): Corporate
 
-  @LinkCaseTxnDslMarker
   fun linkedCaseTransaction(
     sourceCase: CourtCase,
     targetCase: CourtCase,
@@ -792,6 +782,7 @@ interface NomisDataDsl {
     active: Boolean = true,
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
+    updateAllowed: Boolean = true,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): AgencyLocation
 
@@ -801,6 +792,7 @@ interface NomisDataDsl {
     active: Boolean = true,
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
+    updateAllowed: Boolean = true,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Prison
 
@@ -811,10 +803,10 @@ interface NomisDataDsl {
     active: Boolean = true,
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
+    updateAllowed: Boolean = true,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Agency
 
-  @GeneralLedgerTransactionDslMarker
   fun generalLedgerTransaction(
     transactionId: Long,
     transactionEntrySequence: Int,
@@ -827,7 +819,6 @@ interface NomisDataDsl {
     dsl: GeneralLedgerTransactionDsl.() -> Unit = {},
   ): GeneralLedgerTransaction
 
-  @CaseloadCurrentAccountsBaseDslMarker
   fun caseloadCurrentAccountBase(
     caseloadId: String = "MDI",
     accountCode: Int = 2101,
@@ -836,7 +827,6 @@ interface NomisDataDsl {
     dsl: CaseloadCurrentAccountsBaseDsl.() -> Unit = {},
   ): CaseloadCurrentAccountsBase
 
-  @AgencyVisitDayDslMarker
   fun agencyVisitDay(prisonerId: String, weekDay: WeekDay, dsl: AgencyVisitDayDsl.() -> Unit = {}): AgencyVisitDay
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
@@ -495,6 +495,7 @@ class NomisData(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): AgencyLocation = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.build(
@@ -505,6 +506,7 @@ class NomisData(
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
       contactName = contactName,
+      courtTypeCode = courtTypeCode,
     )
       .also { builder.apply(dsl) }
   }
@@ -517,6 +519,7 @@ class NomisData(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Agency = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildAgency(
@@ -528,6 +531,7 @@ class NomisData(
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
       contactName = contactName,
+      courtTypeCode = courtTypeCode,
     )
       .also { builder.apply(dsl) }
   }
@@ -539,6 +543,7 @@ class NomisData(
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
     contactName: String?,
+    courtTypeCode: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Prison = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildPrison(
@@ -550,6 +555,7 @@ class NomisData(
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
       contactName = contactName,
+      courtTypeCode = courtTypeCode,
     )
       .also { builder.apply(dsl) }
   }
@@ -790,6 +796,7 @@ interface NomisDataDsl {
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
     contactName: String? = null,
+    courtTypeCode: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): AgencyLocation
 
@@ -801,6 +808,7 @@ interface NomisDataDsl {
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
     contactName: String? = null,
+    courtTypeCode: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Prison
 
@@ -813,6 +821,7 @@ interface NomisDataDsl {
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
     contactName: String? = null,
+    courtTypeCode: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Agency
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/NomisData.kt
@@ -494,6 +494,7 @@ class NomisData(
     districtCode: String?,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): AgencyLocation = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.build(
@@ -503,6 +504,7 @@ class NomisData(
       active = active,
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
+      contactName = contactName,
     )
       .also { builder.apply(dsl) }
   }
@@ -514,6 +516,7 @@ class NomisData(
     districtCode: String?,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Agency = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildAgency(
@@ -524,6 +527,7 @@ class NomisData(
       districtCode = districtCode,
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
+      contactName = contactName,
     )
       .also { builder.apply(dsl) }
   }
@@ -534,6 +538,7 @@ class NomisData(
     districtCode: String?,
     deactivationDate: LocalDate?,
     updateAllowed: Boolean,
+    contactName: String?,
     dsl: AgencyLocationDsl.() -> Unit,
   ): Prison = agencyLocationBuilderFactory!!.builder().let { builder ->
     builder.buildPrison(
@@ -544,6 +549,7 @@ class NomisData(
       districtCode = districtCode,
       deactivationDate = deactivationDate,
       updateAllowed = updateAllowed,
+      contactName = contactName,
     )
       .also { builder.apply(dsl) }
   }
@@ -783,6 +789,7 @@ interface NomisDataDsl {
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
+    contactName: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): AgencyLocation
 
@@ -793,6 +800,7 @@ interface NomisDataDsl {
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
+    contactName: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Prison
 
@@ -804,6 +812,7 @@ interface NomisDataDsl {
     districtCode: String? = null,
     deactivationDate: LocalDate? = null,
     updateAllowed: Boolean = true,
+    contactName: String? = null,
     dsl: AgencyLocationDsl.() -> Unit = {},
   ): Agency
 


### PR DESCRIPTION
Added:
* UPDATED_ALLOWED_FLAG
* CONTACT_NAME
* JURISDICTION_CODE

Might be a reason at this point to create a Court subclass - but confusingly the "prison" location "OUT" has a JURISDICTION_CODE of Crown Court - so if we find more Court only fields we will drop courtType from all other iagency types and just add to Courts and see what hacks we can use to ignore the OUT court type