### PR TITLE
SDIT-4062 OffenderImprisonmentStatus basic rewrite

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/ImprisonmentStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/ImprisonmentStatusService.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderBooking
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderImprisonmentStatus
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderImprisonmentStatusId
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.CourtEventChargeRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.ImprisonmentStatusRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderBookingRepository
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderChargeRepository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository.OffenderImprisonmentStatusRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -19,6 +21,8 @@ class ImprisonmentStatusService(
   private val offenderImprisonmentStatusRepository: OffenderImprisonmentStatusRepository,
   private val imprisonmentStatusRepository: ImprisonmentStatusRepository,
   private val offenderBookingRepository: OffenderBookingRepository,
+  private val offenderChargeRepository: OffenderChargeRepository,
+  private val courtEventChargeRepository: CourtEventChargeRepository,
 ) {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -31,7 +35,8 @@ class ImprisonmentStatusService(
   }
 
   fun recalculateImprisonmentStatusAndMainOffence(offenderNo: String, reason: ChangeType): ImprisonmentStatusAndMainOffence {
-    val booking = offenderBookingRepository.findAllByOffenderNomsId(offenderNo).firstOrNull()
+    val booking = offenderBookingRepository.findLatestBookingIdByOffenderNomsId(offenderNo)
+      ?.let { offenderBookingRepository.findByIdOrNullForUpdate(it) }
       ?: throw NotFoundException("No booking found for offenderNo $offenderNo")
     val status = statusAndMainOffence(booking, offenderNo)
 
@@ -57,6 +62,8 @@ class ImprisonmentStatusService(
     reason: ChangeType,
   ) {
     currentStatuses.filter { it.latestStatus }.forEach {
+      // try to acquire lock
+      offenderImprisonmentStatusRepository.findByIdWaitForLock(it.id)
       it.latestStatus = false
       it.expiryDate = LocalDate.now()
     }
@@ -101,17 +108,26 @@ class ImprisonmentStatusService(
     resetMainOffenceForOldCharge(booking, offenderChargeId)
 
     val newMainOffenceCharge = booking.courtCases.flatMap { it.offenderCharges }.first { it.id == offenderChargeId }
+    // try to acquire lock
+    offenderChargeRepository.findByIdWaitForLock(newMainOffenceCharge.id)
     newMainOffenceCharge.mostSeriousFlag = true
     val courtEventCharges = booking.courtCases.flatMap { it.courtEvents }.flatMap { it.courtEventCharges }.filter { it.id.offenderCharge == newMainOffenceCharge }
-    courtEventCharges.forEach { it.mostSeriousFlag = true }
+    courtEventCharges.forEach {
+      courtEventChargeRepository.findByIdWaitForLock(it.id)
+      it.mostSeriousFlag = true
+    }
   }
 
   private fun resetMainOffenceForOldCharge(booking: OffenderBooking, offenderChargeId: Long) {
     val currentMainOffenceCharges = booking.courtCases.flatMap { it.offenderCharges }.filter { it.mostSeriousFlag }.filter { it.id != offenderChargeId }
     currentMainOffenceCharges.forEach { offenderCharge ->
+      offenderChargeRepository.findByIdWaitForLock(offenderCharge.id)
       offenderCharge.mostSeriousFlag = false
       val courtEventCharges = booking.courtCases.flatMap { it.courtEvents }.flatMap { it.courtEventCharges }.filter { it.id.offenderCharge == offenderCharge }
-      courtEventCharges.forEach { it.mostSeriousFlag = false }
+      courtEventCharges.forEach {
+        courtEventChargeRepository.findByIdWaitForLock(it.id)
+        it.mostSeriousFlag = false
+      }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
@@ -19,4 +19,9 @@ interface CourtEventChargeRepository : JpaRepository<CourtEventCharge, CourtEven
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
   @Query("SELECT c FROM CourtEventCharge c WHERE c.id = :id")
   fun findByIdOrNullForUpdate(id: CourtEventChargeId): CourtEventCharge?
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
+  @Query("SELECT c FROM CourtEventCharge c WHERE c.id = :id")
+  fun findByIdWaitForLock(id: CourtEventChargeId): CourtEventCharge
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
@@ -31,6 +31,16 @@ interface OffenderBookingRepository :
   )
   fun findLatestByOffenderNomsId(@Param("nomsId") nomsId: String): OffenderBooking?
 
+  @Query(
+    """
+    select booking.bookingId from OffenderBooking booking 
+        join Offender offender on booking.offender = offender 
+        where offender.nomsId = :nomsId 
+        and booking.bookingSequence = 1
+        """,
+  )
+  fun findLatestBookingIdByOffenderNomsId(@Param("nomsId") nomsId: String): Long?
+
   fun findAllByOffenderNomsId(@Param("nomsId") nomsId: String): List<OffenderBooking>
 
   fun findOneByOffenderNomsIdAndBookingSequence(nomsId: String, sequence: Int): OffenderBooking?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderChargeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderChargeRepository.kt
@@ -17,4 +17,9 @@ interface OffenderChargeRepository : JpaRepository<OffenderCharge, Long> {
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
   @Query("SELECT c FROM OffenderCharge c WHERE c.id = :id")
   fun findByIdOrNullForUpdate(id: Long): OffenderCharge?
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
+  @Query("SELECT c FROM OffenderCharge c WHERE c.id = :id")
+  fun findByIdWaitForLock(id: Long): OffenderCharge
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderImprisonmentStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderImprisonmentStatusRepository.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderImprisonmentStatus
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderImprisonmentStatusId
@@ -101,6 +105,11 @@ SELECT NVL(imprisonment_status,'UNKNOWN'),
     nativeQuery = true,
   )
   fun getStatusAndMainOffenceViaChargeOutcomeByBookingId(bookingId: Long): StatusAndMainOffence
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
+  @Query("from OffenderImprisonmentStatus ois where ois.id = :status")
+  fun findByIdWaitForLock(status: OffenderImprisonmentStatusId): OffenderImprisonmentStatus
 }
 
 data class StatusAndMainOffence(val imprisonmentStatus: String, val offenderChargeId: BigDecimal?)


### PR DESCRIPTION
Now lock booking record to prevent service being called concurrently for same booking.

Also try to acquire lock for each of these records that can be updated:

* OFFENDER_IMPRISON_STATUSES
* OFFENDER_CHARGES
* COURT_EVENT_CHARGES

This should prevent a NOMIS lock from hanging this service indefinitely

* Switch to use this service from Stored Procedure