### PR TITLE
SDIT-4051 Adjudication room lookup fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationService.kt
@@ -997,7 +997,10 @@ class AdjudicationService(
           locationType = "ADJU",
           active = false,
         ).firstOrNull()
-          .also { log.warn("An active adjudication room (location type ADJU) not found at prison ${incidentCharge.incident.prison.id} so checking for any inactive rooms, assuming this prison is now closed") }
+          ?.also { log.warn("An active adjudication room (location type ADJU) not found at prison ${incidentCharge.incident.prison.id} so checking for any inactive rooms, assuming this prison is now closed") }
+        // else find any room that has previously been used in case location type has been changed by prison
+        ?: adjudicationHearingRepository.findFirstOrNullByAgencyInternalLocation_Agency_AndCommentStartsWith(incidentCharge.incident.prison, DPS_REFERRAL_PLACEHOLDER_HEARING)?.agencyInternalLocation
+          ?.also { log.warn("No adjudication room (location type ADJU) found at prison ${incidentCharge.incident.prison.id} so using any previous room instead. Location found is ${it.locationId}") }
         ?: throw NotFoundException("Adjudication room (location type ADJU) not found at prison ${incidentCharge.incident.prison.id}")
 
     val dummyHearingIdentifier = "$DPS_REFERRAL_PLACEHOLDER_HEARING-$chargeSequence"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AdjudicationHearingRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.FETCH
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AdjudicationHearing
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 
 @Repository
 interface AdjudicationHearingRepository : JpaRepository<AdjudicationHearing, Long> {
@@ -12,4 +13,7 @@ interface AdjudicationHearingRepository : JpaRepository<AdjudicationHearing, Lon
   fun findByAdjudicationNumber(adjudicationNumber: Long): List<AdjudicationHearing>
   fun deleteByAdjudicationNumber(adjudicationNumber: Long)
   fun findByAdjudicationNumberAndComment(adjudicationNumber: Long, comment: String): AdjudicationHearing?
+
+  @Suppress("FunctionName")
+  fun findFirstOrNullByAgencyInternalLocation_Agency_AndCommentStartsWith(agency: AgencyLocation, comment: String): AdjudicationHearing?
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/adjudications/AdjudicationsHearingResultsResourceIntTest.kt
@@ -409,6 +409,7 @@ class AdjudicationsHearingResultsResourceIntTest : IntegrationTestBase() {
     private val existingAdjudicationNumber = 123456L
     private lateinit var existingCharge: AdjudicationIncidentCharge
     private lateinit var existingSecondCharge: AdjudicationIncidentCharge
+    private lateinit var existingThirdCharge: AdjudicationIncidentCharge
 
     @BeforeEach
     fun createPrisonerWithAdjudication() {
@@ -425,6 +426,7 @@ class AdjudicationsHearingResultsResourceIntTest : IntegrationTestBase() {
             adjudicationParty(incident = existingIncident, adjudicationNumber = existingAdjudicationNumber) {
               existingCharge = charge(offenceCode = "51:1B", generateOfficeId = false)
               existingSecondCharge = charge(offenceCode = "51:1C", generateOfficeId = false)
+              existingThirdCharge = charge(offenceCode = "51:1C", generateOfficeId = false)
             }
           }
         }
@@ -558,6 +560,31 @@ class AdjudicationsHearingResultsResourceIntTest : IntegrationTestBase() {
           assertThat(adjudicationHearing.comment).isEqualTo("DPS_REFERRAL_PLACEHOLDER-${existingCharge.id.chargeSequence}")
           assertThat(adjudicationHearing.hearingDateTime).isEqualTo(LocalDateTime.now().with(LocalTime.MIDNIGHT))
           assertThat(adjudicationHearing.hearingResults[0].findingType.code).isEqualTo("REF_POLICE")
+
+          // now switch location type so it is no longer a Adjudication Usage type for below test
+          adjudicationHearing.agencyInternalLocation?.locationType = "LOCA"
+        }
+
+        webTestClient.post()
+          .uri("/adjudications/adjudication-number/$existingAdjudicationNumber/charge/${existingThirdCharge.id.chargeSequence}/result")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              aHearingResultRequest(pleaFindingCode = "NOT_ASKED", findingCode = "REF_POLICE"),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        repository.runInTransaction {
+          val adjudicationHearing = hearingRepository.findByAdjudicationNumber(existingAdjudicationNumber)[1]
+          assertThat(adjudicationHearing.comment).isEqualTo("DPS_REFERRAL_PLACEHOLDER-${existingThirdCharge.id.chargeSequence}")
+          assertThat(adjudicationHearing.hearingDateTime).isEqualTo(LocalDateTime.now().with(LocalTime.MIDNIGHT))
+          assertThat(adjudicationHearing.hearingResults[0].findingType.code).isEqualTo("REF_POLICE")
+
+          // now switch back to Adjudication type
+          adjudicationHearing.agencyInternalLocation?.locationType = "ADJU"
         }
       }
 


### PR DESCRIPTION
When looking up a room for the dummy hearing and no location with usage type of 'ADJU' found then full back to looking for any previous room that has been used for referrals

FDI has changed their room types so dummy hearings can no longer be created.