### PR TITLE
SDIT-4072 Reject case cloning for future dated appearance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/config/ExceptionHandler.kt
@@ -7,6 +7,7 @@ import org.springframework.dao.PessimisticLockingFailureException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
+import org.springframework.http.HttpStatus.FAILED_DEPENDENCY
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.LOCKED
 import org.springframework.http.HttpStatus.NOT_FOUND
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.DependencyException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.DuplicateInsertException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ImageBadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ImageNotFoundException
@@ -119,6 +121,21 @@ class ExceptionHandler {
       .body(
         ErrorResponse(
           status = CONFLICT,
+          userMessage = e.message,
+          developerMessage = e.message,
+          moreInfo = e.entityId,
+        ),
+      )
+  }
+
+  @ExceptionHandler(DependencyException::class)
+  fun handleDependencyException(e: DependencyException): ResponseEntity<ErrorResponse>? {
+    log.info("Dependency http error: {}", e.message)
+    return ResponseEntity
+      .status(FAILED_DEPENDENCY)
+      .body(
+        ErrorResponse(
+          status = FAILED_DEPENDENCY,
           userMessage = e.message,
           developerMessage = e.message,
           moreInfo = e.entityId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
@@ -2868,6 +2868,7 @@ data class CourtAppearanceRequest(
   // nomis UI doesn't allow this during a create but DPS does
   val nextCourtId: String?,
   val comment: String?,
+  val futureAppearance: Boolean? = false,
 
   /* not currently provided by sentencing service:
   val orderRequestedFlag: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.audit.AuditRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.CodeDescription
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.DependencyException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.toCodeDescription
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.truncateToUtf8Length
@@ -420,6 +421,11 @@ class CourtSentencingService(
       clonedCourtCases = null,
     )
   } else {
+    // assume we are adding this future dated appearance at same time as we are adding
+    // the main warrant - so allow this to fail until cloning has finished
+    if (courtAppearanceRequest.futureAppearance == true) {
+      throw DependencyException("Cannot add future dated appearance until case has been cloned to latest booking", entityId = courtCase.id)
+    }
     cloneCourtCasesToLatestBookingFrom(courtCase).let {
       val sourceCase = it.courtCases.find { cases -> cases.sourceCourtCase.id == courtCase.id }!!
       val indexOfSourceCase = it.courtCases.indexOf(sourceCase)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/data/Exceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/data/Exceptions.kt
@@ -18,6 +18,7 @@ class ConflictException(message: String?, val entityId: Any? = null) :
   Supplier<ConflictException> {
   override fun get(): ConflictException = ConflictException(message, entityId)
 }
+class DependencyException(message: String?, val entityId: Any? = null) : RuntimeException(message)
 
 class NotFoundException(message: String?) :
   RuntimeException(message),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.web.reactive.function.BodyInserters
@@ -4937,6 +4938,25 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
         assertThat(clonedCourtCaseResponse.courtEvents).hasSize(2)
         assertThat(clonedCourtCaseResponse.courtEvents[1].eventDateTime).isEqualTo(LocalDateTime.parse("2023-01-05T09:00:00"))
         assertThat(clonedCourtCaseResponse.courtEvents[1].courtEventCharges).hasSize(2)
+      }
+
+      @Test
+      fun `will reject adding future court appearance until case is cloned`() {
+        webTestClient.post()
+          .uri("/prisoners/$offenderNo/sentencing/court-cases/${previousBookingCourtCase.id}/court-appearances")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createCourtAppearanceRequest(
+                courtEventCharges = mutableListOf(
+                  CourtEventChargeRequest(previousBookingOffenderCharge1.id, previousBookingOffenderCharge1.resultCode1?.code),
+                  CourtEventChargeRequest(previousBookingOffenderCharge2.id, previousBookingOffenderCharge2.resultCode1?.code),
+                ),
+              ).copy(futureAppearance = true),
+            ),
+          )
+          .exchange().expectStatus().isEqualTo(HttpStatus.FAILED_DEPENDENCY.value())
       }
 
       @Test


### PR DESCRIPTION
The issue is if a warrant with a next appearance is added but on a case on an old booking we react to the court appearance insert by cloning the court case. Since we might also get an event for next appearance at same time we can then clone the case twice causing chaos.

This will reject the clone for a next appearance and rely on sync retrying (await parent style)

NB there is potential for a extreme rare bug if DPS court appearance on old booking was amended to add a next court appearance while still being on old booking. This would result on message going on DLQ for manual intervention.