### PR TITLE
MAPB-744 Close a property container in NOMIS when DPS removes it

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderPropertyContainer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderPropertyContainer.kt
@@ -55,7 +55,7 @@ data class OffenderPropertyContainer(
   var containerCode: PropertyContainerCode,
 
   var proposedDisposalDate: LocalDate? = null,
-  val expiryDate: LocalDate? = null,
+  var expiryDate: LocalDate? = null,
 ) : NomisAuditableEntityBasic() {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyContainerCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyContainerCreateRequest.kt
@@ -31,7 +31,7 @@ data class PropertyContainerCreateRequest(
   )
   val containerCode: PropertyContainerCode,
 
-  @Schema(description = "Date the container is no longer active")
+  @Schema(description = "Date the container is no longer active", example = "2027-01-01")
   val expiryDate: LocalDate? = null,
 
   @Schema(description = "Date the container will be disposed of")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyContainerUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyContainerUpdateRequest.kt
@@ -23,4 +23,10 @@ data class PropertyContainerUpdateRequest(
 
   @Schema(description = "Date the container will be disposed of")
   val proposedDisposalDate: LocalDate? = null,
+
+  @Schema(description = "Whether the container is active")
+  val active: Boolean,
+
+  @Schema(description = "Date the container is no longer active", example = "2027-01-01")
+  val expiryDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyService.kt
@@ -44,6 +44,8 @@ class PropertyService(
       sealMark = propertyContainerUpdateRequest.sealMark
       agencyInternalLocation = findLocation(propertyContainerUpdateRequest.internalLocationId)
       proposedDisposalDate = propertyContainerUpdateRequest.proposedDisposalDate
+      active = propertyContainerUpdateRequest.active
+      expiryDate = propertyContainerUpdateRequest.expiryDate
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/property/PropertyResourceIntTest.kt
@@ -320,6 +320,8 @@ class PropertyResourceIntTest : IntegrationTestBase() {
               assertThat(sealMark).isEqualTo("SEAL4567")
               assertThat(containerCode).isEqualTo(PropertyContainerCode.BRA)
               assertThat(proposedDisposalDate).isEqualTo("2027-11-02")
+              assertThat(active).isFalse()
+              assertThat(expiryDate).isEqualTo("2026-07-02")
             }
         }
       }
@@ -585,6 +587,8 @@ fun validUpdateJsonRequest(internalLocationId: Long): String =
      "internalLocationId": $internalLocationId,
      "proposedDisposalDate": "2027-11-02",
      "sealMark": "SEAL4567",
-     "containerCode": "BRA"
+     "containerCode": "BRA",
+     "active": false,
+     "expiryDate": "2026-07-02"
    }
   """.trimIndent()


### PR DESCRIPTION
## Description
This PR implements the ability to close a property container in NOMIS when DPS (Digital Prison Services) removes it.

## Changes
- Updates `PropertyContainerUpdateRequest` to support marking containers as inactive
- Adds handling for the active/inactive status in `PropertyService`
- Updates `OffenderPropertyContainer` entity to track the active state
- Adds test coverage for the new property container update functionality

## Ticket
[MAPB-744](https://dps-jira.digital.noms.gsi.gov.uk/browse/MAPB-744)

[MAPB-744]: https://dsdmoj.atlassian.net/browse/MAPB-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