### PR TITLE
SDIT-3910: Fix N+1 query problems on GET /movements/{offenderNo}/taps

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderTapApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderTapApplication.kt
@@ -40,6 +40,7 @@ import java.time.LocalDateTime
     NamedAttributeNode(value = "applicationType"),
     NamedAttributeNode(value = "tapType"),
     NamedAttributeNode(value = "tapSubType"),
+    NamedAttributeNode(value = "toAddress"),
   ],
   subgraphs = [
     NamedSubgraph(
@@ -50,6 +51,7 @@ import java.time.LocalDateTime
         NamedAttributeNode(value = "escort"),
         NamedAttributeNode(value = "eventStatus"),
         NamedAttributeNode(value = "eventSubType"),
+        NamedAttributeNode(value = "toAddress"),
       ],
     ),
     NamedSubgraph(
@@ -60,6 +62,7 @@ import java.time.LocalDateTime
         NamedAttributeNode(value = "escort"),
         NamedAttributeNode(value = "fromCity"),
         NamedAttributeNode(value = "toCity"),
+        NamedAttributeNode(value = "toAddress"),
       ],
     ),
   ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderTapScheduleOut.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/OffenderTapScheduleOut.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.JoinColumnOrFormula
 import org.hibernate.annotations.JoinColumnsOrFormulas
 import org.hibernate.annotations.JoinFormula
