### PR TITLE
SDIT-3997 Treat null direction code as OUT

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
@@ -13,8 +13,25 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
 
 @Repository
 interface CourtEventRepository : JpaRepository<CourtEvent, Long> {
-  fun findAllByOffenderBooking_Offender_NomsIdAndDirectionCode_CodeIs(offenderNo: String, directionCode: String): List<CourtEvent>
-  fun findAllByOffenderBooking_BookingIdAndDirectionCode_CodeIs(bookingId: Long, directionCode: String): List<CourtEvent>
+  @Query(
+    """
+    SELECT c FROM CourtEvent c
+    LEFT JOIN c.directionCode dc
+    WHERE c.offenderBooking.offender.nomsId = :offenderNo
+      AND (dc.code = :directionCode OR dc.code IS NULL)
+  """,
+  )
+  fun findAllByOffenderAndDirectionCodeOrNull(offenderNo: String, directionCode: String): List<CourtEvent>
+
+  @Query(
+    """
+      SELECT c FROM CourtEvent c
+      LEFT JOIN c.directionCode dc
+      WHERE c.offenderBooking.bookingId = :bookingId
+        AND (dc.code = :directionCode OR dc.code IS NULL)
+    """,
+  )
+  fun findAllByOffenderBookingAndDirectionCodeOrNull(bookingId: Long, directionCode: String): List<CourtEvent>
   fun findByOffenderBooking_BookingIdAndParentEventId(offenderBookingBookingId: Long, parentEventId: Long): CourtEvent?
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/offender/OffenderCourtMovementsService.kt
@@ -35,7 +35,7 @@ class OffenderCourtMovementsService(
       .filterNot { it.createUsername == "SYS" && it.auditModuleName == "MERGE" }
     val allMovementsIn = courtMovementInRepository.findAllByOffenderBooking_Offender_NomsId(offenderNo)
       .filterNot { it.createUsername == "SYS" && it.auditModuleName == "MERGE" }
-    val allSchedulesOut = courtEventRepository.findAllByOffenderBooking_Offender_NomsIdAndDirectionCode_CodeIs(offenderNo, "OUT")
+    val allSchedulesOut = courtEventRepository.findAllByOffenderAndDirectionCodeOrNull(offenderNo, "OUT")
 
     // When finding unscheduled movements we also have to cross reference with the schedules we loaded - just in case any are linked to a schedule without a direction (bad old NOMIS data that we are ignoring)
     val unscheduledMovementsOut = allMovementsOut.filter { it.courtScheduleOutId == null || it.courtScheduleOutId !in(allSchedulesOut.map { it.id }) }
@@ -73,7 +73,7 @@ class OffenderCourtMovementsService(
       .filterNot { it.createUsername == "SYS" && it.auditModuleName == "MERGE" }
     val allMovementsIn = courtMovementInRepository.findAllByOffenderBooking_BookingId(bookingId)
       .filterNot { it.createUsername == "SYS" && it.auditModuleName == "MERGE" }
-    val allSchedulesOut = courtEventRepository.findAllByOffenderBooking_BookingIdAndDirectionCode_CodeIs(bookingId, "OUT")
+    val allSchedulesOut = courtEventRepository.findAllByOffenderBookingAndDirectionCodeOrNull(bookingId, "OUT")
 
     // When finding unscheduled movements we also have to cross reference with the schedules we loaded - just in case any are linked to a schedule without a direction (bad old NOMIS data that we are ignoring)
     val unscheduledMovementsOut = allMovementsOut.filter { it.courtScheduleOutId == null || it.courtScheduleOutId !in(allSchedulesOut.map { it.id }) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
@@ -39,7 +39,7 @@ class CourtScheduleService(
       throw NotFoundException("Offender with nomsId=$offenderNo not found")
     }
     return courtEventRepository.findByIdOrNull(eventId)
-      ?.takeIf { it.directionCode?.code == DirectionType.OUT }
+      ?.takeIf { it.directionCode == null || it.directionCode?.code == DirectionType.OUT }
       ?.toResponse()
       ?: throw NotFoundException("Court event OUT with id=$eventId not found for prisoner with nomsId=$offenderNo")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtScheduleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/CourtScheduleResourceIntTest.kt
@@ -169,6 +169,31 @@ class CourtScheduleResourceIntTest(
             assertThat(this.startTime.toLocalTime()).isEqualTo(LocalTime.of(12, 0))
           }
       }
+
+      @Test
+      fun `should treat null direction code as OUT`() {
+        nomisDataBuilder.build {
+          offender = offender(nomsId = offenderNo) {
+            booking = booking {
+              scheduleOut = courtEventOut(eventDateTime = LocalDateTime.now())
+            }
+          }
+        }
+
+        repository.runInTransaction {
+          // Set the schedule direction code to null
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS SET DIRECTION_CODE = null where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.getCourtScheduleOutOk(offenderNo, scheduleOut.id)
+          .apply {
+            assertThat(eventId).isEqualTo(scheduleOut.id)
+          }
+      }
     }
 
     @Nested
@@ -431,6 +456,31 @@ class CourtScheduleResourceIntTest(
             }
           }
       }
+
+      @Test
+      fun `should update court schedule out where direction code is null`() {
+        repository.runInTransaction {
+          // Set the schedule direction code to null
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS SET DIRECTION_CODE = null where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.upsertCourtScheduleOutOk(
+          request = aRequest(eventId = scheduleOut.id),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(courtEventRepository.findByIdOrNull(eventId)!!) {
+                assertThat(courtEventType.code).isEqualTo("CRT")
+                assertThat(directionCode?.code).isEqualTo(null)
+              }
+              assertThat(courtEventRepository.findByOffenderBooking_BookingIdAndParentEventId(bookingId, eventId)).isNull()
+            }
+          }
+      }
     }
 
     @Nested
