### PR TITLE
SDIT-4031 Switch to synchronous version ImprisonmentStatus NOMIS proc…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -298,7 +298,7 @@ class CourtSentencingService(
     )
 
     refreshCourtOrder(courtEvent = courtCase.courtEvents[0], offenderNo = offenderNo)
-    storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+    storedProcedureRepository.imprisonmentStatusUpdate(
       bookingId = booking.bookingId,
       changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
     )
@@ -383,7 +383,7 @@ class CourtSentencingService(
 
       courtEventRepository.saveAndFlush(courtEvent).let { createdCourtEvent ->
         refreshCourtOrder(courtEvent = createdCourtEvent, offenderNo = offenderNo)
-        storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+        storedProcedureRepository.imprisonmentStatusUpdate(
           bookingId = courtCase.offenderBooking.bookingId,
           changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
         )
@@ -511,7 +511,7 @@ class CourtSentencingService(
           offenderChargeId = createdOffenderCharge.id,
         ).also { response ->
           // calculates main offence
-          storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+          storedProcedureRepository.imprisonmentStatusUpdate(
             bookingId = courtCase.offenderBooking.bookingId,
             changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
           )
@@ -652,7 +652,7 @@ class CourtSentencingService(
         )
 
         refreshCourtOrder(courtEvent = courtAppearance, offenderNo = offenderNo)
-        storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+        storedProcedureRepository.imprisonmentStatusUpdate(
           bookingId = courtCase.offenderBooking.bookingId,
           changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
         )
@@ -717,7 +717,7 @@ class CourtSentencingService(
           offenderChargesRemovedFromAppearance = offenderCharges,
         )
         telemetry["deletedOffenderCharges"] = deletedOffenderCharges.map { it.id }.toString()
-        storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+        storedProcedureRepository.imprisonmentStatusUpdate(
           bookingId = case.offenderBooking.bookingId,
           changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
         )
@@ -770,7 +770,7 @@ class CourtSentencingService(
     courtCaseRepository.findByIdOrNull(caseId)?.also {
       telemetry = telemetry + ("bookingId" to it.offenderBooking.bookingId.toString())
       courtCaseRepository.delete(it)
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = it.offenderBooking.bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
       )
@@ -823,7 +823,7 @@ class CourtSentencingService(
                 refreshCourtOrder(courtEvent = courtAppearance, offenderNo = offenderNo)
               }
             }
-            storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+            storedProcedureRepository.imprisonmentStatusUpdate(
               bookingId = courtCase.offenderBooking.bookingId,
               changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
             )
@@ -883,7 +883,7 @@ class CourtSentencingService(
           }
         }
     }
-    storedProcedureRepository.imprisonmentStatusUpdateSynchronous(
+    storedProcedureRepository.imprisonmentStatusUpdate(
       bookingId = latestBooking.bookingId,
       changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
     )
@@ -947,7 +947,7 @@ class CourtSentencingService(
     )
 
     offenderSentenceRepository.saveAndFlush(sentence).also {
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = offenderBooking.bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -996,7 +996,7 @@ class CourtSentencingService(
       sentenceTermType = lookupSentenceTermType(termRequest.sentenceTermType),
     )
     offenderSentenceTermRepository.saveAndFlush(term).also {
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = offenderBooking.bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -1139,7 +1139,7 @@ class CourtSentencingService(
         }
 
         offenderSentenceRepository.saveAndFlush(sentence).also {
-          storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+          storedProcedureRepository.imprisonmentStatusUpdate(
             bookingId = case.offenderBooking.bookingId,
             changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
           )
@@ -1199,7 +1199,7 @@ class CourtSentencingService(
         term.sentenceTermType = lookupSentenceTermType(termRequest.sentenceTermType)
 
         offenderSentenceTermRepository.saveAndFlush(term).also {
-          storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+          storedProcedureRepository.imprisonmentStatusUpdate(
             bookingId = case.offenderBooking.bookingId,
             changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
           )
@@ -1440,7 +1440,7 @@ class CourtSentencingService(
     }
 
     bookingIds.forEach { bookingId ->
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -1481,7 +1481,7 @@ class CourtSentencingService(
     request.sentencesRemoved.updateSentences()
     request.returnToCustody.createOrUpdateBooking(bookingIds)
     bookingIds.forEach { bookingId ->
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -1536,7 +1536,7 @@ class CourtSentencingService(
     request.sentences.updateSentences()
     request.returnToCustody.createOrUpdateBooking(bookingIds)
     bookingIds.forEach { bookingId ->
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -1568,7 +1568,7 @@ class CourtSentencingService(
     bookingIds.forEach { bookingId ->
       findOffenderBooking(bookingId).fixedTermRecall = null
       offenderFixedTermRecallRepository.deleteById(bookingId)
-      storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+      storedProcedureRepository.imprisonmentStatusUpdate(
         bookingId = bookingId,
         changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
       )
@@ -2174,7 +2174,7 @@ class CourtSentencingService(
       }
 
       courtCaseRepository.saveAllAndFlush(clonedCases).also {
-        storedProcedureRepository.imprisonmentStatusUpdateAsynchronous(
+        storedProcedureRepository.imprisonmentStatusUpdate(
           bookingId = latestBooking.bookingId,
           changeType = ImprisonmentStatusChangeType.UPDATE_RESULT.name,
         )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/StoredProcedureRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/StoredProcedureRepository.kt
@@ -4,7 +4,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.storedprocs.ImprisonmentStatusUpdate
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.storedprocs.KeyDateAdjustmentDelete
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.storedprocs.KeyDateAdjustmentUpsert
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.repository.storedprocs.UpdateStatusAndMainOffence
@@ -20,12 +19,7 @@ interface StoredProcedureRepository {
     bookingId: Long,
   )
 
-  fun imprisonmentStatusUpdateAsynchronous(
-    bookingId: Long,
-    changeType: String,
-  )
-
-  fun imprisonmentStatusUpdateSynchronous(
+  fun imprisonmentStatusUpdate(
     bookingId: Long,
     changeType: String,
   )
@@ -36,7 +30,6 @@ interface StoredProcedureRepository {
 class StoredProcedureRepositoryOracle(
   private val keyDateAdjustmentUpsertProcedure: KeyDateAdjustmentUpsert,
   private val keyDateAdjustmentDeleteProcedure: KeyDateAdjustmentDelete,
-  private val imprisonmentStatusUpdate: ImprisonmentStatusUpdate,
   private val updateStatusAndMainOffence: UpdateStatusAndMainOffence,
 ) : StoredProcedureRepository {
 
@@ -60,16 +53,7 @@ class StoredProcedureRepositoryOracle(
     keyDateAdjustmentDeleteProcedure.execute(params)
   }
 
-  override fun imprisonmentStatusUpdateAsynchronous(
-    bookingId: Long,
-    changeType: String,
-  ) {
-    val params = MapSqlParameterSource()
-      .addValue("p_offender_book_id", bookingId)
-      .addValue("p_change_type", changeType)
-    imprisonmentStatusUpdate.execute(params)
-  }
-  override fun imprisonmentStatusUpdateSynchronous(
+  override fun imprisonmentStatusUpdate(
     bookingId: Long,
     changeType: String,
   ) {
@@ -102,14 +86,7 @@ class StoredProcedureRepositoryH2 : StoredProcedureRepository {
     log.info("calling H2 version of StoreProcedure preKeyDateAdjustmentDeletion")
   }
 
-  override fun imprisonmentStatusUpdateAsynchronous(
-    bookingId: Long,
-    changeType: String,
-  ) {
-    log.info("calling H2 version of StoreProcedure imprisonmentStatusUpdate with bookingId: $bookingId and change type: $changeType")
-  }
-
-  override fun imprisonmentStatusUpdateSynchronous(bookingId: Long, changeType: String) {
+  override fun imprisonmentStatusUpdate(bookingId: Long, changeType: String) {
     log.info("calling H2 version of StoreProcedure updateStatusAndMainOffence with bookingId: $bookingId and change type: $changeType")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/storedprocs/ImprisonmentStatusUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/repository/storedprocs/ImprisonmentStatusUpdate.kt
@@ -7,22 +7,6 @@ import java.sql.Types
 import javax.sql.DataSource
 
 @Component
-class ImprisonmentStatusUpdate(dataSource: DataSource) : SimpleJdbcCall(dataSource) {
-  init {
-    withSchemaName("OMS_OWNER")
-      .withCatalogName("TAG_IMPRISONMENT_STATUS")
-      .withProcedureName("post_message")
-      .withoutProcedureColumnMetaDataAccess()
-      .withNamedBinding()
-      .declareParameters(
-        SqlParameter("p_offender_book_id", Types.NUMERIC),
-        SqlParameter("p_change_type", Types.VARCHAR),
-      )
-    compile()
-  }
-}
-
-@Component
 class UpdateStatusAndMainOffence(dataSource: DataSource) : SimpleJdbcCall(dataSource) {
   init {
     withSchemaName("OMS_OWNER")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -3204,7 +3204,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -4447,7 +4447,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
 
-        verify(spRepository).imprisonmentStatusUpdateSynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -4726,7 +4726,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         assertThat(courtAppearanceResponse.clonedCourtCases).isNull()
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -4795,7 +4795,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
 
         assertThat(courtAppearanceResponse.id).isGreaterThan(0)
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -4905,7 +4905,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         assertThat(courtAppearanceResponse.clonedCourtCases).isNotNull()
 
         // imprisonment statu, s stored procedure is called - but on latest booking where the appearance was added
-        verify(spRepository, times(2)).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository, times(2)).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -5091,7 +5091,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
 
         assertThat(courtAppearanceResponse.id).isGreaterThan(0)
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -5255,7 +5255,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .jsonPath("offenderCharges[0].chargeStatus.description").isEqualTo("Active")
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -5501,7 +5501,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .jsonPath("courtOrders[0].id").doesNotExist()
 
         // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -5903,7 +5903,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         assertThat(courtAppearanceResponse.createdCourtEventChargesIds.size).isEqualTo(0)
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -6416,7 +6416,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .jsonPath("courtEvents[0].id").isEqualTo(courtEvent2.id)
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -6584,7 +6584,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .expectStatus().isNotFound
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -7217,7 +7217,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .expectStatus().isOk
 
 // imprisonment status stored procedure is called
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_RESULT.name),
         )
@@ -7729,7 +7729,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .expectStatus().isCreated.expectBody(CreateSentenceResponse::class.java)
             .returnResult().responseBody!!.sentenceSeq
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
         )
@@ -8132,7 +8132,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
         )
@@ -8523,7 +8523,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .expectStatus().isCreated.expectBody(CreateSentenceTermResponse::class.java)
             .returnResult().responseBody!!
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
         )
@@ -8744,7 +8744,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           .exchange()
           .expectStatus().isOk
 
-        verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+        verify(spRepository).imprisonmentStatusUpdate(
           bookingId = eq(latestBookingId),
           changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
         )
@@ -9742,7 +9742,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -10068,7 +10068,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -10268,7 +10268,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -10611,7 +10611,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -11341,7 +11341,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -11781,7 +11781,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )
@@ -12201,7 +12201,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .exchange()
             .expectStatus().isOk
 
-          verify(spRepository).imprisonmentStatusUpdateAsynchronous(
+          verify(spRepository).imprisonmentStatusUpdate(
             bookingId = eq(booking.bookingId),
             changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
           )


### PR DESCRIPTION
…edure

The asyncrhonous version can lead to the underlying procedure to be called on different connections at the same time causing data corruption.

Since we lock the case or booking anyway this can never happen when calling the synchronous version.