### PR TITLE
SDIT-4062 Sentence Term no longer calls imprisonment status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/contactperson/ContactPersonService.kt
@@ -777,7 +777,7 @@ class ContactPersonService(
   fun identifierTypeOf(code: String): IdentifierType = identifierRepository.findByIdOrNull(IdentifierType.pk(code)) ?: throw BadDataException("IdentifierType with code $code does not exist")
   fun restrictionTypeOf(code: String): RestrictionType = restrictionTypeRepository.findByIdOrNull(RestrictionType.pk(code)) ?: throw BadDataException("RestrictionType with code $code does not exist")
   fun contactOf(personId: Long, contactId: Long): OffenderContactPerson = (contactRepository.findByIdOrNull(contactId) ?: throw NotFoundException("Contact with id=$contactId does not exist")).takeIf { it.person == personOf(personId) } ?: throw NotFoundException("Contact with id=$contactId on Person with id=$personId does not exist")
-  fun getContactAndLock(personId: Long, contactId: Long): OffenderContactPerson = (contactRepository.findByIdOrNullForUpdate(contactId) ?: throw NotFoundException("Contact with id=$contactId does not exist")).takeIf { it.person == personOf(personId) } ?: throw NotFoundException("Contact with id=$contactId on Person with id=$personId does not exist")
+  fun getContactAndLock(personId: Long, contactId: Long): OffenderContactPerson = (contactRepository.findByIdOrNullWaitForLock(contactId) ?: throw NotFoundException("Contact with id=$contactId does not exist")).takeIf { it.person == personOf(personId) } ?: throw NotFoundException("Contact with id=$contactId on Person with id=$personId does not exist")
 
   fun getContact(contactId: Long): PersonContact {
     val contact = contactRepository.findByIdOrNull(contactId) ?: throw NotFoundException("Contact with id=$contactId does not exist")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -708,7 +708,7 @@ class CourtSentencingService(
         "caseId" to caseId.toString(),
       )
 
-      courtEventRepository.findByIdOrNullForUpdate(eventId)?.also {
+      courtEventRepository.findByIdOrNullWaitForLock(eventId)?.also {
         val offenderCharges = it.courtEventCharges.map { cec -> cec.id.offenderCharge }
         case.courtEvents.remove(it)
         courtCaseRepository.saveAndFlush(case)
@@ -999,12 +999,7 @@ class CourtSentencingService(
       endDate = null,
       sentenceTermType = lookupSentenceTermType(termRequest.sentenceTermType),
     )
-    offenderSentenceTermRepository.saveAndFlush(term).also {
-      imprisonmentStatusService.recalculateImprisonmentStatusAndMainOffence(
-        bookingId = offenderBooking.bookingId,
-        changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
-      )
-    }
+    offenderSentenceTermRepository.saveAndFlush(term)
 
     CreateSentenceTermResponse(
       sentenceSeq = sentenceSequence,
@@ -1027,7 +1022,7 @@ class CourtSentencingService(
   fun deleteSentence(offenderNo: String, caseId: Long, sentenceSequence: Long) {
     findCourtCase(id = caseId, offenderNo = offenderNo).let { case ->
       val offenderBooking = case.offenderBooking
-      offenderSentenceRepository.findByIdOrNullForUpdate(
+      offenderSentenceRepository.findByIdOrNullWaitForLock(
         SentenceId(
           offenderBooking = offenderBooking,
           sequence = sentenceSequence,
@@ -1058,7 +1053,7 @@ class CourtSentencingService(
   fun deleteSentenceTerm(offenderNo: String, caseId: Long, sentenceSequence: Long, termSequence: Long) {
     findCourtCase(id = caseId, offenderNo = offenderNo).let { case ->
       val offenderBooking = case.offenderBooking
-      offenderSentenceTermRepository.findByIdOrNullForUpdate(
+      offenderSentenceTermRepository.findByIdOrNullWaitForLock(
         OffenderSentenceTermId(
           offenderBooking = offenderBooking,
           sentenceSequence = sentenceSequence,
@@ -1202,12 +1197,7 @@ class CourtSentencingService(
         term.lifeSentenceFlag = termRequest.lifeSentenceFlag
         term.sentenceTermType = lookupSentenceTermType(termRequest.sentenceTermType)
 
-        offenderSentenceTermRepository.saveAndFlush(term).also {
-          imprisonmentStatusService.recalculateImprisonmentStatusAndMainOffence(
-            bookingId = case.offenderBooking.bookingId,
-            changeType = ImprisonmentStatusChangeType.UPDATE_SENTENCE.name,
-          )
-        }
+        offenderSentenceTermRepository.saveAndFlush(term)
 
         telemetryClient.trackEvent(
           "sentence-term-updated",
@@ -1489,7 +1479,7 @@ class CourtSentencingService(
       )
     }
     val casesUpdated = request.beachCourtEventIds.mapNotNull {
-      courtEventRepository.findByIdOrNullForUpdate(it)?.let { courtEvent ->
+      courtEventRepository.findByIdOrNullWaitForLock(it)?.let { courtEvent ->
         if (courtEvent.courtCase in courtCasesInRecall) {
           courtEvent.setEventDateAndTime(request.recallRevocationDate.atTime(LocalTime.MIDNIGHT))
           updatedBreachCourtEventIds.add(it)
@@ -1545,7 +1535,7 @@ class CourtSentencingService(
     }
 
     request.beachCourtEventIds.forEach {
-      courtEventRepository.findByIdOrNullForUpdate(it)?.run {
+      courtEventRepository.findByIdOrNullWaitForLock(it)?.run {
         courtEventRepository.delete(this)
       }
     }
@@ -1576,7 +1566,7 @@ class CourtSentencingService(
       )
     }
     request.beachCourtEventIds.forEach {
-      courtEventRepository.findByIdOrNullForUpdate(it)?.run {
+      courtEventRepository.findByIdOrNullWaitForLock(it)?.run {
         courtEventRepository.delete(this)
       }
     }
@@ -1685,19 +1675,19 @@ class CourtSentencingService(
   private fun findOffenderBooking(id: Long): OffenderBooking = offenderBookingRepository.findByIdOrNull(id)
     ?: throw NotFoundException("Offender booking $id not found")
 
-  private fun findOffenderBookingWithLock(id: Long): OffenderBooking = offenderBookingRepository.findByIdOrNullForUpdate(id)
+  private fun findOffenderBookingWithLock(id: Long): OffenderBooking = offenderBookingRepository.findByIdOrNullWaitForLock(id)
     ?: throw NotFoundException("Offender booking $id not found")
 
   private fun findCourtCase(id: Long, offenderNo: String): CourtCase = courtCaseRepository.findByIdOrNull(id)
     ?: throw NotFoundException("Court case $id for $offenderNo not found")
 
-  private fun findCourtCaseWithLock(id: Long, offenderNo: String): CourtCase = courtCaseRepository.findByIdOrNullForUpdate(id)
+  private fun findCourtCaseWithLock(id: Long, offenderNo: String): CourtCase = courtCaseRepository.findByIdOrNullWaitForLock(id)
     ?: throw NotFoundException("Court case $id for $offenderNo not found")
 
   private fun findCourtAppearance(id: Long, offenderNo: String): CourtEvent = courtEventRepository.findByIdOrNull(id)
     ?: throw NotFoundException("Court appearance $id for $offenderNo not found")
 
-  private fun findCourtAppearanceWithLock(id: Long, offenderNo: String): CourtEvent = courtEventRepository.findByIdOrNullForUpdate(id)
+  private fun findCourtAppearanceWithLock(id: Long, offenderNo: String): CourtEvent = courtEventRepository.findByIdOrNullWaitForLock(id)
     ?: throw NotFoundException("Court appearance $id for $offenderNo not found")
 
   private fun findSentence(sentenceSequence: Long, booking: OffenderBooking): OffenderSentence = offenderSentenceRepository.findByIdOrNull(
@@ -1708,7 +1698,7 @@ class CourtSentencingService(
   )
     ?: throw NotFoundException("Sentence for booking ${booking.bookingId} and sentence sequence $sentenceSequence not found")
 
-  private fun findSentenceWithLock(sentenceSequence: Long, booking: OffenderBooking): OffenderSentence = offenderSentenceRepository.findByIdOrNullForUpdate(
+  private fun findSentenceWithLock(sentenceSequence: Long, booking: OffenderBooking): OffenderSentence = offenderSentenceRepository.findByIdOrNullWaitForLock(
     SentenceId(
       sequence = sentenceSequence,
       offenderBooking = booking,
@@ -1735,7 +1725,7 @@ class CourtSentencingService(
     sentenceSequence: Long,
     booking: OffenderBooking,
     offenderNo: String,
-  ): OffenderSentenceTerm = offenderSentenceTermRepository.findByIdOrNullForUpdate(
+  ): OffenderSentenceTerm = offenderSentenceTermRepository.findByIdOrNullWaitForLock(
     OffenderSentenceTermId(
       termSequence = termSequence,
       sentenceSequence = sentenceSequence,
@@ -1747,13 +1737,13 @@ class CourtSentencingService(
   private fun findOffenderCharge(id: Long, offenderNo: String): OffenderCharge = offenderChargeRepository.findByIdOrNull(id)
     ?: throw NotFoundException("Offender Charge $id for $offenderNo not found")
 
-  private fun findOffenderChargeWithLock(id: Long, offenderNo: String): OffenderCharge = offenderChargeRepository.findByIdOrNullForUpdate(id)
+  private fun findOffenderChargeWithLock(id: Long, offenderNo: String): OffenderCharge = offenderChargeRepository.findByIdOrNullWaitForLock(id)
     ?: throw NotFoundException("Offender Charge $id for $offenderNo not found")
 
   private fun findCourtEventCharge(id: CourtEventChargeId, offenderNo: String): CourtEventCharge = courtEventChargeRepository.findByIdOrNull(id)
     ?: throw NotFoundException("Court event charge with offenderChargeId ${id.offenderCharge.id} for $offenderNo not found")
 
-  private fun findCourtEventChargeWithLock(id: CourtEventChargeId, offenderNo: String): CourtEventCharge = courtEventChargeRepository.findByIdOrNullForUpdate(id)
+  private fun findCourtEventChargeWithLock(id: CourtEventChargeId, offenderNo: String): CourtEventCharge = courtEventChargeRepository.findByIdOrNullWaitForLock(id)
     ?: throw NotFoundException("Court event charge with offenderChargeId ${id.offenderCharge.id} for $offenderNo not found")
 
   private fun lookupLegalCaseType(code: String): LegalCaseType = legalCaseTypeRepository.findByIdOrNull(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/ImprisonmentStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/ImprisonmentStatusService.kt
@@ -109,10 +109,14 @@ class ImprisonmentStatusService(
   private fun updateMainOffence(booking: OffenderBooking, offenderChargeId: Long) {
     resetMainOffenceForOldCharge(booking, offenderChargeId)
 
-    val newMainOffenceCharge = booking.courtCases.flatMap { it.offenderCharges }.first { it.id == offenderChargeId }
+    val newMainOffenceCharge = booking.courtCases.flatMap { it.offenderCharges }.firstOrNull { it.id == offenderChargeId }
     // try to acquire lock
-    offenderChargeRepository.findByIdWaitForLock(newMainOffenceCharge.id)
-    newMainOffenceCharge.mostSeriousFlag = true
+    newMainOffenceCharge?.run {
+      offenderChargeRepository.findByIdWaitForLock(id)
+      mostSeriousFlag = true
+    } ?: run {
+      log.trace("OffenderCharge with id $offenderChargeId not found for offenderBooking ${booking.bookingId}, cannot set as main offence")
+    }
     val courtEventCharges = booking.courtCases.flatMap { it.courtEvents }.flatMap { it.courtEventCharges }.filter { it.id.offenderCharge == newMainOffenceCharge }
     courtEventCharges.forEach {
       courtEventChargeRepository.findByIdWaitForLock(it.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/csip/CSIPService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/csip/CSIPService.kt
@@ -173,7 +173,7 @@ class CSIPService(
     }
   }
 
-  private fun updateCSIPReport(request: UpsertCSIPRequest): CSIPReport = csipRepository.findByIdOrNullForUpdate(request.id!!)?.apply {
+  private fun updateCSIPReport(request: UpsertCSIPRequest): CSIPReport = csipRepository.findByIdOrNullWaitForLock(request.id!!)?.apply {
     incidentDate = request.incidentDate
     incidentTime = request.incidentTime?.atDate(incidentDate)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/incidents/IncidentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/incidents/IncidentService.kt
@@ -79,7 +79,7 @@ class IncidentService(
     val reportedStaff = lookupStaff(request.reportedBy)
 
     return (
-      incidentRepository.findByIdOrNullForUpdate(incidentId)?.apply {
+      incidentRepository.findByIdOrNullWaitForLock(incidentId)?.apply {
         this.title = request.title.truncateToUtf8Length(240, true)
         this.description = reconstructText(request)
         this.incidentType = questionnaire.code

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CSIPReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CSIPReportRepository.kt
@@ -59,7 +59,7 @@ interface CSIPReportRepository :
   fun findIdsByOffenderBookingBookingId(bookingId: Long): List<Long>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT c FROM CSIPReport c WHERE c.id = :csipId")
-  fun findByIdOrNullForUpdate(csipId: Long): CSIPReport?
+  fun findByIdOrNullWaitForLock(csipId: Long): CSIPReport?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtCaseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtCaseRepository.kt
@@ -66,9 +66,9 @@ interface CourtCaseRepository : JpaRepository<CourtCase, Long> {
   fun findCourtCaseIdsForOffender(offenderNo: String): List<Long>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT c FROM CourtCase c WHERE c.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): CourtCase?
+  fun findByIdOrNullWaitForLock(id: Long): CourtCase?
 
   @Modifying
   @Query(nativeQuery = true, value = "UPDATE OFFENDER_CASES cc SET cc.CASE_INFO_NUMBER = :caseInfoNumber WHERE cc.CASE_ID = :caseId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventChargeRepository.kt
@@ -16,9 +16,9 @@ interface CourtEventChargeRepository : JpaRepository<CourtEventCharge, CourtEven
   fun existsByIdOffenderChargeId(offenderChargeId: Long): Boolean
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT c FROM CourtEventCharge c WHERE c.id = :id")
-  fun findByIdOrNullForUpdate(id: CourtEventChargeId): CourtEventCharge?
+  fun findByIdOrNullWaitForLock(id: CourtEventChargeId): CourtEventCharge?
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CourtEventRepository.kt
@@ -35,7 +35,7 @@ interface CourtEventRepository : JpaRepository<CourtEvent, Long> {
   fun findByOffenderBooking_BookingIdAndParentEventId(offenderBookingBookingId: Long, parentEventId: Long): CourtEvent?
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT c FROM CourtEvent c WHERE c.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): CourtEvent?
+  fun findByIdOrNullWaitForLock(id: Long): CourtEvent?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/IncidentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/IncidentRepository.kt
@@ -115,7 +115,7 @@ interface IncidentRepository :
   fun findAllIncidentsByBookingId(bookingId: Long): List<Incident>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT incident FROM Incident incident WHERE incident.id = :incidentId")
-  fun findByIdOrNullForUpdate(incidentId: Long): Incident?
+  fun findByIdOrNullWaitForLock(incidentId: Long): Incident?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderBookingRepository.kt
@@ -93,9 +93,9 @@ interface OffenderBookingRepository :
   fun findActivePrisonNumbersBetweenIds(fromRootOffenderId: Long, toRootOffenderId: Long): List<String>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("from OffenderBooking ob where ob.bookingId = :bookingId")
-  fun findByIdOrNullForUpdate(bookingId: Long): OffenderBooking?
+  fun findByIdOrNullWaitForLock(bookingId: Long): OffenderBooking?
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderChargeRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderChargeRepository.kt
@@ -14,9 +14,9 @@ interface OffenderChargeRepository : JpaRepository<OffenderCharge, Long> {
   fun deleteByOffenderBookingBookingId(bookingId: Long)
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT c FROM OffenderCharge c WHERE c.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): OffenderCharge?
+  fun findByIdOrNullWaitForLock(id: Long): OffenderCharge?
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderContactPersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderContactPersonRepository.kt
@@ -19,5 +19,5 @@ interface OffenderContactPersonRepository : JpaRepository<OffenderContactPerson,
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("select c from OffenderContactPerson c where c.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): OffenderContactPerson?
+  fun findByIdOrNullWaitForLock(id: Long): OffenderContactPerson?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceRepository.kt
@@ -28,7 +28,7 @@ interface OffenderSentenceRepository :
   fun findByIdOffenderBookingBookingIdInAndAuditModuleNameAndStatusAndCourtCaseIsNotNull(offenderBookingIds: List<Long>, auditModule: String = "MERGE", status: String = "I"): List<OffenderSentence>
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT s FROM OffenderSentence s WHERE s.id = :id")
-  fun findByIdOrNullForUpdate(id: SentenceId): OffenderSentence?
+  fun findByIdOrNullWaitForLock(id: SentenceId): OffenderSentence?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceTermRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderSentenceTermRepository.kt
@@ -16,7 +16,7 @@ interface OffenderSentenceTermRepository : JpaRepository<OffenderSentenceTerm, O
   fun getNextTermSequence(offenderBookId: Long, sentenceSeq: Long): Long
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "2000")])
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT st FROM OffenderSentenceTerm st WHERE st.id = :id")
-  fun findByIdOrNullForUpdate(id: OffenderSentenceTermId): OffenderSentenceTerm?
+  fun findByIdOrNullWaitForLock(id: OffenderSentenceTermId): OffenderSentenceTerm?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapApplicationRepository.kt
@@ -29,5 +29,5 @@ interface OffenderTapApplicationRepository : JpaRepository<OffenderTapApplicatio
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT ota FROM OffenderTapApplication ota WHERE ota.tapApplicationId = :id")
-  fun findByIdOrNullForUpdate(id: Long): OffenderTapApplication?
+  fun findByIdOrNullWaitForLock(id: Long): OffenderTapApplication?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapScheduleOutRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapScheduleOutRepository.kt
@@ -17,5 +17,5 @@ interface OffenderTapScheduleOutRepository : JpaRepository<OffenderTapScheduleOu
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query(value = "select tso from OffenderTapScheduleOut tso where (tso.eventId = :eventId)")
-  fun findByEventIdOrNullForUpdate(eventId: Long): OffenderTapScheduleOut?
+  fun findByEventIdOrNullWaitForLock(eventId: Long): OffenderTapScheduleOut?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderVisitBalanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderVisitBalanceRepository.kt
@@ -14,5 +14,5 @@ interface OffenderVisitBalanceRepository : CrudRepository<OffenderVisitBalance, 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "20000")])
   @Query("SELECT ovb FROM OffenderVisitBalance ovb WHERE ovb.offenderBookingId = :offenderBookingId")
-  fun findByIdForUpdate(offenderBookingId: Long): OffenderVisitBalance?
+  fun findByIdOrNullWaitForLock(offenderBookingId: Long): OffenderVisitBalance?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/VisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/VisitRepository.kt
@@ -49,7 +49,7 @@ interface VisitRepository :
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("SELECT v FROM Visit v WHERE v.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): Visit?
+  fun findByIdOrNullWaitForLock(id: Long): Visit?
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/VisitVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/VisitVisitorRepository.kt
@@ -26,5 +26,5 @@ interface VisitVisitorRepository : JpaRepository<VisitVisitor, Long> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")])
   @Query("select vv from VisitVisitor vv where vv.id = :id")
-  fun findByIdOrNullForUpdate(id: Long): VisitVisitor?
+  fun findByIdOrNullWaitForLock(id: Long): VisitVisitor?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/court/schedule/CourtScheduleService.kt
@@ -59,7 +59,7 @@ class CourtScheduleService(
 
     val scheduleOut = request.eventId
       ?.takeIf { !recreate }
-      ?.let { courtEventRepository.findByIdOrNullForUpdate(it)!! }
+      ?.let { courtEventRepository.findByIdOrNullWaitForLock(it)!! }
       ?. apply {
         this.setEventDateAndTime(request.startTime)
         this.courtEventType = courtEventType
@@ -113,7 +113,7 @@ class CourtScheduleService(
   @Transactional
   @Audit(auditModule = "DPS_COURT_SCHEDULER_SYNCHRONISATION")
   fun deleteCourtScheduleOut(offenderNo: String, eventId: Long) {
-    courtEventRepository.findByIdOrNullForUpdate(eventId)
+    courtEventRepository.findByIdOrNullWaitForLock(eventId)
       ?.also { schedule ->
         movementOutRepository.findByCourtScheduleOutId(eventId)
           .takeIf { it != null }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/application/TapApplicationService.kt
@@ -64,7 +64,7 @@ class TapApplicationService(
 
     val application = request.tapApplicationId
       ?.let {
-        applicationRepository.findByIdOrNullForUpdate(request.tapApplicationId)
+        applicationRepository.findByIdOrNullWaitForLock(request.tapApplicationId)
           ?: throw NotFoundException("Tap application with id=$request.movementApplicationId not found for offender with nomsId=$offenderNo")
       } ?: OffenderTapApplication(
       offenderBooking = offenderBooking,
@@ -110,7 +110,7 @@ class TapApplicationService(
       val schedule = application.tapScheduleOuts.firstOrNull()
       if (schedule?.tapMovementOut != null) throw BadDataException("Attempt to remove a schedule from an unapproved application failed - the schedule (${schedule.eventId}) is attached to a movement (${schedule.tapMovementOut!!.id.offenderBooking.bookingId}/${schedule.tapMovementOut!!.id.sequence}).")
       schedule?.run {
-        scheduleOutRepository.findByEventIdOrNullForUpdate(schedule.eventId)
+        scheduleOutRepository.findByEventIdOrNullWaitForLock(schedule.eventId)
           ?.also { scheduleOutRepository.delete(it) }
         application.tapScheduleOuts.remove(schedule)
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/schedule/TapScheduleService.kt
@@ -140,7 +140,7 @@ class TapScheduleService(
 
   @Transactional
   fun deleteTapScheduleOut(offenderNo: String, eventId: Long) {
-    scheduleOutRepository.findByEventIdOrNullForUpdate(eventId)
+    scheduleOutRepository.findByEventIdOrNullWaitForLock(eventId)
       ?.also { schedule ->
         if (schedule.tapMovementOut != null) {
           throw ConflictException("Cannot delete tap schedule out eventId $eventId because it has a movement ${schedule.tapMovementOut!!.id.offenderBooking.bookingId} / ${schedule.tapMovementOut!!.id.sequence}}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visitbalances/VisitBalanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visitbalances/VisitBalanceService.kt
@@ -145,7 +145,7 @@ class VisitBalanceService(
     // Inserting an adjustment causes a trigger to fire to update the balance
     // We don't want the balance to be updated with old data if multiple adjustments are inserted
     // at the same time (due to visit cancellation), so attempt to avoid by selecting for update here
-    val visitBalance = visitBalanceRepository.findByIdForUpdate(offenderBooking.bookingId)
+    val visitBalance = visitBalanceRepository.findByIdOrNullWaitForLock(offenderBooking.bookingId)
       ?: OffenderVisitBalance(
         remainingVisitOrders = 0,
         remainingPrivilegedVisitOrders = 0,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/OfficialVisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/OfficialVisitsService.kt
@@ -169,7 +169,7 @@ class OfficialVisitsService(
 
   @Audit(auditModule = "DPS_SYNCHRONISATION_OFFICIAL_VISITS")
   fun updateVisit(visitId: Long, request: UpdateOfficialVisitRequest) {
-    val visit = visitRepository.findByIdOrNullForUpdate(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
+    val visit = visitRepository.findByIdOrNullWaitForLock(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
 
     with(visit) {
       commentText = request.commentText
@@ -195,7 +195,7 @@ class OfficialVisitsService(
     visitId: Long,
     request: CreateOfficialVisitorRequest,
   ): OfficialVisitResponse.OfficialVisitor {
-    val visit = visitRepository.findByIdOrNullForUpdate(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
+    val visit = visitRepository.findByIdOrNullWaitForLock(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
     val person = personRepository.findByIdOrNull(request.personId) ?: throw BadDataException("Person with id ${request.personId} not found")
     visit.visitors.find { it.person?.id == request.personId }?.also {
       throw ConflictException("Person ${request.personId} is already on visit $visitId", entityId = it.id.toString())
@@ -223,8 +223,8 @@ class OfficialVisitsService(
     visitorId: Long,
     request: UpdateOfficialVisitorRequest,
   ) {
-    visitVisitorRepository.findByIdOrNullForUpdate(visitorId)?.also { visitor ->
-      val visit = visitRepository.findByIdOrNullForUpdate(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
+    visitVisitorRepository.findByIdOrNullWaitForLock(visitorId)?.also { visitor ->
+      val visit = visitRepository.findByIdOrNullWaitForLock(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
       if (visitor.visit != visit) {
         throw BadDataException("Visitor with id $visitorId does not belong to visit with id $visitId")
       }
@@ -241,8 +241,8 @@ class OfficialVisitsService(
 
   @Audit(auditModule = "DPS_SYNCHRONISATION_OFFICIAL_VISITS")
   fun deleteVisitorForVisit(visitId: Long, visitorId: Long) {
-    visitRepository.findByIdOrNullForUpdate(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
-    visitVisitorRepository.findByIdOrNullForUpdate(visitorId)?.also { visitor ->
+    visitRepository.findByIdOrNullWaitForLock(visitId) ?: throw NotFoundException("Visit with id $visitId not found")
+    visitVisitorRepository.findByIdOrNullWaitForLock(visitorId)?.also { visitor ->
       if (visitor.visit.id != visitId) {
         throw BadDataException("Visitor with id $visitorId does not belong to visit with id $visitId")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitService.kt
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.nomisprisonerapi.config.trackEvent
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.BadDataException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.ConflictException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
@@ -149,7 +148,7 @@ class VisitService(
   fun cancelVisit(offenderNo: String, visitId: Long, visitDto: CancelVisitRequest) {
     val today = LocalDate.now()
 
-    val visit = visitRepository.findByIdOrNullForUpdate(visitId)
+    val visit = visitRepository.findByIdOrNullWaitForLock(visitId)
       ?: throw NotFoundException("Nomis visit id $visitId not found")
 
     val visitOutcome = visitOutcomeRepository.findById(VisitOutcomeReason.pk(visitDto.outcome))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -8614,12 +8614,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
             .expectStatus().isCreated.expectBody(CreateSentenceTermResponse::class.java)
             .returnResult().responseBody!!
 
-        verify(spRepository).imprisonmentStatusUpdate(
-          jdbcTemplate = any(),
-          bookingId = eq(latestBookingId),
-          changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
-        )
-
         webTestClient.get()
           .uri("/prisoners/${prisonerAtMoorland.nomsId}/sentence-terms/booking-id/${response.bookingId}/sentence-sequence/${response.sentenceSeq}/term-sequence/${response.termSeq}")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
@@ -8835,12 +8829,6 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
           )
           .exchange()
           .expectStatus().isOk
-
-        verify(spRepository).imprisonmentStatusUpdate(
-          jdbcTemplate = any(),
-          bookingId = eq(latestBookingId),
-          changeType = eq(ImprisonmentStatusChangeType.UPDATE_SENTENCE.name),
-        )
 
         webTestClient.get()
           .uri("/prisoners/${prisonerAtMoorland.nomsId}/sentence-terms/booking-id/${prisonerAtMoorland.latestBooking().bookingId}/sentence-sequence/${sentenceTwo.id.sequence}/term-sequence/${term.id.termSequence}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapApplicationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapApplicationResourceIntTest.kt
@@ -776,7 +776,7 @@ class TapApplicationResourceIntTest(
       @Test
       fun `should return 423 if application is locked for update`() {
         repository.runInTransaction {
-          applicationRepository.findByIdOrNullForUpdate(application.tapApplicationId)
+          applicationRepository.findByIdOrNullWaitForLock(application.tapApplicationId)
 
           webTestClient.upsertApplication(request = anUpsertApplicationRequest(id = application.tapApplicationId))
             .isEqualTo(423)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/visits/VisitServiceTest.kt
@@ -517,7 +517,7 @@ internal class VisitServiceTest {
 
     @Test
     fun `visit data is amended correctly`() {
-      whenever(visitRepository.findByIdOrNullForUpdate(VISIT_ID)).thenReturn(defaultVisit)
+      whenever(visitRepository.findByIdOrNullWaitForLock(VISIT_ID)).thenReturn(defaultVisit)
       whenever(visitVisitorRepository.findAllByIdIn(defaultVisit.visitors.map { it.id })).thenReturn(defaultVisit.visitors)
 
       visitService.cancelVisit(OFFENDER_NO, VISIT_ID, cancelVisitRequest)


### PR DESCRIPTION
Term has no effect on status or main offence so no need to refresh at this point.

Alos renamed all repo methods that acquire lock to be explicit what it is doing

Also temp fix to deal with offender charge not found during imprisonment status calculation. This requires further work