### PR TITLE
SDIT-4132 Add force clone on court appearance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResource.kt
@@ -2869,6 +2869,7 @@ data class CourtAppearanceRequest(
   val nextCourtId: String?,
   val comment: String?,
   val futureAppearance: Boolean? = false,
+  val forceClone: Boolean? = false,
 
   /* not currently provided by sentencing service:
   val orderRequestedFlag: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingService.kt
@@ -420,7 +420,8 @@ class CourtSentencingService(
   } else {
     // assume we are adding this future dated appearance at same time as we are adding
     // the main warrant - so allow this to fail until cloning has finished
-    if (courtAppearanceRequest.futureAppearance == true) {
+    // unless we force a clone because this is not part of a new parent appearance
+    if (courtAppearanceRequest.futureAppearance == true && courtAppearanceRequest.forceClone == false) {
       throw DependencyException("Cannot add future dated appearance until case has been cloned to latest booking", entityId = courtCase.id)
     }
     cloneCourtCasesToLatestBookingFrom(courtCase).let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/courtsentencing/CourtSentencingResourceIntTest.kt
@@ -5033,6 +5033,32 @@ class CourtSentencingResourceIntTest : IntegrationTestBase() {
       }
 
       @Test
+      fun `will not reject adding future court appearance until case is cloned if forces to clone true`() {
+        webTestClient.post()
+          .uri("/prisoners/$offenderNo/sentencing/court-cases/${previousBookingCourtCase.id}/court-appearances")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              createCourtAppearanceRequest(
+                courtEventCharges = mutableListOf(
+                  CourtEventChargeRequest(previousBookingOffenderCharge1.id, previousBookingOffenderCharge1.resultCode1?.code),
+                  CourtEventChargeRequest(previousBookingOffenderCharge2.id, previousBookingOffenderCharge2.resultCode1?.code),
+                ),
+              ).copy(futureAppearance = true, forceClone = true),
+            ),
+          )
+          .exchange().expectStatus().isCreated
+
+        transaction {
+          assertThat(offenderBookingRepository.findByIdOrNull(latestBookingId)!!.courtCases).hasSize(4)
+          assertThat(
+            offenderBookingRepository.findByIdOrNull(latestBookingId)!!.findByCaseInfoNumber("NOT_INVOLVED"),
+          ).isNull()
+        }
+      }
+
+      @Test
       fun `will move all related cases to the latest booking for a target combined case`() {
         transaction {
           assertThat(offenderBookingRepository.findByIdOrNull(latestBookingId)!!.courtCases).hasSize(1)


### PR DESCRIPTION
Where a future dated appearance is added onto a previous booking we ignore cloning since the parant appearance is typically added at the same time, and we don't want to clone twice.

This adds an override for repairs