@@ -71,7 +72,11 @@ class OffenderTapScheduleOut(
 
   // There should only be a single return, but due to a bug in merges there might be more
   // The current strategy is to move the incorrect returns to the correct parent before mapping to the DTO
+  //
+  // @BatchSize is set to the Oracle max here because prod data shows that some offenders have thousands of schedule OUTs
+  // and we'll be loading the associated schedule INs for as many of them as possible in one go - to avoid n+1 queries.
   @OneToMany(mappedBy = "tapScheduleOut", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+  @BatchSize(size = 1000)
   var tapScheduleIns: MutableList<OffenderTapScheduleIn> = mutableListOf(),
 
   @OneToOne(mappedBy = "tapScheduleOut", cascade = [CascadeType.ALL])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyLocationAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/AgencyLocationAddressRepository.kt
@@ -2,8 +2,15 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.AgencyLocationAddress
 
 @Repository
-interface AgencyLocationAddressRepository : JpaRepository<AgencyLocationAddress, Long>
+interface AgencyLocationAddressRepository : JpaRepository<AgencyLocationAddress, Long> {
+  // agencyLocation is a required (non-null, non-@NotFound) LAZY to-one association - without this JOIN FETCH,
+  // accessing .agencyLocation on each returned address would issue one extra query per distinct agency, reintroducing
+  // an N+1.
+  @Query("SELECT ala FROM AgencyLocationAddress ala JOIN FETCH ala.agencyLocation WHERE ala.addressId IN :addressIds")
+  fun findAllByAddressIdInWithAgencyLocation(addressIds: Collection<Long>): List<AgencyLocationAddress>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CorporateAddressRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/CorporateAddressRepository.kt
@@ -2,6 +2,7 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
 
@@ -9,4 +10,9 @@ import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.CorporateAddress
 interface CorporateAddressRepository : JpaRepository<CorporateAddress, Long> {
   @Suppress("ktlint:standard:function-naming")
   fun findAllByCorporate_CorporateName(corporateName: String): List<CorporateAddress>
+
+  // corporate is a required (non-null, non-@NotFound) LAZY to-one association - without this JOIN FETCH, accessing
+  // .corporate on each returned address would issue one extra query per distinct corporate, reintroducing an N+1.
+  @Query("SELECT ca FROM CorporateAddress ca JOIN FETCH ca.corporate WHERE ca.addressId IN :addressIds")
+  fun findAllByAddressIdInWithCorporate(addressIds: Collection<Long>): List<CorporateAddress>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapMovementInRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapMovementInRepository.kt
@@ -3,14 +3,32 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovementId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
 
 @Repository
 interface OffenderTapMovementInRepository : JpaRepository<OffenderTapMovementIn, OffenderExternalMovementId> {
+  // The tapScheduleIn and tapScheduleOut associations are annotated with @NotFound(IGNORE) which means Hibernate
+  // cannot proxy them and must resolve them eagerly - explicitly LEFT JOIN FETCH-ing them here avoids two extra
+  // SELECTs per row. fromAddress on this movement, and toAddress on both the schedule out and its own linked
+  // movement out, are also fetched eagerly (plain @ManyToOne / forced-eager @NotFound respectively), so they need
+  // the same treatment - the mapping code walks all of these to build the tap's "from" address.
+  @Query(
+    "SELECT mi FROM OffenderTapMovementIn mi LEFT JOIN FETCH mi.tapScheduleIn LEFT JOIN FETCH mi.tapScheduleOut tso " +
+      "LEFT JOIN FETCH tso.toAddress LEFT JOIN FETCH tso.tapMovementOut tmo LEFT JOIN FETCH tmo.toAddress " +
+      "LEFT JOIN FETCH mi.fromAddress WHERE mi.offenderBooking.offender.nomsId = :offenderNo",
+  )
   fun findAllByOffenderBooking_Offender_NomsId(offenderNo: String): List<OffenderTapMovementIn>
+
+  @Query(
+    "SELECT mi FROM OffenderTapMovementIn mi LEFT JOIN FETCH mi.tapScheduleIn LEFT JOIN FETCH mi.tapScheduleOut tso " +
+      "LEFT JOIN FETCH tso.toAddress LEFT JOIN FETCH tso.tapMovementOut tmo LEFT JOIN FETCH tmo.toAddress " +
+      "LEFT JOIN FETCH mi.fromAddress WHERE mi.offenderBooking.bookingId = :bookingId",
+  )
   fun findAllByOffenderBooking_BookingId(bookingId: Long): List<OffenderTapMovementIn>
+
   fun findAllByOffenderBooking_Offender_NomsIdAndTapScheduleInIsNull(offenderNo: String): List<OffenderTapMovementIn>
 
   fun findById_OffenderBooking_BookingIdAndId_Sequence(bookingId: Long, sequence: Int): OffenderTapMovementIn?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapMovementOutRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/jpa/repository/OffenderTapMovementOutRepository.kt
@@ -3,13 +3,27 @@
 package uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderExternalMovementId
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
 
 @Repository
 interface OffenderTapMovementOutRepository : JpaRepository<OffenderTapMovementOut, OffenderExternalMovementId> {
+  // The tapScheduleOut association is annotated with @NotFound(IGNORE) which means Hibernate cannot proxy it and
+  // must resolve it eagerly - explicitly LEFT JOIN FETCH-ing it here avoids one extra SELECT per row. toAddress on
+  // both this movement and on its linked schedule out are also fetched eagerly (plain @ManyToOne / forced-eager
+  // @NotFound respectively), so they need the same treatment.
+  @Query(
+    "SELECT mo FROM OffenderTapMovementOut mo LEFT JOIN FETCH mo.tapScheduleOut tso LEFT JOIN FETCH tso.toAddress " +
+      "LEFT JOIN FETCH mo.toAddress WHERE mo.offenderBooking.offender.nomsId = :offenderNo",
+  )
   fun findAllByOffenderBooking_Offender_NomsId(offenderNo: String): List<OffenderTapMovementOut>
+
+  @Query(
+    "SELECT mo FROM OffenderTapMovementOut mo LEFT JOIN FETCH mo.tapScheduleOut tso LEFT JOIN FETCH tso.toAddress " +
+      "LEFT JOIN FETCH mo.toAddress WHERE mo.offenderBooking.bookingId = :bookingId",
+  )
   fun findAllByOffenderBooking_BookingId(bookingId: Long): List<OffenderTapMovementOut>
 
   fun findById_OffenderBooking_BookingIdAndId_Sequence(bookingId: Long, sequence: Int): OffenderTapMovementOut?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/TapAddressService.kt
@@ -44,6 +44,31 @@ class TapAddressService(
     }
   }
 
+  /**
+   * Batch-loads the descriptions for many addresses in at most 2 queries (one for corporate addresses and one for
+   * agency addresses), instead of the 1 query per address that [getAddressDescription] performs. Use this instead of
+   * [getAddressDescription] when mapping a list of records that may each reference their own address, to avoid an
+   * N+1 query problem.
+   */
+  fun getAddressDescriptions(addresses: Collection<Address?>): Map<Long, String?> {
+    val distinctAddresses = addresses.filterNotNull().distinctBy { it.addressId }
+    val corporateIds = distinctAddresses.filter { it.addressOwnerClass == "CORP" }.map { it.addressId }
+    val agencyIds = distinctAddresses.filter { it.addressOwnerClass == "AGY" }.map { it.addressId }
+
+    val corporateDescriptions = if (corporateIds.isEmpty()) {
+      emptyMap()
+    } else {
+      corporateAddressRepository.findAllByAddressIdInWithCorporate(corporateIds).associate { it.addressId to it.corporate.corporateName }
+    }
+    val agencyDescriptions = if (agencyIds.isEmpty()) {
+      emptyMap()
+    } else {
+      agencyLocationAddressRepository.findAllByAddressIdInWithAgencyLocation(agencyIds).associate { it.addressId to it.agencyLocation.description }
+    }
+
+    return corporateDescriptions + agencyDescriptions
+  }
+
   fun findOrCreateAddress(request: UpsertTapAddress, offender: Offender): Address {
     // If we have an address id then use that
     if (request.id != null) return movementHelpers.addressOrThrow(request.id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/offender/OffenderTapsService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.data.NotFoundException
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.helpers.toAudit
+import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.Address
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapApplication
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementIn
 import uk.gov.justice.digital.hmpps.nomisprisonerapi.jpa.OffenderTapMovementOut
@@ -59,6 +60,10 @@ class OffenderTapsService(
     val unscheduledTapMovementOuts = allTapMovementOuts - tapApplications.tapMovementOuts()
     val unscheduledTapMovementIns = allTapMovementIns - tapApplications.tapMovementIns()
 
+    // Batch-load all the address descriptions needed for this response in at most 2 queries, instead of looking
+    // each one up individually while mapping (which would cause an N+1 query problem for offenders with many taps).
+    val addressDescriptions = collectAddressDescriptions(tapApplications, allTapMovementOuts, allTapMovementIns)
+
     data class Booking(val id: Long, val active: Boolean, val latest: Boolean)
 
     val bookings = (
@@ -76,6 +81,7 @@ class OffenderTapsService(
           tapApplications = tapApplications,
           unscheduledTapMovementOuts = unscheduledTapMovementOuts,
           unscheduledTapMovementIns = unscheduledTapMovementIns,
+          addressDescriptions = addressDescriptions,
         )
       },
     )
@@ -100,6 +106,10 @@ class OffenderTapsService(
     val unscheduledTapMovementOuts = allTapMovementOuts - movementApplications.tapMovementOuts()
     val unscheduledTapMovementIns = allTapMovementIns - movementApplications.tapMovementIns()
 
+    // Batch-load all the address descriptions needed for this response in at most 2 queries, instead of looking
+    // each one up individually while mapping (which would cause an N+1 query problem for bookings with many taps).
+    val addressDescriptions = collectAddressDescriptions(movementApplications, allTapMovementOuts, allTapMovementIns)
+
     return toBookingTaps(
       bookingId = bookingId,
       active = booking.active,
@@ -107,6 +117,7 @@ class OffenderTapsService(
       tapApplications = movementApplications,
       unscheduledTapMovementOuts = unscheduledTapMovementOuts,
       unscheduledTapMovementIns = unscheduledTapMovementIns,
+      addressDescriptions = addressDescriptions,
     )
   }
 
@@ -224,6 +235,41 @@ class OffenderTapsService(
     }
   }
 
+  /**
+   * Collects every [Address] reachable from the given records so their descriptions can be batch-loaded via
+   * [TapAddressService.getAddressDescriptions] instead of one-by-one during mapping.
+   */
+  private fun collectAddressDescriptions(
+    tapApplications: List<OffenderTapApplication>,
+    allTapMovementOuts: List<OffenderTapMovementOut>,
+    allTapMovementIns: List<OffenderTapMovementIn>,
+  ): Map<Long, String?> {
+    val addresses = buildList {
+      tapApplications.forEach { application ->
+        application.toAddress?.let(::add)
+        application.tapScheduleOuts.forEach { scheduleOut ->
+          scheduleOut.toAddress?.let(::add)
+          scheduleOut.tapMovementOut?.toAddress?.let(::add)
+          scheduleOut.tapScheduleIns.forEach { scheduleIn ->
+            scheduleIn.tapMovementIn?.fromAddress?.let(::add)
+          }
+        }
+      }
+      allTapMovementOuts.forEach { movementOut ->
+        (movementOut.toAddress ?: movementOut.toAgency?.addresses?.firstOrNull())?.let(::add)
+        movementOut.tapScheduleOut?.toAddress?.let(::add)
+      }
+      allTapMovementIns.forEach { movementIn ->
+        (movementIn.fromAddress ?: movementIn.fromAgency?.addresses?.firstOrNull())?.let(::add)
+        movementIn.tapScheduleOut?.tapMovementOut?.toAddress?.let(::add)
+        movementIn.tapScheduleOut?.toAddress?.let(::add)
+      }
+    }
+    return tapAddressService.getAddressDescriptions(addresses)
+  }
+
+  private fun Map<Long, String?>.descriptionFor(address: Address?): String? = address?.addressId?.let { this[it] }
+
   // Make a tap movement in unscheduled if the schedules have been corrupted
   private fun toBookingTaps(
     bookingId: Long,
@@ -232,19 +278,20 @@ class OffenderTapsService(
     tapApplications: List<OffenderTapApplication>,
     unscheduledTapMovementOuts: List<OffenderTapMovementOut>,
     unscheduledTapMovementIns: List<OffenderTapMovementIn>,
+    addressDescriptions: Map<Long, String?>,
   ) = BookingTaps(
     bookingId = bookingId,
     activeBooking = active,
     latestBooking = latest,
     tapApplications = tapApplications.filter { it.offenderBooking.bookingId == bookingId }
-      .map { it.toResponse() },
+      .map { it.toResponse(addressDescriptions) },
     unscheduledTapMovementOuts = unscheduledTapMovementOuts.filter { it.offenderBooking.bookingId == bookingId }
-      .map { mov -> mov.toUnscheduledResponse() },
+      .map { mov -> mov.toUnscheduledResponse(addressDescriptions) },
     unscheduledTapMovementIns = unscheduledTapMovementIns.filter { it.offenderBooking.bookingId == bookingId }
-      .map { mov -> mov.toUnscheduledResponse() },
+      .map { mov -> mov.toUnscheduledResponse(addressDescriptions) },
   )
 
-  private fun OffenderTapApplication.toResponse() = BookingTapApplication(
+  private fun OffenderTapApplication.toResponse(addressDescriptions: Map<Long, String?>) = BookingTapApplication(
     tapApplicationId = tapApplicationId,
     eventSubType = eventSubType.code,
     applicationDate = applicationDate.toLocalDate(),
@@ -258,8 +305,8 @@ class OffenderTapsService(
     comment = comment,
     toAddressId = toAddress?.addressId,
     toAddressOwnerClass = toAddress?.addressOwnerClass,
-    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
-    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressDescription = addressDescriptions.descriptionFor(toAddress),
+    toFullAddress = toAddress?.toFullAddress(addressDescriptions.descriptionFor(toAddress)),
     toAddressPostcode = toAddress?.postalCode?.trim(),
     prisonId = prison.id,
     toAgencyId = toAgency?.id,
@@ -273,16 +320,16 @@ class OffenderTapsService(
         ?: it.tapScheduleIns.firstOrNull()
       val tapMovementIn = tapScheduleIn?.tapMovementIn
       BookingTap(
-        tapScheduleOut = it.toResponse(getToReturnDateAndTime()),
+        tapScheduleOut = it.toResponse(getToReturnDateAndTime(), addressDescriptions),
         tapScheduleIn = tapScheduleIn?.toResponse(),
-        tapMovementOut = it.tapMovementOut?.toResponse(),
-        tapMovementIn = tapMovementIn?.toResponse(),
+        tapMovementOut = it.tapMovementOut?.toResponse(addressDescriptions),
+        tapMovementIn = tapMovementIn?.toResponse(addressDescriptions),
       )
     },
     audit = toAudit(),
   )
 
-  private fun OffenderTapScheduleOut.toResponse(applicationReturnTime: LocalDateTime) = BookingTapScheduleOut(
+  private fun OffenderTapScheduleOut.toResponse(applicationReturnTime: LocalDateTime, addressDescriptions: Map<Long, String?>) = BookingTapScheduleOut(
     eventId = eventId,
     eventDate = eventDate ?: tapApplication.fromDate,
     startTime = getAppointmentStartDateAndTime() ?: tapApplication.releaseTime,
@@ -297,8 +344,8 @@ class OffenderTapsService(
     returnTime = returnTime ?: applicationReturnTime,
     toAddressId = toAddress?.addressId,
     toAddressOwnerClass = toAddress?.addressOwnerClass,
-    toAddressDescription = tapAddressService.getAddressDescription(toAddress),
-    toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+    toAddressDescription = addressDescriptions.descriptionFor(toAddress),
+    toFullAddress = toAddress?.toFullAddress(addressDescriptions.descriptionFor(toAddress)),
     toAddressPostcode = toAddress?.postalCode?.trim(),
     applicationDate = applicationDate,
     applicationTime = getApplicationDateAndTime(),
@@ -319,7 +366,7 @@ class OffenderTapsService(
     audit = toAudit(),
   )
 
-  private fun OffenderTapMovementOut.toUnscheduledResponse(): BookingTapMovementOut {
+  private fun OffenderTapMovementOut.toUnscheduledResponse(addressDescriptions: Map<Long, String?>): BookingTapMovementOut {
     val address = toAddress ?: toAgency?.addresses?.firstOrNull()
     return BookingTapMovementOut(
       sequence = id.sequence,
@@ -334,14 +381,14 @@ class OffenderTapsService(
       commentText = commentText,
       toAddressId = address?.addressId,
       toAddressOwnerClass = address?.addressOwnerClass,
-      toAddressDescription = tapAddressService.getAddressDescription(address),
-      toFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(address)) ?: toCity?.description,
+      toAddressDescription = addressDescriptions.descriptionFor(address),
+      toFullAddress = address?.toFullAddress(addressDescriptions.descriptionFor(address)) ?: toCity?.description,
       toAddressPostcode = address?.postalCode?.trim(),
       audit = toAudit(),
     )
   }
 
-  private fun OffenderTapMovementIn.toUnscheduledResponse(): BookingTapMovementIn {
+  private fun OffenderTapMovementIn.toUnscheduledResponse(addressDescriptions: Map<Long, String?>): BookingTapMovementIn {
     val address = fromAddress ?: fromAgency?.addresses?.firstOrNull()
     return BookingTapMovementIn(
       sequence = id.sequence,
@@ -355,14 +402,14 @@ class OffenderTapsService(
       commentText = commentText,
       fromAddressId = address?.addressId,
       fromAddressOwnerClass = address?.addressOwnerClass,
-      fromAddressDescription = tapAddressService.getAddressDescription(address),
-      fromFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(fromAddress)) ?: fromCity?.description,
+      fromAddressDescription = addressDescriptions.descriptionFor(address),
+      fromFullAddress = address?.toFullAddress(addressDescriptions.descriptionFor(fromAddress)) ?: fromCity?.description,
       fromAddressPostcode = address?.postalCode?.trim(),
       audit = toAudit(),
     )
   }
 
-  private fun OffenderTapMovementOut.toResponse(): BookingTapMovementOut {
+  private fun OffenderTapMovementOut.toResponse(addressDescriptions: Map<Long, String?>): BookingTapMovementOut {
     // The address may only exist on the schedule so check there too
     val toAddress = toAddress ?: tapScheduleOut?.toAddress
     return BookingTapMovementOut(
@@ -378,14 +425,14 @@ class OffenderTapsService(
       commentText = commentText,
       toAddressId = toAddress?.addressId,
       toAddressOwnerClass = toAddress?.addressOwnerClass,
-      toAddressDescription = tapAddressService.getAddressDescription(toAddress),
-      toFullAddress = toAddress?.toFullAddress(tapAddressService.getAddressDescription(toAddress)),
+      toAddressDescription = addressDescriptions.descriptionFor(toAddress),
+      toFullAddress = toAddress?.toFullAddress(addressDescriptions.descriptionFor(toAddress)),
       toAddressPostcode = toAddress?.postalCode?.trim(),
       audit = toAudit(),
     )
   }
 
-  private fun OffenderTapMovementIn.toResponse(): BookingTapMovementIn {
+  private fun OffenderTapMovementIn.toResponse(addressDescriptions: Map<Long, String?>): BookingTapMovementIn {
     // The address may only exist on the outbound movement or the scheduled outbound movement so check there too
     val address = fromAddress
       ?: tapScheduleOut?.tapMovementOut?.toAddress
@@ -402,8 +449,8 @@ class OffenderTapsService(
       commentText = commentText,
       fromAddressId = address?.addressId,
       fromAddressOwnerClass = address?.addressOwnerClass,
-      fromAddressDescription = tapAddressService.getAddressDescription(address),
-      fromFullAddress = address?.toFullAddress(tapAddressService.getAddressDescription(address)),
+      fromAddressDescription = addressDescriptions.descriptionFor(address),
+      fromFullAddress = address?.toFullAddress(addressDescriptions.descriptionFor(address)),
       fromAddressPostcode = address?.postalCode?.trim(),
       audit = toAudit(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/OffenderTapsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisprisonerapi/movements/taps/OffenderTapsResourceIntTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps
 
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.SessionFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -997,6 +998,91 @@ class OffenderTapsResourceIntTest(
         .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressDescription").isEqualTo("Boots")
         .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toFullAddress").isEqualTo("41 High Street, Sheffield, England")
         .jsonPath("$.bookings[0].tapApplications[0].taps[0].tapScheduleOut.toAddressPostcode").isEqualTo("")
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /movements/{offenderNo}/taps - query performance")
+  inner class GetOffenderTapsQueryPerformance {
+
+    /**
+     * Builds an offender with [applicationCount] TAP applications, each with a schedule out, a movement out, a
+     * schedule in and a movement in - this covers every relationship walked by
+     * [uk.gov.justice.digital.hmpps.nomisprisonerapi.movements.taps.offender.OffenderTapsService.getOffenderTaps].
+     *
+     * Each schedule out gets its own, distinct address, alternating between corporate addresses and offender
+     * addresses, so the test also exercises the bulk address-description lookup's handling of both address owner
+     * types (see `TapAddressService.getAddressDescriptions`) - a single shared address (or addresses of only one
+     * owner type) would let that N+1 slip through undetected. The same address is also set on the tap application,
+     * movement out and movement in (not just the schedule out) so every LEFT JOIN FETCH added to resolve an address
+     * is actually exercised by a distinct, non-null address rather than trivially satisfied by a null association.
+     */
+    private fun buildOffenderWithTapApplications(nomsId: String, applicationCount: Int) {
+      val corporateAddresses = mutableListOf<CorporateAddress>()
+      val offenderAddresses = mutableListOf<OffenderAddress>()
+      nomisDataBuilder.build {
+        repeat(applicationCount) { index ->
+          if (index % 2 == 0) {
+            corporate(corporateName = "Boots-$nomsId-$index") {
+              corporateAddresses += address(postcode = "S2 2A$index")
+            }
+          }
+        }
+        offender(nomsId = nomsId) {
+          repeat(applicationCount) { index ->
+            if (index % 2 != 0) {
+              offenderAddresses += address(postcode = "S3 3A$index")
+            }
+          }
+          booking {
+            repeat(applicationCount) { index ->
+              val address = if (index % 2 == 0) corporateAddresses[index / 2] else offenderAddresses[index / 2]
+              tapApplication(toAddress = address) {
+                tapScheduleOut(toAddress = address) {
+                  tapMovementOut(toAddress = address)
+                  tapScheduleIn {
+                    tapMovementIn(fromAddress = address)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    private fun queryOffenderTaps(nomsId: String): Long {
+      val statistics = entityManager.entityManagerFactory.unwrap(SessionFactory::class.java).statistics
+      statistics.isStatisticsEnabled = true
+      statistics.clear()
+
+      webTestClient.get()
+        .uri("/movements/$nomsId/taps")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_PRISONER_API__SYNCHRONISATION__RW")))
+        .exchange()
+        .expectStatus().isOk
+
+      return statistics.prepareStatementCount
+    }
+
+    @Test
+    fun `should not issue additional queries per tap application (no N+1)`() {
+      // A correctly fetch-planned response should need roughly the same number of queries whether the offender
+      // has 1 tap application or 10 - the query count should not grow linearly with the number of applications.
+      buildOffenderWithTapApplications("D6347EA", applicationCount = 1)
+      val queryCountForOneApplication = queryOffenderTaps("D6347EA")
+      offenderRepository.deleteAll()
+
+      buildOffenderWithTapApplications("D6347EB", applicationCount = 10)
+      val queryCountForTenApplications = queryOffenderTaps("D6347EB")
+
+      assertThat(queryCountForTenApplications - queryCountForOneApplication)
+        .withFailMessage(
+          "Expected the query count to stay roughly constant as the number of tap applications grows " +
+            "(1 application took $queryCountForOneApplication queries, 10 applications took " +
+            "$queryCountForTenApplications queries) - this looks like an N+1 query problem.",
+        )
+        .isLessThanOrEqualTo(5)
     }
   }
 


### PR DESCRIPTION
Fixes various issues that caused multiple N+1 queries. Each has been well commented by the AI in the code, so read those comments for full details. The comments are long but definitely worth keeping for future readers.