### PR TITLE
SDIT-4032 Handle race to delete schedule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapScheduleOutRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapScheduleOutRepository.kt
@@ -2,7 +2,10 @@
 
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapScheduleOut
 
@@ -11,4 +14,8 @@ interface OffenderTapScheduleOutRepository : JpaRepository<OffenderTapScheduleOu
   fun findByEventIdAndOffenderBooking_Offender_NomsId(eventId: Long, offenderNo: String): OffenderTapScheduleOut?
 
   fun countByOffenderBooking_Offender_NomsId_AndTapApplicationIsNotNull(offenderNo: String): Long
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(value = "select tso from OffenderTapScheduleOut tso where (tso.eventId = :eventId)")
+  fun findByEventIdOrNullForUpdate(eventId: Long): OffenderTapScheduleOut?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapApplicationRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderTapScheduleOutRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.MovementHelpers
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.MovementHelpers.Companion.MAX_TAP_COMMENT_LENGTH
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.TapAddressService
@@ -25,6 +26,7 @@ class TapApplicationService(
   private val offenderBookingRepository: OffenderBookingRepository,
   private val offenderRepository: OffenderRepository,
   private val applicationRepository: OffenderTapApplicationRepository,
+  private val scheduleOutRepository: OffenderTapScheduleOutRepository,
   private val tapAddressService: TapAddressService,
   private val movementHelpers: MovementHelpers,
 ) {
@@ -107,7 +109,11 @@ class TapApplicationService(
     if (!application.isApproved() && application.isSingle()) {
       val schedule = application.tapScheduleOuts.firstOrNull()
       if (schedule?.tapMovementOut != null) throw BadDataException("Attempt to remove a schedule from an unapproved application failed - the schedule (${schedule.eventId}) is attached to a movement (${schedule.tapMovementOut!!.id.offenderBooking.bookingId}/${schedule.tapMovementOut!!.id.sequence}).")
-      application.tapScheduleOuts.remove(schedule)
+      schedule?.run {
+        scheduleOutRepository.findByEventIdOrNullForUpdate(schedule.eventId)
+          ?.also { scheduleOutRepository.delete(it) }
+        application.tapScheduleOuts.remove(schedule)
+      }
     }
 
     return applicationRepository.save(application)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
@@ -140,7 +140,7 @@ class TapScheduleService(
 
   @Transactional
   fun deleteTapScheduleOut(offenderNo: String, eventId: Long) {
-    scheduleOutRepository.findByIdOrNull(eventId)
+    scheduleOutRepository.findByEventIdOrNullForUpdate(eventId)
       ?.also { schedule ->
         if (schedule.tapMovementOut != null) {
           throw ConflictException("Cannot delete tap schedule out eventId $eventId because it has a movement ${schedule.tapMovementOut!!.id.offenderBooking.bookingId} / ${schedule.tapMovementOut!!.id.sequence}}")


### PR DESCRIPTION
We can receive concurrent events to delete a schedule - one from an application update, one from a direct delete request - and we had an error where one pod deleted a schedule another pod thought existed ending with a stale object exception and a rejected delete. While nothing went wrong, we ended having to investigate a DLQ message, and this is not idempotent behaviour from the delete endpoint.

So to fix we always lock the row before deleting - then it doesn't matter which pod wins the race.