### PR TITLE
SDIT-4060 Allow order date to be updated.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -1263,9 +1263,9 @@ class CourtSentencingService(
   ) {
     if (courtEvent.courtEventCharges.any { charge -> charge.resultCode1?.resultRequiresACourtOrder() == true }) {
       existingCourtOrder(courtEvent.offenderBooking, courtEvent)?.let { order ->
-        // only amending orders without a sentence
-        if (!courtEvent.courtEventCharges.map { it.id.offenderCharge }
-            .any { it.offenderSentenceCharges.isNotEmpty() }
+        // only allow amending orders without a sentence, unless created today to allow for out of sequence appearance date updates
+        if (courtEvent.courtEventCharges.all { it.id.offenderCharge.offenderSentenceCharges.isEmpty() } ||
+          order.createDatetime.toLocalDate().isEqual(LocalDate.now())
         ) {
           if (order.courtDate != courtEvent.eventDate) {
             order.courtDate = courtEvent.eventDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -7502,6 +7502,7 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
   inner class CreateSentence {
     private lateinit var courtCase: CourtCase
     private lateinit var courtAppearance: CourtEvent
+    private lateinit var courtAppearanceWithOrderToday: CourtEvent
     private lateinit var courtAppearanceNoCourtOrder: CourtEvent
     private lateinit var offenderCharge1: OffenderCharge
     private lateinit var offenderCharge2: OffenderCharge
@@ -7531,12 +7532,23 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
                     offenderCharge = offenderCharge1,
                     plea = "NG",
                   )
-                  courtOrder(courtDate = LocalDate.of(2023, 1, 10)) {
+                  courtOrder(courtDate = LocalDate.of(2023, 1, 10), whenCreated = LocalDateTime.now().minusDays(1)) {
                     sentencePurpose(purposeCode = "REPAIR")
                     sentencePurpose(purposeCode = "PUNISH")
                   }
                   // NOMIS allows multiple orders for an appearance - but it is rare
                   courtOrder(courtDate = LocalDate.of(2023, 1, 10))
+                }
+                courtAppearanceWithOrderToday = courtEvent {
+// overrides from the parent offender charge fields
+                  courtEventCharge(
+                    resultCode1 = offenderCharge1.resultCode1?.code,
+                    offenderCharge = offenderCharge1,
+                    plea = "NG",
+                  )
+                  courtOrder(courtDate = LocalDate.of(2023, 1, 10), whenCreated = LocalDateTime.now()) {
+                    sentencePurpose(purposeCode = "PUNISH")
+                  }
                 }
                 courtAppearanceNoCourtOrder = courtEvent {
                   courtEventCharge(
@@ -7849,6 +7861,51 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
 
 // don't update if sentence exists
         verify(telemetryClient, never()).trackEvent(eq("court-order-updated"), any(), isNull())
+      }
+
+      @Test
+      fun `court order date updated when sentence exists but only just been created`() {
+        webTestClient.post().uri("/prisoners/${prisonerAtMoorland.nomsId}/court-cases/${courtCase.id}/sentences")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createSentence(
+                offenderChargeIds = mutableListOf(offenderCharge1.id, offenderCharge2.id),
+                eventId = courtAppearanceWithOrderToday.id,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated.expectBody(CreateSentenceResponse::class.java)
+          .returnResult().responseBody!!.sentenceSeq
+
+        webTestClient.put()
+          .uri("/prisoners/${prisonerAtMoorland.nomsId}/sentencing/court-cases/${courtCase.id}/court-appearances/${courtAppearanceWithOrderToday.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createCourtAppearanceRequest(
+// a different date to the court order
+                eventDateTime = LocalDateTime.parse("2023-06-06T00:00"),
+                courtEventCharges = mutableListOf(
+                  CourtEventChargeRequest(offenderCharge1.id, "1004"),
+                  CourtEventChargeRequest(offenderCharge2.id, "1005"),
+                ),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        verify(telemetryClient).trackEvent(
+          eq("court-order-updated"),
+          check {
+            assertThat(it).containsEntry("orderDate", "2023-06-06")
+          },
+          isNull(),
+        )
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourtEvent.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourtEvent.kt
@@ -27,9 +27,8 @@ import java.time.LocalDateTime
 @DslMarker
 annotation class CourtEventDslMarker
 
-@NomisDataDslMarker
+@CourtEventDslMarker
 interface CourtEventDsl {
-  @CourtEventChargeDslMarker
   fun courtEventCharge(
     offenderCharge: OffenderCharge,
     offencesCount: Int? = null,
@@ -50,7 +49,6 @@ interface CourtEventDsl {
     dsl: CourtEventChargeDsl.() -> Unit = {},
   ): CourtEventCharge
 
-  @CourtOrderDslMarker
   fun courtOrder(
     courtDate: LocalDate = LocalDate.of(2023, 1, 1),
     issuingCourt: String = "MDI",
@@ -62,10 +60,10 @@ interface CourtEventDsl {
     seriousnessLevel: String? = "HIGH",
     commentText: String? = "a court order comment",
     nonReportFlag: Boolean = false,
+    whenCreated: LocalDateTime? = null,
     dsl: CourtOrderDsl.() -> Unit = {},
   ): CourtOrder
 
-  @OffenderExternalMovementDslMarker
   fun courtMovementOut(
     date: LocalDateTime = LocalDateTime.now(),
     fromPrison: String = "BXI",
@@ -74,7 +72,6 @@ interface CourtEventDsl {
     comment: String? = null,
   ): OffenderCourtMovementOut
 
-  @OffenderExternalMovementDslMarker
   fun courtMovementIn(
     date: LocalDateTime = LocalDateTime.now(),
     toPrison: String = "BXI",
@@ -226,6 +223,7 @@ class CourtEventBuilder(
     seriousnessLevel: String?,
     commentText: String?,
     nonReportFlag: Boolean,
+    whenCreated: LocalDateTime?,
     dsl: CourtOrderDsl.() -> Unit,
   ) = courtOrderBuilderFactory.builder().let { builder ->
     builder.build(
@@ -240,6 +238,7 @@ class CourtEventBuilder(
       seriousnessLevel = seriousnessLevel,
       commentText = commentText,
       nonReportFlag = nonReportFlag,
+      whenCreated = whenCreated,
     )
       .also { courtEvent.courtOrders += it }
       .also { builder.apply(dsl) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourtOrder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/helper/builders/CourtOrder.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.helper.builders
 
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocation
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CourtEvent
@@ -11,13 +12,13 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.AgencyLocati
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtOrderRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ReferenceCodeRepository
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @DslMarker
 annotation class CourtOrderDslMarker
 
-@NomisDataDslMarker
+@CourtOrderDslMarker
 interface CourtOrderDsl {
-  @SentencePurposeDslMarker
   fun sentencePurpose(
     purposeCode: String = "REPAIR",
     orderPartyCode: String = "CRT",
@@ -41,14 +42,19 @@ class CourtOrderBuilderRepository(
   val repository: CourtOrderRepository,
   val agencyLocationRepository: AgencyLocationRepository,
   val seriousnessLevelTypeRepository: ReferenceCodeRepository<SeriousnessLevelType>,
+  private val jdbcTemplate: JdbcTemplate,
 ) {
-  fun save(courtOrder: CourtOrder): CourtOrder = repository.save(courtOrder)
+  fun save(courtOrder: CourtOrder): CourtOrder = repository.saveAndFlush(courtOrder)
 
   fun lookupAgency(id: String): AgencyLocation = agencyLocationRepository.findByIdOrNull(id)!!
 
   fun lookupSeriousnessType(code: String): SeriousnessLevelType = seriousnessLevelTypeRepository.findByIdOrNull(
     SeriousnessLevelType.pk(code),
   )!!
+
+  fun updateCreateDatetime(courtOrder: CourtOrder, whenCreated: LocalDateTime) {
+    jdbcTemplate.update("update ORDERS set CREATE_DATETIME = ? where ORDER_ID = ?", whenCreated, courtOrder.id)
+  }
 }
 
 class CourtOrderBuilder(
@@ -69,6 +75,7 @@ class CourtOrderBuilder(
     seriousnessLevel: String?,
     commentText: String?,
     nonReportFlag: Boolean,
+    whenCreated: LocalDateTime?,
   ): CourtOrder = CourtOrder(
     courtDate = courtDate,
     issuingCourt = repository.lookupAgency(issuingCourt),
@@ -86,6 +93,7 @@ class CourtOrderBuilder(
     courtEvent = courtEvent,
   )
     .let { repository.save(it) }
+    .also { whenCreated?.run { repository.updateCreateDatetime(it, whenCreated) } }
     .also { courtOrder = it }
 
   override fun sentencePurpose(


### PR DESCRIPTION
Allow Order dates to be updated when they have a sentence on the day of creation.

This is to allow edge case of sentence being created at same time of appearance date being changed while warrant is being added