@@ -458,6 +508,34 @@ class CourtScheduleResourceIntTest(
               with(courtEventRepository.findByIdOrNull(eventId)!!) {
                 assertThat(eventStatus.code).isEqualTo("COMP")
                 assertThat(directionCode?.code).isEqualTo("OUT")
+              }
+              with(courtEventRepository.findByOffenderBooking_BookingIdAndParentEventId(bookingId, eventId)!!) {
+                assertThat(eventStatus.code).isEqualTo("SCH")
+                assertThat(directionCode?.code).isEqualTo("IN")
+              }
+            }
+          }
+      }
+
+      @Test
+      fun `should update court schedule out and in where out direction is null`() {
+        repository.runInTransaction {
+          // Set the schedule direction code to null
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS SET DIRECTION_CODE = null where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
+        webTestClient.upsertCourtScheduleOutOk(
+          request = aRequest(eventId = scheduleOut.id, eventStatus = "COMP", returnStatus = "SCH"),
+        )
+          .apply {
+            repository.runInTransaction {
+              with(courtEventRepository.findByIdOrNull(eventId)!!) {
+                assertThat(eventStatus.code).isEqualTo("COMP")
+                assertThat(directionCode?.code).isEqualTo(null)
               }
               with(courtEventRepository.findByOffenderBooking_BookingIdAndParentEventId(bookingId, eventId)!!) {
                 assertThat(eventStatus.code).isEqualTo("SCH")
@@ -643,6 +721,25 @@ class CourtScheduleResourceIntTest(
 
       @Test
       fun `should delete schedule`() {
+        webTestClient.deleteCourtScheduleOut()
+          .expectStatus().isNoContent
+
+        repository.runInTransaction {
+          assertThat(courtEventRepository.findByIdOrNull(scheduleOut.id)).isNull()
+        }
+      }
+
+      @Test
+      fun `should delete schedule if direction code is null`() {
+        repository.runInTransaction {
+          // Set the schedule direction code to null
+          entityManager.createNativeQuery(
+            """
+              update COURT_EVENTS SET DIRECTION_CODE = null where EVENT_ID = ${scheduleOut.id}
+            """.trimIndent(),
+          ).executeUpdate()
+        }
+
         webTestClient.deleteCourtScheduleOut()
           .expectStatus().isNoContent
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/OffenderCourtMovementsResourceIntTest.kt
@@ -463,7 +463,7 @@ class OffenderCourtMovementsResourceIntTest(
       }
 
       @Test
-      fun `should not return any schedules with null direction code`() {
+      fun `should treat null direction code as as OUT`() {
         nomisDataBuilder.build {
           offender = offender(nomsId = offenderNo) {
             booking = booking {
@@ -488,9 +488,8 @@ class OffenderCourtMovementsResourceIntTest(
         // The court schedule without direction code should not be returned
         webTestClient.getOffenderCourtMovementsOk(offenderNo)
           .apply {
-            with(bookings[0]) {
-              assertThat(courtSchedules).isEmpty()
-              assertThat(unscheduledCourtMovementOuts).hasSize(1)
+            with(bookings[0].courtSchedules[0]) {
+              assertThat(eventId).isEqualTo(scheduleOut.id)
             }
           }
       }
@@ -715,6 +714,38 @@ class OffenderCourtMovementsResourceIntTest(
           assertThat(courtSchedules[0].courtMovementIn).isNull()
           assertThat(unscheduledCourtMovementOuts).isEmpty()
           assertThat(unscheduledCourtMovementIns).isEmpty()
+        }
+    }
+
+    @Test
+    fun `should treat null direction code as as OUT`() {
+      nomisDataBuilder.build {
+        offender = offender(nomsId = offenderNo) {
+          booking = booking {
+            scheduleOut = courtEventOut {
+              movementOut = courtMovementOut()
+            }
+          }
+        }
+      }
+
+      // Set the schedule direction code to null
+      repository.runInTransaction {
+        entityManager.createNativeQuery(
+          """
+              update COURT_EVENTS
+              set DIRECTION_CODE = null
+              where EVENT_ID = ${scheduleOut.id}
+          """.trimIndent(),
+        ).executeUpdate()
+      }
+
+      // The court schedule without direction code should not be returned
+      webTestClient.getBookingCourtMovementsOk(booking.bookingId)
+        .apply {
+          with(courtSchedules[0]) {
+            assertThat(eventId).isEqualTo(scheduleOut.id)
+          }
         }
     }
   }


### PR DESCRIPTION
All court events with null direction code have been identified as OUT (they don't have a parent event ID) - it's just that there's some really old bad data where the direction code is null, and that data keeps getting copied onto new bookings.